### PR TITLE
Ensure previous job was successful and returned actual data

### DIFF
--- a/src/workers/pdf2Markdown.ts
+++ b/src/workers/pdf2Markdown.ts
@@ -4,7 +4,6 @@ import { pdf2Markdown, splitText } from '../queues'
 import elastic from '../elastic'
 import llama from '../config/llama'
 import discord from '../discord'
-import { TextChannel } from 'discord.js'
 
 const minutes = 60
 
@@ -126,12 +125,12 @@ const worker = new Worker(
       message.edit('👌 Filen var redan hanterad. Återanvänder resultat.')
       job.log(`Using existing job: ${id}`)
       text = previousJob.returnvalue
-    } else if (!existingId) {
+    } else if (!previousJob || !existingId) {
       job.log(`Downloading from url: ${url}`)
 
       const response = await fetch(url)
       const buffer = await response.arrayBuffer()
-      pdfHash = await elastic.hashPdf(Buffer.from(buffer))
+      pdfHash = elastic.hashPdf(Buffer.from(buffer))
 
       message.edit('🤖 Tolkar tabeller...')
 

--- a/src/workers/pdf2Markdown.ts
+++ b/src/workers/pdf2Markdown.ts
@@ -120,7 +120,7 @@ const worker = new Worker(
     const message = await discord.sendMessage(job.data, '🤖 Kollar cache...')
 
     const previousJob = (await pdf2Markdown.getCompleted()).find(
-      (p) => p.data.url === url
+      (p) => p.data.url === url && p.returnvalue !== null
     )
     if (previousJob) {
       message.edit('👌 Filen var redan hanterad. Återanvänder resultat.')


### PR DESCRIPTION
This PR solves `TypeError: Cannot read properties of null (reading 'length')` which was triggered in at least one instance at http://localhost:3000/admin/queues/queue/pdf2Markdown/93?status=failed

It seems like `completed` jobs can still get `null` as their return value. It might be a symptom of previous jobs not finishing as expected.

Looking at the error from above, the input data looks odd. According to the type definition at https://github.com/Klimatbyran/garbo/blob/543c3bf54e7aeb6500f825fdd131b7063f1daf61/src/workers/pdf2Markdown.ts#L104, `existingId` should always be a string, but as you can see in the screenshot below, it's `undefined`.

![image](https://github.com/Klimatbyran/garbo/assets/6125097/82e086cb-9a91-47da-b970-79132d879ab6)

This is what caused the original error.