### PR TITLE
fix: send message to discord after storage in done

### DIFF
--- a/src/discord.ts
+++ b/src/discord.ts
@@ -151,7 +151,7 @@ export class Discord {
       await thread?.sendTyping()
       return thread.send(msg)
     } catch (e) {
-      console.error('Error sending message to thread', e)
+      console.error('Error sending message to thread: ', e)
       return undefined
     }
   }


### PR DESCRIPTION
I know this shouldn't be necessary, but the lack of logs in saveToDb is clear - sometimes (probably when running multiple instances) a discord error isn't handled and breaks the job - before saving to elastic. By just sending the message to after the index/update operation is done this error won't silently fail