### PR TITLE
Use native Intl.DateTimeFormat instead of external library.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "chromadb": "^1.9.4",
         "compromise": "^14.13.0",
         "cors": "^2.8.5",
-        "date-fns": "^4.1.0",
         "discord.js": "^14.16.3",
         "dotenv": "^16.4.5",
         "dotenv-cli": "^7.4.4",
@@ -3708,15 +3707,6 @@
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/dateformat": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "chromadb": "^1.9.4",
     "compromise": "^14.13.0",
     "cors": "^2.8.5",
-    "date-fns": "^4.1.0",
     "discord.js": "^14.16.3",
     "dotenv": "^16.4.5",
     "express": "^5.0.1",

--- a/src/lib/reportingPeriodDates.ts
+++ b/src/lib/reportingPeriodDates.ts
@@ -1,4 +1,3 @@
-import { format } from 'date-fns'
 /**
  * Translate the reporting period dates into another year. Can handle leap years.
  */
@@ -24,6 +23,11 @@ export function getPeriodDatesForYear(
   return [start, end]
 }
 
+/**
+ * Format a date according to the ISO standard, e.g. "2023-01-01"
+ */
+const isoDate = new Intl.DateTimeFormat('sv-SE', { dateStyle: 'short' })
+
 export function getReportingPeriodDates(
   year: number,
   startMonth: number,
@@ -32,10 +36,9 @@ export function getReportingPeriodDates(
   const startYear = startMonth >= endMonth ? year - 1 : year
   const endYear = year
 
-  const start = format(new Date(startYear, startMonth - 1, 1), 'yyyy-MM-dd')
-  const end = format(
-    new Date(endYear, endMonth - 1, getLastDayInMonth(endYear, endMonth - 1)),
-    'yyyy-MM-dd'
+  const start = isoDate.format(new Date(startYear, startMonth - 1, 1))
+  const end = isoDate.format(
+    new Date(endYear, endMonth - 1, getLastDayInMonth(endYear, endMonth - 1))
   )
 
   return [start, end]


### PR DESCRIPTION
We didn't use any non-native functionality.