### PR TITLE
fix: use a specific version of pdf-to-img which is not using transparency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "express": "^5.0.1",
     "jest": "^29.7.0",
     "openai": "^4.73.1",
-    "pdf-to-img": "^4.3.0",
+    "pdf-to-img": "4.1.1",
     "pino-http": "^10.3.0",
     "prisma-zod-generator": "^0.8.13",
     "sharp": "^0.33.5",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c86fd3b3-b248-4a40-b0fb-4142aff9e06a)
