### PR TITLE
Release without base image

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -12,7 +12,7 @@ env:
   BASE_IMAGE_NAME: ${{ github.repository }}/garbo-base
 
 jobs:
-  build-and-push:
+  build-and-push-base-image:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -17,7 +17,9 @@ RUN apk add --no-cache \
     giflib-dev \
     libjpeg-turbo-dev \
     ghostscript \
-    graphicsmagick
+    ghostscript-dev \
+    graphicsmagick \
+    graphicsmagick-dev
 
 # TODO: Remove unused native dependencies: `cairo`, `pango`, `pixman`, `giflib` and maybe others?
 


### PR DESCRIPTION
This pull request includes changes to the `Dockerfile` and `Dockerfile.base` to update the base image and add necessary dependencies for the application. The most important changes include switching the base image to `node:alpine` and adding various development packages.

Changes to `Dockerfile`:

* Switched the base image from `ghcr.io/klimatbyran/garbo-base:main` to `node:alpine`.
* Added multiple development packages such as `chromium`, `nss`, `freetype`, `python3`, `make`, and others to support the application dependencies.

Changes to `Dockerfile.base`:

* Added `ghostscript-dev` and `graphicsmagick-dev` to the list of installed packages.