### PR TITLE
feat: WIP add buttons for retry, feedback to each element on list

### DIFF
--- a/src/discord/commands/list.ts
+++ b/src/discord/commands/list.ts
@@ -40,8 +40,8 @@ export default {
         if (job) {
           row = new ActionRowBuilder().addComponents(
             new ButtonBuilder()
-              .setCustomId(`decline~${job.id}`)
-              .setLabel('Decline')
+              .setCustomId(`retry~${job.id}`)
+              .setLabel('Retry')
               .setStyle(ButtonStyle.Danger),
             new ButtonBuilder()
               .setCustomId(`feedback~${job.id}`)

--- a/src/discord/commands/list.ts
+++ b/src/discord/commands/list.ts
@@ -1,4 +1,7 @@
 import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
   ChatInputCommandInteraction,
   SlashCommandBuilder,
   TextChannel,
@@ -7,6 +10,7 @@ import elastic from '../../elastic'
 import { summaryTable } from '../../lib/discordTable'
 import { CompanyData } from '../../models/companyEmissions'
 import { compareFacitToCompanyData, findFacit } from '../../lib/facit'
+import { discordReview, saveToDb } from '../../queues'
 
 export default {
   data: new SlashCommandBuilder()
@@ -14,11 +18,14 @@ export default {
     .setDescription('Ta fram en lista på alla godkända rapporter.'),
 
   async execute(interaction: ChatInputCommandInteraction) {
+    const list = await elastic.getAllLatestApprovedReports()
+    const jobsFinished = discordReview.getCompleted()
+
     const thread = await (interaction.channel as TextChannel).threads.create({
-      name: 'List of all approved reports',
+      name: `List of ${list.length} approved reports`,
       autoArchiveDuration: 1440,
     })
-    const list = await elastic.getAllLatestApprovedReports()
+
     await Promise.all(
       list.map(async (report) => {
         const company = {
@@ -26,6 +33,22 @@ export default {
           emissions: Object.values(report.emissions),
         } as CompanyData
         const summary = await summaryTable(company)
+        let row = null
+        const job =
+          report.id &&
+          (await jobsFinished).find((j) => j.data?.pdfHash === report.id)
+        if (job) {
+          row = new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+              .setCustomId(`decline~${job.id}`)
+              .setLabel('Decline')
+              .setStyle(ButtonStyle.Danger),
+            new ButtonBuilder()
+              .setCustomId(`feedback~${job.id}`)
+              .setLabel('Feedback')
+              .setStyle(ButtonStyle.Primary)
+          )
+        }
 
         return thread.send({
           content: `${report.companyName}
@@ -33,13 +56,13 @@ export default {
 ${summary}
 \`\`\`
 `,
-          components: [], // TODO: add retry button
+          components: row ? [row] : [], // TODO: add retry button
         })
       })
     )
 
-    await interaction.reply({
-      content: `${list.length} godkända.`,
+    await thread.send({
+      content: `Summering: ${list.length} godkända.`,
     })
   },
 }

--- a/src/elastic.ts
+++ b/src/elastic.ts
@@ -402,7 +402,11 @@ class Elastic {
       })) as any
 
       const reports =
-        result.hits?.hits?.map(({ _source: item }) => item.report) || []
+        result.hits?.hits?.map(({ _source: item, _id, pdfHash, url }) => ({
+          ...item.report,
+          url: url || item.report.url,
+          id: pdfHash || _id,
+        })) || []
       return reports
     } catch (error) {
       console.error('Error fetching latest approved reports:', error)


### PR DESCRIPTION
When pressing Retry or Feedback on any company on the list we want to create new jobs so we can manually check each company we publish and add feedback based on new information we get.