### PR TITLE
Update chunking strategi

### DIFF
--- a/src/lib/vectordb.ts
+++ b/src/lib/vectordb.ts
@@ -11,9 +11,9 @@ const collection = await client.getOrCreateCollection({
   embeddingFunction: embedder,
 })
 
-async function addReport(url: string, markdown: string, paragraphs: string[]) {
-  const ids = paragraphs.map((p, i) => url + '#' + i)
-  const metadatas = paragraphs.map((p, i) => ({
+async function addReport(url: string, markdown: string, chunks: string[]) {
+  const ids = chunks.map((_, i) => url + '#' + i)
+  const metadatas = chunks.map((_, i) => ({
     source: url,
     markdown,
     type: 'company_sustainability_report', // this is our own type to be able to filter in the future if needed
@@ -23,7 +23,7 @@ async function addReport(url: string, markdown: string, paragraphs: string[]) {
   await collection.add({
     ids,
     metadatas,
-    documents: paragraphs,
+    documents: chunks,
   })
 }
 

--- a/src/workers/indexMarkdown.ts
+++ b/src/workers/indexMarkdown.ts
@@ -13,17 +13,17 @@ const indexMarkdown = new DiscordWorker(
     const chunkSize = 1000
     const overlapSize = 200
 
-    const paragraphs: string[] = []
+    const chunks: string[] = []
     for (let i = 0; i < markdown.length; i += chunkSize - overlapSize) {
-      const chunk = markdown.slice(i, i + chunkSize)
-      paragraphs.push(chunk.trim())
+      const chunk = markdown.slice(i, i + chunkSize).trim()
+      if (chunk.length > 0) chunks.push(chunk)
     }
 
     await job.sendMessage(`🤖 Sparar i vektordatabas...`)
-    job.log('Indexing ' + paragraphs.length + ' paragraphs from url: ' + url)
+    job.log('Indexing ' + chunks.length + ' chunks from url: ' + url)
 
     try {
-      await vectorDB.addReport(url, markdown, paragraphs)
+      await vectorDB.addReport(url, markdown, chunks)
       job.editMessage(`✅ Sparad i vektordatabasen`)
       job.log('Done!')
 

--- a/src/workers/indexMarkdown.ts
+++ b/src/workers/indexMarkdown.ts
@@ -10,10 +10,14 @@ const indexMarkdown = new DiscordWorker(
     const childrenValues = await job.getChildrenEntries()
     const { markdown }: { markdown: string } = childrenValues
 
-    const paragraphs = markdown
-      .split('\n###')
-      .map((p) => p.trim())
-      .filter((p) => p.length > 0)
+    const chunkSize = 1000
+    const overlapSize = 200
+
+    const paragraphs: string[] = []
+    for (let i = 0; i < markdown.length; i += chunkSize - overlapSize) {
+      const chunk = markdown.slice(i, i + chunkSize)
+      paragraphs.push(chunk.trim())
+    }
 
     await job.sendMessage(`🤖 Sparar i vektordatabas...`)
     job.log('Indexing ' + paragraphs.length + ' paragraphs from url: ' + url)


### PR DESCRIPTION
✂️ Previously we divided chunks by "###n" (header sections)
✂️ With this approach we divide the text into chunks of 1000 characters with 200 character overlap

📈 From my experiments the results where substantially better with this method

Ex:

## Addtech https://www.addtech.se/fileadmin/user_upload/Arsredovisningar/Addtech-Arsredovisning-22-23.pdf

### Result with previous chunking method
<img width="500" alt="before_new_chunking" src="https://github.com/user-attachments/assets/ee199502-a7ac-438f-8e5b-773dfb9e0194">


### Result with new chunking method (3/3 categories identified) 🚀 
![after_new_chunking](https://github.com/user-attachments/assets/11032ea0-25df-4c51-b79f-a528d1f429c6)

Tried a few more as well. Here it is 100% https://www.add.life/media/nwepx4r4/addlife-annual-report-2023.pdf


fixes #282  