### PR TITLE
fix: more consistant prompt for scope 3

### DIFF
--- a/src/prompts/followUp/scope3.ts
+++ b/src/prompts/followUp/scope3.ts
@@ -21,52 +21,44 @@ export const schema = z.object({
   ),
 })
 
-export const prompt = `
-Extract scope 3 emissions according to the GHG protocol. Add it as field emissions per year. Include all years you can find and never exclude the latest year. Include as many categories as you can find and their scope 3 emissions.
+export const prompt = `## Scope 3:
+Extract scope 3 emissions according to the GHG Protocol and organize them by year. Add a field \`emissionsPerYear\` and include as many categories as explicitly reported. Always include the latest year if available. Do not infer or estimate data.
 
-Important! Always report according to the official GHG categories. If you can't find the corresponding category, do not report it.
+### Instructions:
 
-NEVER CALCULATE ANY EMISSIONS. ONLY REPORT THE DATA AS IT IS IN THE PDF. If you can't find any data or if you are uncertain, report it as null. If the company has reported individual categories but no totals, never try to calculate totals, just report it as is.
+1. **Reporting categories**:
+   Always report data according to the official GHG Protocol categories. If a reported category does not match the official list, include it under "16: other."
 
-Regarding transport: If you can't find the exact category, report it as category 4 or 9 depending on the context.
+2. **Missing or incomplete data**:
+   If data is missing or unclear, explicitly report it as \`null\`. Do not make assumptions or attempt to infer missing values.
 
-UNITS: All emissions should be reported in metric tons of CO2 equivalent. If the unit is different (as an example kton), convert it.
+3. **Units**:
+   Report all emissions in metric tons of CO2 equivalent. If the data is provided in a different unit, convert it. This is the only permitted calculation.
 
-If the company is identified as a financial institution or investment company, look for emissions data from investments, the portfolio, or financed emissions. They are often found elsewhere in the report. Do not use markdown in the output.
+4. **Financial institutions**:
+   If the company is a financial institution, look specifically for emissions data related to investments, portfolio, or financed emissions. These may be located in separate sections of the report.
 
-1: purchasedGoods
-2: capitalGoods
-3: fuelAndEnergyRelatedActivities
-4: upstreamTransportationAndDistribution
-5: wasteGeneratedInOperations
-6: businessTravel
-7: employeeCommuting
-8: upstreamLeasedAssets
-9: downstreamTransportationAndDistribution
-10: processingOfSoldProducts
-11: useOfSoldProducts
-12: endOfLifeTreatmentOfSoldProducts
-13: downstreamLeasedAssets
-14: franchises
-15: investments
-16: other
+5. **Totals**:
+   Only report total emissions if explicitly stated. Do not calculate totals, even if all categories are individually reported.
 
-Example: Keep this format and add as many years as you can find. Keep the categories you find and if the company has invented new categories, please add them to the 16: other category.
+6. **Transportation categories**:
+   If a transportation-related category is unclear, classify it as either \`4: upstreamTransportationAndDistribution\` or \`9: downstreamTransportationAndDistribution\` based on how it is described.
+
+7. **Output format**:
+   Keep the output strictly in JSON format, following this structure:
 
 \`\`\`json
 {
   "scope3": [
     {
       "year": 2021,
-      "scope3": {
-        "categories": [
-          { "category": 1, "total": 10},
-          { "category": 2, "total": 20},
-          { "category": 3, "total": 40},
-          { "category": 14, "total": 40}
-        ],
-        "statedTotalEmissions": { "total": 110 }
-      }
+      "categories": [
+        { "category": 1, "total": 10 },
+        { "category": 2, "total": 20 },
+        { "category": 3, "total": 40 },
+        { "category": 14, "total": 40 }
+      ],
+      "statedTotalEmissions": { "total": 110 }
     },
     { "year": 2022, ... },
     { "year": 2023, ... }

--- a/src/prompts/followUp/scope3.ts
+++ b/src/prompts/followUp/scope3.ts
@@ -70,7 +70,7 @@ Extract scope 3 emissions according to the GHG Protocol and organize them by yea
   "scope3": [
    {
     "year": 2021,
-    "categories": [
+    "scope3": [
       { "category": 1, "total": 10 },
       { "category": 2, "total": 20 },
       { "category": 3, "total": 40 },

--- a/src/prompts/followUp/scope3.ts
+++ b/src/prompts/followUp/scope3.ts
@@ -22,46 +22,64 @@ export const schema = z.object({
 })
 
 export const prompt = `## Scope 3:
-Extract scope 3 emissions according to the GHG Protocol and organize them by year. Add a field \`emissionsPerYear\` and include as many categories as explicitly reported. Always include the latest year if available. Do not infer or estimate data.
+Extract scope 3 emissions according to the GHG Protocol and organize them by year. Add a field \`scope3\` and include as many categories as explicitly reported. Always include the latest year if available. Do not infer or estimate data.
 
 ### Instructions:
 
-1. **Reporting categories**:
-   Always report data according to the official GHG Protocol categories. If a reported category does not match the official list, include it under "16: other."
+1. **Reporting Categories**:
+  Always report data according to the official GHG Protocol categories. If a reported category does not match the official list, include it under "16: Other."
 
-2. **Missing or incomplete data**:
-   If data is missing or unclear, explicitly report it as \`null\`. Do not make assumptions or attempt to infer missing values.
+  GHG Categories:
+   1: Purchased Goods
+   2: Capital Goods
+   3: Fuel And Energy Related Activities
+   4: Upstream Transportation And Distribution
+   5: Waste Generated In Operations
+   6: Business Travel
+   7: Employee Commuting
+   8: Upstream Leased Assets
+   9: Downstream Transportation And Distribution
+   10: Processing Of Sold Products
+   11: Use Of Sold Products
+   12: End Of Life Treatment Of Sold Products
+   13: Downstream Leased Assets
+   14: Franchises
+   15: Investments
+   16: Other
+
+2. **Missing Or Incomplete Data**:
+  If data is missing or unclear, explicitly report it as \`null\`. Do not make assumptions or attempt to infer missing values.
 
 3. **Units**:
-   Report all emissions in metric tons of CO2 equivalent. If the data is provided in a different unit, convert it. This is the only permitted calculation.
+  Report all emissions in metric tons of CO2 equivalent. If the data is provided in a different unit, convert it. This is the only permitted calculation.
 
-4. **Financial institutions**:
-   If the company is a financial institution, look specifically for emissions data related to investments, portfolio, or financed emissions. These may be located in separate sections of the report.
+4. **Financial Institutions**:
+  If the company is a financial institution, look specifically for emissions data related to investments, portfolio, or financed emissions. These may be located in separate sections of the report.
 
 5. **Totals**:
-   Only report total emissions if explicitly stated. Do not calculate totals, even if all categories are individually reported.
+  Only report total emissions if explicitly stated. Do not calculate totals, even if all categories are individually reported.
 
-6. **Transportation categories**:
-   If a transportation-related category is unclear, classify it as either \`4: upstreamTransportationAndDistribution\` or \`9: downstreamTransportationAndDistribution\` based on how it is described.
+6. **Transportation Categories**:
+  If a transportation-related category is unclear, classify it as either \`4: Upstream Transportation And Distribution\` or \`9: Downstream Transportation And Distribution\` based on how it is described.
 
-7. **Output format**:
-   Keep the output strictly in JSON format, following this structure:
+7. **Output Format**:
+  Keep the output strictly in JSON format, following this structure:
 
 \`\`\`json
 {
   "scope3": [
-    {
-      "year": 2021,
-      "categories": [
-        { "category": 1, "total": 10 },
-        { "category": 2, "total": 20 },
-        { "category": 3, "total": 40 },
-        { "category": 14, "total": 40 }
-      ],
-      "statedTotalEmissions": { "total": 110 }
-    },
-    { "year": 2022, ... },
-    { "year": 2023, ... }
+   {
+    "year": 2021,
+    "categories": [
+      { "category": 1, "total": 10 },
+      { "category": 2, "total": 20 },
+      { "category": 3, "total": 40 },
+      { "category": 14, "total": 40 }
+    ],
+    "statedTotalEmissions": { "total": 110 }
+   },
+   { "year": 2022, ... },
+   { "year": 2023, ... }
   ]
 }
 \`\`\`


### PR DESCRIPTION
This pull request includes significant updates to the `prompt` in the `scope3.ts` file to improve clarity and ensure consistent reporting of scope 3 emissions according to the GHG Protocol. The changes focus on restructuring the instructions and refining the output format.

Key changes include:

### Improvements to prompt clarity and structure:

* The `prompt` has been restructured into a more organized format with clear sections and instructions. This includes adding headings and numbered instructions to enhance readability and comprehension.

### Detailed instructions for data reporting:

* Added specific guidelines for reporting categories, handling missing or incomplete data, and converting units to metric tons of CO2 equivalent.
* Included instructions for financial institutions to look for emissions data related to investments and portfolios, which may be found in different sections of reports.
* Clarified that total emissions should only be reported if explicitly stated and not calculated from individual categories.

### Output format specification:

* Specified that the output must be in JSON format and provided a detailed example to ensure consistency in how the data is reported.