### PR TITLE
Sync staging with main

### DIFF
--- a/k8s/api.yaml
+++ b/k8s/api.yaml
@@ -14,7 +14,7 @@ spec:
         app: garbo
     spec:
       containers:
-        - image: ghcr.io/klimatbyran/garbo:3.1.21 # {"$imagepolicy": "flux-system:garbo"}
+        - image: ghcr.io/klimatbyran/garbo:3.1.22 # {"$imagepolicy": "flux-system:garbo"}
           resources: {}
           name: garbo
           ports:

--- a/k8s/api.yaml
+++ b/k8s/api.yaml
@@ -14,7 +14,7 @@ spec:
         app: garbo
     spec:
       containers:
-        - image: ghcr.io/klimatbyran/garbo:3.1.22 # {"$imagepolicy": "flux-system:garbo"}
+        - image: ghcr.io/klimatbyran/garbo:3.1.23 # {"$imagepolicy": "flux-system:garbo"}
           resources: {}
           name: garbo
           ports:

--- a/k8s/api.yaml
+++ b/k8s/api.yaml
@@ -14,7 +14,7 @@ spec:
         app: garbo
     spec:
       containers:
-        - image: ghcr.io/klimatbyran/garbo:3.1.20 # {"$imagepolicy": "flux-system:garbo"}
+        - image: ghcr.io/klimatbyran/garbo:3.1.21 # {"$imagepolicy": "flux-system:garbo"}
           resources: {}
           name: garbo
           ports:

--- a/k8s/pre-deploy/db-migrate.yaml
+++ b/k8s/pre-deploy/db-migrate.yaml
@@ -9,7 +9,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: migration
-          image: ghcr.io/klimatbyran/garbo:3.1.21 # {"$imagepolicy": "flux-system:garbo"}
+          image: ghcr.io/klimatbyran/garbo:3.1.22 # {"$imagepolicy": "flux-system:garbo"}
           command: ['npm', 'run', 'migrate']
           env:
             - name: POSTGRES_PASSWORD

--- a/k8s/pre-deploy/db-migrate.yaml
+++ b/k8s/pre-deploy/db-migrate.yaml
@@ -9,7 +9,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: migration
-          image: ghcr.io/klimatbyran/garbo:3.1.20 # {"$imagepolicy": "flux-system:garbo"}
+          image: ghcr.io/klimatbyran/garbo:3.1.21 # {"$imagepolicy": "flux-system:garbo"}
           command: ['npm', 'run', 'migrate']
           env:
             - name: POSTGRES_PASSWORD

--- a/k8s/pre-deploy/db-migrate.yaml
+++ b/k8s/pre-deploy/db-migrate.yaml
@@ -9,7 +9,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: migration
-          image: ghcr.io/klimatbyran/garbo:3.1.22 # {"$imagepolicy": "flux-system:garbo"}
+          image: ghcr.io/klimatbyran/garbo:3.1.23 # {"$imagepolicy": "flux-system:garbo"}
           command: ['npm', 'run', 'migrate']
           env:
             - name: POSTGRES_PASSWORD

--- a/k8s/worker.yaml
+++ b/k8s/worker.yaml
@@ -14,7 +14,7 @@ spec:
         app: worker
     spec:
       containers:
-        - image: ghcr.io/klimatbyran/garbo:3.1.20 # {"$imagepolicy": "flux-system:garbo"}
+        - image: ghcr.io/klimatbyran/garbo:3.1.21 # {"$imagepolicy": "flux-system:garbo"}
           resources: {}
           command: ['npm', 'run', 'workers']
           name: worker

--- a/k8s/worker.yaml
+++ b/k8s/worker.yaml
@@ -14,7 +14,7 @@ spec:
         app: worker
     spec:
       containers:
-        - image: ghcr.io/klimatbyran/garbo:3.1.21 # {"$imagepolicy": "flux-system:garbo"}
+        - image: ghcr.io/klimatbyran/garbo:3.1.22 # {"$imagepolicy": "flux-system:garbo"}
           resources: {}
           command: ['npm', 'run', 'workers']
           name: worker

--- a/k8s/worker.yaml
+++ b/k8s/worker.yaml
@@ -14,7 +14,7 @@ spec:
         app: worker
     spec:
       containers:
-        - image: ghcr.io/klimatbyran/garbo:3.1.22 # {"$imagepolicy": "flux-system:garbo"}
+        - image: ghcr.io/klimatbyran/garbo:3.1.23 # {"$imagepolicy": "flux-system:garbo"}
           resources: {}
           command: ['npm', 'run', 'workers']
           name: worker

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garbo",
-  "version": "3.1.22",
+  "version": "3.1.23",
   "description": "",
   "type": "module",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garbo",
-  "version": "3.1.21",
+  "version": "3.1.22",
   "description": "",
   "type": "module",
   "engines": {


### PR DESCRIPTION
This pull request includes updates to the image version and the package version for the `garbo` application. The primary changes are as follows:

Version updates:

* [`k8s/api.yaml`](diffhunk://#diff-dd30f0e817cb2c8d2badae6c4a416547cc48d9f33fdfd3c358c1640975211631L17-R17): Updated the `garbo` image version from `3.1.20` to `3.1.23` in the `spec` section.
* [`k8s/pre-deploy/db-migrate.yaml`](diffhunk://#diff-b7e3098f6f4d46b0fc9caf497c010722437197fa07654596153aa41dba43776eL12-R12): Updated the `garbo` image version from `3.1.20` to `3.1.23` in the `spec` section.
* [`k8s/worker.yaml`](diffhunk://#diff-93e545542bd6994776e508e6d47317afdf317ae9b8fdf9dc82b77dc426d3f17bL17-R17): Updated the `garbo` image version from `3.1.20` to `3.1.23` in the `spec` section.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the `garbo` package version from `3.1.21` to `3.1.23`.