### PR TITLE
Extend tables sent to openai vision

### DIFF
--- a/src/lib/jsonExtraction.ts
+++ b/src/lib/jsonExtraction.ts
@@ -170,6 +170,7 @@ export type Table = {
   name: string
   level: number
   content: string
+  markdown?: string
 }
 
 export type TableWithFilename = Table & { filename: string }

--- a/src/lib/pdfTools.ts
+++ b/src/lib/pdfTools.ts
@@ -111,7 +111,7 @@ export async function extractTablesFromJson(
   json: ParsedDocument,
   outputDir: string,
   searchTerms: string[]
-): Promise<TableWithFilename[]> {
+): Promise<{ tables: TableWithFilename[]; uniquePageCount: number }> {
   const pngs = await getPngsFromPdfPage(pdf)
   const pages = Object.values(
     findRelevantTablesGroupedOnPages(json, searchTerms)
@@ -148,5 +148,10 @@ export async function extractTablesFromJson(
     }
   )
 
-  return Promise.all(tablePromises).then((results) => results.flat())
+  const tables = await Promise.all(tablePromises).then((results) =>
+    results.flat()
+  )
+  const uniquePageCount = processedPages.size
+
+  return { tables, uniquePageCount }
 }

--- a/src/workers/nlmExtractTables.ts
+++ b/src/workers/nlmExtractTables.ts
@@ -85,18 +85,17 @@ const nlmExtractTables = new DiscordWorker(
       const pdf = await fetchPdf(url)
       const outputDir = path.resolve('/tmp')
       job.editMessage(`✅ PDF nedladdad!`)
-      const results = await extractTablesFromJson(
+      const { tables: results, uniquePageCount } = await extractTablesFromJson(
         pdf,
         json,
         outputDir,
         searchTerms
       )
 
-      const uniquePages = new Set(results.map((table) => table.page_idx))
       const totalTables = results.length
 
       job.sendMessage(
-        `🤖 Hittade ${totalTables} relevanta tabeller på ${uniquePages.size} unika sidor.`
+        `🤖 Hittade ${totalTables} relevanta tabeller på ${uniquePageCount} unika sidor.`
       )
 
       const groupedResults = results.reduce((acc, table) => {

--- a/src/workers/nlmExtractTables.ts
+++ b/src/workers/nlmExtractTables.ts
@@ -39,7 +39,7 @@ const extractTextViaVisionAPI = async (
       },
       {
         role: 'user',
-        content: `I have a PDF with couple of tables related to a company's CO2 emissions. Can you extract the text from screenshot, especially a table called ${name}? I will send you the screenshot- only extract the table contents and ignore the surrounding text if they are not related to the tables/graphs (such as footnotes or disclaimers). Use Markdown format for the table(s), only reply with markdown. OK?`,
+        content: `I have a PDF with couple of tables related to a company's CO2 emissions. Can you extract the text from screenshot. I will send you the screenshot extract the header and table contents and ignore the surrounding text if they are not related to the tables/graphs (such as header, description, footnotes or disclaimers). Use Markdown format for the table(s), only reply with markdown. OK?`,
       },
       {
         role: 'assistant',


### PR DESCRIPTION
🔍 It would be great if we could find more relevant tables to search with openAI vision. 
🔍 In this implementation we extend the table searchterm --> searchTerms and look through thoose
🔍 However because of a bugg we currently send a picture of the entire page to openAI, this is not something we want to do for tables that are on the same page. I feel that this implementation wasn't super readable so not quite happy with it yet. Would like to simplify. But the ideá / problem is interesting. "How do we send the right data to visonAPI". 

⚙️ Leaving this up as a draft for know. Look forward to discussing 

This relates to issue #260 but I am not confident in the results yet

Fix #260 