### PR TITLE
Fix/build and push base image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: version
 
+    # Add concurrency check for base image
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: false
+
     steps:
+      - name: 🔍 Wait for base image workflow
+        uses: lewagon/wait-on-check-action@v1.3.1
+        with:
+          ref: ${{ github.ref }}
+          check-name: 'build-and-push'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+          allowed-conclusions: success,skipped
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,14 +53,17 @@ jobs:
       cancel-in-progress: false
 
     steps:
-      - name: 🔍 Wait for base image workflow
+      - name: 🔍 Check for base image workflow
+        id: check-workflow
+        continue-on-error: true
         uses: lewagon/wait-on-check-action@v1.3.1
         with:
           ref: ${{ github.ref }}
-          check-name: 'build-and-push'
+          check-name: 'build-and-push-base-image'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
           allowed-conclusions: success,skipped
+          running-workflow-name: 'Build and Push Base Image'
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: 🔍 Check for base image workflow
         id: check-workflow
         continue-on-error: true
-        uses: lewagon/wait-on-check-action@v1.3.1
+        uses: lewagon/wait-on-check-action@v1.3.4
         with:
           ref: ${{ github.ref }}
           check-name: 'build-and-push-base-image'


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow configuration to add concurrency control and a step to check for the completion of another workflow before proceeding.

Improvements to GitHub Actions workflow:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR50-R66): Added concurrency control to ensure that only one instance of the workflow runs at a time for a given reference.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR50-R66): Introduced a step to check for the completion of the 'build-and-push-base-image' workflow before continuing with the current workflow. This step uses the `lewagon/wait-on-check-action@v1.3.1` action.