### PR TITLE
feat: Add a wrapper lib around our vector DB to simplify the code and future updates

### DIFF
--- a/src/lib/DiscordWorker.ts
+++ b/src/lib/DiscordWorker.ts
@@ -2,9 +2,6 @@ import { Worker, WorkerOptions, Job, Queue } from 'bullmq'
 import { Message, TextChannel } from 'discord.js'
 import redis from '../config/redis'
 import discord from '../discord'
-import { ChromaClient, OpenAIEmbeddingFunction } from 'chromadb'
-import openai from '../config/openai'
-import chromadb from '../config/chromadb'
 
 export class DiscordJob extends Job {
   declare data: {
@@ -23,8 +20,6 @@ export class DiscordJob extends Job {
   setThreadName: (name: string) => Promise<any>
   sendTyping: () => Promise<any>
   getChildrenEntries: () => Promise<any>
-  embedder: OpenAIEmbeddingFunction
-  chromaClient: ChromaClient
 }
 
 function addCustomMethods(job: DiscordJob) {
@@ -96,8 +91,6 @@ function addCustomMethods(job: DiscordJob) {
     return thread.setName(name)
   }
 
-  job.embedder = new OpenAIEmbeddingFunction(openai)
-  job.chromaClient = new ChromaClient(chromadb)
   return job
 }
 

--- a/src/lib/vectordb.ts
+++ b/src/lib/vectordb.ts
@@ -1,0 +1,71 @@
+import { ChromaClient, OpenAIEmbeddingFunction } from 'chromadb'
+
+import chromadb from '../config/chromadb'
+import openai from '../config/openai'
+
+const client = new ChromaClient(chromadb)
+const embedder = new OpenAIEmbeddingFunction(openai)
+
+const collection = await client.getOrCreateCollection({
+  name: 'emission_reports',
+  embeddingFunction: embedder,
+})
+
+async function addReport(url: string, markdown: string, paragraphs: string[]) {
+  const ids = paragraphs.map((p, i) => url + '#' + i)
+  const metadatas = paragraphs.map((p, i) => ({
+    source: url,
+    markdown,
+    type: 'company_sustainability_report', // this is our own type to be able to filter in the future if needed
+    parsed: new Date().toISOString(),
+    page: i,
+  }))
+  await collection.add({
+    ids,
+    metadatas,
+    documents: paragraphs,
+  })
+}
+
+async function hasReport(url: string) {
+  return collection
+    .get({
+      where: { source: url },
+      limit: 1,
+    })
+    .then((r) => r?.documents?.length > 0)
+}
+
+async function getRelevantMarkdown(
+  url: string,
+  queryTexts: string[],
+  nResults = 10
+) {
+  /* might get better results if we query for imaginary results from a query instead of the actual query
+  const query = await ask([
+    {
+      role: 'user',
+      content:
+        'Please give me some example data from this prompt that I can use as search query in a vector database indexed from PDFs. OK?'
+    },
+    {role: 'assistant', content: 'OK sure, give '},
+        prompt,
+    },
+  ])*/
+  const result = await collection.query({
+    nResults,
+    where: {
+      source: url,
+    },
+    queryTexts,
+  })
+
+  const markdown = result.documents.join('\n\n')
+  return markdown
+}
+
+export const vectorDB = {
+  addReport,
+  hasReport,
+  getRelevantMarkdown,
+}

--- a/src/workers/indexMarkdown.ts
+++ b/src/workers/indexMarkdown.ts
@@ -1,16 +1,15 @@
-import { ChromaClient } from 'chromadb'
-import chromadb from '../config/chromadb'
 import { DiscordWorker, DiscordJob } from '../lib/DiscordWorker'
+import { vectorDB } from '../lib/vectordb'
 
 class JobData extends DiscordJob {}
 
 const indexMarkdown = new DiscordWorker(
   'indexMarkdown',
   async (job: JobData) => {
-    const client = new ChromaClient(chromadb)
     const { url } = job.data
     const childrenValues = await job.getChildrenEntries()
-    const { markdown } = childrenValues
+    const { markdown }: { markdown: string } = childrenValues
+
     const paragraphs = markdown
       .split('\n###')
       .map((p) => p.trim())
@@ -18,25 +17,9 @@ const indexMarkdown = new DiscordWorker(
 
     await job.sendMessage(`🤖 Sparar i vektordatabas...`)
     job.log('Indexing ' + paragraphs.length + ' paragraphs from url: ' + url)
+
     try {
-      const collection = await client.getOrCreateCollection({
-        name: 'emission_reports',
-        embeddingFunction: job.embedder,
-      })
-      job.log('Indexing ' + paragraphs.length + ' paragraphs...')
-      const ids = paragraphs.map((p, i) => job.data.url + '#' + i)
-      const metadatas = paragraphs.map((p, i) => ({
-        source: url,
-        markdown,
-        type: 'company_sustainability_report', // this is our own type to be able to filter in the future if needed
-        parsed: new Date().toISOString(),
-        page: i,
-      }))
-      await collection.add({
-        ids,
-        metadatas,
-        documents: paragraphs,
-      })
+      await vectorDB.addReport(url, markdown, paragraphs)
       job.editMessage(`✅ Sparad i vektordatabasen`)
       job.log('Done!')
 


### PR DESCRIPTION
This simplifies the worker code interacting with the vector DB.

NOTE: I opted to let `vectorDB.addReport()` accept both `markdown` and `paragraphs` as parameters, rather than just `markdown`. The reason is that it made more sense to log the number of paragraphs in the `indexMarkdown` worker. One more parameter to the `addReports()` method is worthwhile since it makes the code much more readable, logging the number of paragraphs before we attempt to save to the vector DB.