### PR TITLE
fix: add chromium dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
     freetype-dev \
     harfbuzz \
     ca-certificates \
-    ttf-freefont \
+    ttf-freefont
 
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,16 @@
-FROM node
+FROM node:alpine
+
+RUN apk add --no-cache \
+    chromium \
+    nss \
+    freetype \
+    freetype-dev \
+    harfbuzz \
+    ca-certificates \
+    ttf-freefont \
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+
 COPY package*.json /app/
 WORKDIR /app
 RUN npm install --omit=dev


### PR DESCRIPTION
We need chromium installed to be able to use it through pupeteer. 