### PR TITLE
Update garbo production

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -23,9 +23,18 @@ const tCO2e = 'tCO2e'
 
 export async function upsertScope1(
   emissions: Emissions,
-  scope1: OptionalNullable<Omit<Scope1, 'id' | 'metadataId' | 'unit'>>,
+  scope1: OptionalNullable<Omit<Scope1, 'id' | 'metadataId' | 'unit'>> | null,
   metadata: Metadata
 ) {
+  if (scope1 === null) {
+    if (emissions.scope1Id) {
+      await prisma.scope1.delete({
+        where: { id: emissions.scope1Id },
+      })
+    }
+    return null
+  }
+
   return emissions.scope1Id
     ? prisma.scope1.update({
         where: { id: emissions.scope1Id },
@@ -60,9 +69,18 @@ export async function upsertScope1(
 
 export async function upsertScope2(
   emissions: Emissions,
-  scope2: OptionalNullable<Omit<Scope2, 'id' | 'metadataId' | 'unit'>>,
+  scope2: OptionalNullable<Omit<Scope2, 'id' | 'metadataId' | 'unit'>> | null,
   metadata: Metadata
 ) {
+  if (scope2 === null) {
+    if (emissions.scope2Id) {
+      await prisma.scope2.delete({
+        where: { id: emissions.scope2Id },
+      })
+    }
+    return null
+  }
+
   return emissions.scope2Id
     ? prisma.scope2.update({
         where: { id: emissions.scope2Id },
@@ -97,9 +115,20 @@ export async function upsertScope2(
 
 export async function upsertScope1And2(
   emissions: Emissions,
-  scope1And2: OptionalNullable<Omit<Scope1And2, 'id' | 'metadataId' | 'unit'>>,
+  scope1And2: OptionalNullable<
+    Omit<Scope1And2, 'id' | 'metadataId' | 'unit'>
+  > | null,
   metadata: Metadata
 ) {
+  if (scope1And2 === null) {
+    if (emissions.scope1And2Id) {
+      await prisma.scope1And2.delete({
+        where: { id: emissions.scope1And2Id },
+      })
+    }
+    return null
+  }
+
   return emissions.scope1And2Id
     ? prisma.scope1And2.update({
         where: { id: emissions.scope1And2Id },

--- a/src/routes/readCompanies.ts
+++ b/src/routes/readCompanies.ts
@@ -183,6 +183,7 @@ router.get(
           },
           goals: {
             select: {
+              id: true,
               description: true,
               year: true,
               baseYear: true,
@@ -195,6 +196,7 @@ router.get(
           },
           initiatives: {
             select: {
+              id: true,
               title: true,
               description: true,
               year: true,

--- a/src/routes/updateCompanies.ts
+++ b/src/routes/updateCompanies.ts
@@ -298,7 +298,7 @@ export const emissionsSchema = z
           .array(
             z.object({
               category: z.number().int().min(1).max(16),
-              total: z.number(),
+              total: z.number().nullable(),
             })
           )
           .optional(),

--- a/src/routes/updateCompanies.ts
+++ b/src/routes/updateCompanies.ts
@@ -270,7 +270,9 @@ export const emissionsSchema = z
       .object({
         total: z.number(),
       })
-      .optional(),
+      .optional()
+      .nullable()
+      .describe('Sending null means deleting the scope'),
     scope2: z
       .object({
         mb: z
@@ -291,7 +293,9 @@ export const emissionsSchema = z
             'At least one property of `mb`, `lb` and `unknown` must be defined if scope2 is provided',
         }
       )
-      .optional(),
+      .optional()
+      .nullable()
+      .describe('Sending null means deleting the scope'),
     scope3: z
       .object({
         categories: z
@@ -307,7 +311,11 @@ export const emissionsSchema = z
       .optional(),
     biogenic: z.object({ total: z.number() }).optional(),
     statedTotalEmissions: statedTotalEmissionsSchema,
-    scope1And2: z.object({ total: z.number() }).optional(),
+    scope1And2: z
+      .object({ total: z.number() })
+      .optional()
+      .nullable()
+      .describe('Sending null means deleting the scope'),
   })
   .optional()
 
@@ -471,10 +479,11 @@ router.post(
       // There seems to be a type error in zod which doesn't take into account optional objects.
 
       await Promise.allSettled([
-        scope1 && upsertScope1(dbEmissions, scope1, metadata),
-        scope2 && upsertScope2(dbEmissions, scope2, metadata),
+        scope1 !== undefined && upsertScope1(dbEmissions, scope1, metadata),
+        scope2 !== undefined && upsertScope2(dbEmissions, scope2, metadata),
         scope3 && upsertScope3(dbEmissions, scope3, metadata),
-        scope1And2 && upsertScope1And2(dbEmissions, scope1And2, metadata),
+        scope1And2 !== undefined &&
+          upsertScope1And2(dbEmissions, scope1And2, metadata),
         statedTotalEmissions &&
           upsertStatedTotalEmissions(
             dbEmissions,


### PR DESCRIPTION
- Add `id` for `initiatives` and `goals` to allow updating and deleting data.
- Allow deleting `scope1`, `scope2` and `scope1And2` to unset values.