### PR TITLE
allow null for scope 3 categories in order to delete them

### DIFF
--- a/src/routes/updateCompanies.ts
+++ b/src/routes/updateCompanies.ts
@@ -298,7 +298,7 @@ export const emissionsSchema = z
           .array(
             z.object({
               category: z.number().int().min(1).max(16),
-              total: z.number(),
+              total: z.number().nullable(),
             })
           )
           .optional(),


### PR DESCRIPTION
- We have a problem with scope 3 categories being set to zero when faulty (due to no option to delete them at the moment)
- Solution, allow to purposely have a scope3Cat total as null which will result in a delete of that category.