### PR TITLE
Increase CPU for nlm ingestor workers

### DIFF
--- a/k8s/api.yaml
+++ b/k8s/api.yaml
@@ -14,7 +14,7 @@ spec:
         app: garbo
     spec:
       containers:
-        - image: ghcr.io/klimatbyran/garbo:3.4.13 # {"$imagepolicy": "flux-system:garbo"}
+        - image: ghcr.io/klimatbyran/garbo:3.4.20 # {"$imagepolicy": "flux-system:garbo"}
           resources: {}
           name: garbo
           ports:

--- a/k8s/nlm-ingestor.yaml
+++ b/k8s/nlm-ingestor.yaml
@@ -16,7 +16,7 @@ spec:
         - image: ghcr.io/nlmatics/nlm-ingestor
           resources:
             limits:
-              cpu: 1100m
+              cpu: 3000m
               memory: 2Gi
           name: nlm
           ports:

--- a/k8s/pre-deploy/db-migrate.yaml
+++ b/k8s/pre-deploy/db-migrate.yaml
@@ -9,7 +9,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: migration
-          image: ghcr.io/klimatbyran/garbo:3.4.13 # {"$imagepolicy": "flux-system:garbo"}
+          image: ghcr.io/klimatbyran/garbo:3.4.20 # {"$imagepolicy": "flux-system:garbo"}
           command: ['npm', 'run', 'migrate']
           env:
             - name: POSTGRES_PASSWORD

--- a/k8s/worker.yaml
+++ b/k8s/worker.yaml
@@ -14,7 +14,7 @@ spec:
         app: worker
     spec:
       containers:
-        - image: ghcr.io/klimatbyran/garbo:3.4.13 # {"$imagepolicy": "flux-system:garbo"}
+        - image: ghcr.io/klimatbyran/garbo:3.4.20 # {"$imagepolicy": "flux-system:garbo"}
           resources: {}
           command: ['npm', 'run', 'workers']
           name: worker

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo",
-  "version": "3.4.13",
+  "version": "3.4.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo",
-      "version": "3.4.13",
+      "version": "3.4.20",
       "license": "MIT License",
       "dependencies": {
         "@bull-board/api": "^6.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garbo",
-  "version": "3.4.13",
+  "version": "3.4.20",
   "description": "",
   "type": "module",
   "engines": {


### PR DESCRIPTION
- 4 days ago we increased the number of replicas but reduced the cpu capabilites per replica
- This is likely the reason why many reports are not passing