### PR TITLE
Only pass parsed json data explicitly when needed, and remove from other jobs

### DIFF
--- a/src/routes/updateCompanies.ts
+++ b/src/routes/updateCompanies.ts
@@ -48,7 +48,6 @@ const upsertCompanyBodySchema = z.object({
   description: z.string().optional(),
   url: z.string().url().optional(),
   internalComment: z.string().optional(),
-  // TODO: add history for turnover etc.
 })
 
 const validateCompanyUpsert = () => processRequestBody(upsertCompanyBodySchema)

--- a/src/workers/nlmParsePDF.ts
+++ b/src/workers/nlmParsePDF.ts
@@ -58,6 +58,8 @@ const nlmParsePDF = new DiscordWorker(
         const base = {
           data: {
             ...job.data,
+            // Explicitly remove parsed json since we don't need it in later steps.
+            json: undefined,
           },
         }
 
@@ -66,9 +68,6 @@ const nlmParsePDF = new DiscordWorker(
 
         const precheck = await flow.add({
           ...base,
-          data: {
-            ...base.data,
-          },
           name: 'precheck ' + name,
           queueName: 'precheck',
           children: [
@@ -81,6 +80,7 @@ const nlmParsePDF = new DiscordWorker(
                   ...base,
                   data: {
                     ...base.data,
+                    // Pass json explicitly where we need it
                     json,
                   },
                   name: 'extractTables ' + name,


### PR DESCRIPTION
This should reduce reduce the size of the job data, and reduce storage and memory required for the queue.

Follow up for https://github.com/Klimatbyran/garbo/pull/302 - it seems like that change got lost somewhere when merging staging and main.