### PR TITLE
fix: explicit kton unit conversion

### DIFF
--- a/src/prompts/followUp/scope3.ts
+++ b/src/prompts/followUp/scope3.ts
@@ -51,7 +51,7 @@ Extract scope 3 emissions according to the GHG Protocol and organize them by yea
   If data is missing or unclear, explicitly report it as \`null\`. Do not make assumptions or attempt to infer missing values.
 
 3. **Units**:
-  Report all emissions in metric tons of CO2 equivalent. If the data is provided in a different unit, convert it. This is the only permitted calculation.
+  Report all emissions in metric tons of CO2 equivalent. If the data is provided in a different unit (kton = 1000 tCO2, Mton = 1000000 tCO2), convert it. This is the only permitted calculation.
 
 4. **Financial Institutions**:
   If the company is a financial institution, look specifically for emissions data related to investments, portfolio, or financed emissions. These may be located in separate sections of the report.


### PR DESCRIPTION
This pull request includes a change to the `src/prompts/followUp/scope3.ts` file to clarify the conversion of units for emissions reporting.

* [`src/prompts/followUp/scope3.ts`](diffhunk://#diff-7584de0ff77df58814bb0358e42151ba15bde81d71ce2259377e659e1506373aL54-R54): Updated the instructions to specify that kton (1000 tCO2) and Mton (1000000 tCO2) should be converted to metric tons of CO2 equivalent.