### PR TITLE
fix: retrying doesn't work if we use UnrecoverableError

### DIFF
--- a/src/workers/nlmParsePDF.ts
+++ b/src/workers/nlmParsePDF.ts
@@ -125,7 +125,7 @@ const nlmParsePDF = new DiscordWorker(
       return true
     } catch (error) {
       job.editMessage(`❌ Fel vid nedladdning av PDF: ${error.message}`)
-      throw new UnrecoverableError(error)
+      throw new Error(error)
     }
   },
   { concurrency: 1, connection: redis }


### PR DESCRIPTION
When we try to retry because of a previous failure, the error gets rethrown as an UnrecoverableError which means it will not try again. This PR solves that problem.

Error handling improvement:

* [`src/workers/nlmParsePDF.ts`](diffhunk://#diff-c058c1bae0c644ebe0d37428b23679ce64f4063111b9a8c1e1c5b3cc441c6a24L128-R128): Changed the thrown error from `UnrecoverableError` to `Error` in the `catch` block for better general error handling.