### PR TITLE
Make MB default scope 2 selection

### DIFF
--- a/src/prompts/parsePDF.ts
+++ b/src/prompts/parsePDF.ts
@@ -67,7 +67,7 @@ I have a text extracted from a PDF file containing a company's annual report and
       ]
     }
 
-4. **Never calculate total**: Don't forget to include the total CO2 emissions for each year if presented. Never try to calculate any values! For Scope 2 - if both market based (MB) and location based (LB) emissions are presented, include both values and select the most relevant one for the total emissions.
+4. **Never calculate total**: Don't forget to include the total CO2 emissions for each year if presented. Never try to calculate any values! For Scope 2 - if both market based (MB) and location based (LB) emissions are presented, include both values and select market based (MB) for the total emissions.
 
 5. **Error Codes**: If not all information is available firstly use null, if there is an error or inconsistency- please use the following error codes to indicate missing data (using HTTP Status codes as inspiration):
 


### PR DESCRIPTION
Instead of allowing Garbo to choose between LB and MB when both are available, always opt for MB.