### PR TITLE
Remove `json` from job data after the report has been parsed

### DIFF
--- a/src/workers/followUp.ts
+++ b/src/workers/followUp.ts
@@ -11,7 +11,6 @@ class JobData extends DiscordJob {
     documentId: string
     apiSubEndpoint: string
     type: JobType
-    json: string
     previousAnswer: string
   }
 }

--- a/src/workers/nlmParsePDF.ts
+++ b/src/workers/nlmParsePDF.ts
@@ -67,6 +67,11 @@ const nlmParsePDF = new DiscordWorker(
 
         const precheck = await flow.add({
           ...base,
+          data: {
+            ...base.data,
+            // Once the report has been parsed, we don't need the `json` repressentation of the report anymore.
+            json: undefined,
+          },
           name: 'precheck ' + name,
           queueName: 'precheck',
           children: [


### PR DESCRIPTION
Fix #300 

Removing this as early as possible