### PR TITLE
Add new env variable to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Create a .env file in the root lib and add these tokens/secrets before running t
     DISCORD_APPLICATION_ID=
     DISCORD_TOKEN=
     DISCORD_SERVER_ID=
+    DISCORD_WORKER=
     LLAMA_CLOUD_API_KEY=
     ELASTIC_NODE_URL=
     ELASTIC_INDEX_NAME=


### PR DESCRIPTION
Resolves https://github.com/Klimatbyran/garbo/pull/103#discussion_r1587552270

`DISCORD_WORKER` seems like an optional env variable. Is this correct? Is this used differently between for example dev and prod?