### PR TITLE
Update workers yaml to remove resource demand, and trigger rebuild

### DIFF
--- a/k8s/worker.yaml
+++ b/k8s/worker.yaml
@@ -15,11 +15,7 @@ spec:
     spec:
       containers:
         - image: ghcr.io/klimatbyran/garbo:3.4.6 # {"$imagepolicy": "flux-system:garbo"}
-          resources:
-            requests:
-              memory: '16Gi'
-            limits:
-              memory: '16Gi'
+          resources: {}
           command: ['npm', 'run', 'workers']
           name: worker
           ports:

--- a/src/workers/saveToAPI.ts
+++ b/src/workers/saveToAPI.ts
@@ -265,6 +265,7 @@ const saveToAPI = new DiscordWorker<JobData>(
               economy,
               metadata,
             }
+
             return await apiFetch(`/companies/${wikidataId}/${year}/economy`, {
               body,
             })


### PR DESCRIPTION
The workers are not restarting on build --> might have to do with resource demand in yaml file added yesterday. Trying to remove it and se if it resolves