### PR TITLE
fix: don't send whole markdown document for every chunk

### DIFF
--- a/src/lib/vectordb.ts
+++ b/src/lib/vectordb.ts
@@ -11,11 +11,11 @@ const collection = await client.getOrCreateCollection({
   embeddingFunction: embedder,
 })
 
-async function addReport(url: string, markdown: string, chunks: string[]) {
+async function addReport(url: string, chunks: string[]) {
   const ids = chunks.map((_, i) => url + '#' + i)
-  const metadatas = chunks.map((_, i) => ({
+  const metadatas = chunks.map((chunk, i) => ({
     source: url,
-    markdown,
+    markdown: chunk,
     type: 'company_sustainability_report', // this is our own type to be able to filter in the future if needed
     parsed: new Date().toISOString(),
     page: i,


### PR DESCRIPTION
This pull request includes changes to the `addReport` function in the `src/lib/vectordb.ts` file to improve the handling of report chunks and their metadata. The most important changes are:

Improvements to metadata handling:

* [`src/lib/vectordb.ts`](diffhunk://#diff-5445bbda24d0e9a288887f98ef6209142fdff90061238b6a6a56aedfda0430f6L14-R18): Modified the `addReport` function to remove the `markdown` parameter and use the `chunk` directly within the `metadatas` array. This ensures each chunk's metadata is accurately represented.