### PR TITLE
Feat/delete endpoint for initiatives goals

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -432,6 +432,10 @@ export async function updateGoal(
   })
 }
 
+export async function deleteGoal(id: Goal['id']) {
+  return prisma.goal.delete({ where: { id } })
+}
+
 export async function createInitiatives(
   wikidataId: Company['wikidataId'],
   initiatives: OptionalNullable<
@@ -481,6 +485,10 @@ export async function updateInitiative(
     },
     select: { id: true },
   })
+}
+
+export async function deleteInitiative(id: Initiative['id']) {
+  return prisma.initiative.delete({ where: { id } })
 }
 
 export async function upsertTurnover(

--- a/src/routes/middlewares.ts
+++ b/src/routes/middlewares.ts
@@ -70,15 +70,17 @@ export const fakeAuth =
 
 export const validateMetadata = () =>
   validateRequestBody(
-    z.object({
-      metadata: z
-        .object({
-          comment: z.string().optional(),
-          source: z.string().optional(),
-          dataOrigin: z.string().optional(),
-        })
-        .optional(),
-    })
+    z
+      .object({
+        metadata: z
+          .object({
+            comment: z.string().optional(),
+            source: z.string().optional(),
+            dataOrigin: z.string().optional(),
+          })
+          .optional(),
+      })
+      .optional()
   )
 
 const editMethods = new Set(['POST', 'PATCH', 'PUT'])

--- a/src/routes/readCompanies.ts
+++ b/src/routes/readCompanies.ts
@@ -437,6 +437,7 @@ router.get(
           },
           goals: {
             select: {
+              id: true,
               description: true,
               year: true,
               baseYear: true,
@@ -449,6 +450,7 @@ router.get(
           },
           initiatives: {
             select: {
+              id: true,
               title: true,
               description: true,
               year: true,

--- a/src/routes/updateCompanies.ts
+++ b/src/routes/updateCompanies.ts
@@ -21,6 +21,8 @@ import {
   upsertEmissions,
   upsertEconomy,
   upsertScope1And2,
+  deleteInitiative,
+  deleteGoal,
 } from '../lib/prisma'
 import {
   createMetadata,
@@ -157,6 +159,29 @@ router.patch(
   }
 )
 
+router.delete(
+  '/:wikidataId/goals/:id',
+  processRequest({
+    params: z.object({ id: z.coerce.number() }),
+  }),
+  async (req, res) => {
+    const { id } = req.params
+    await deleteGoal(id).catch((error) => {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2025'
+      ) {
+        throw new GarboAPIError('Goal not found', {
+          statusCode: 404,
+          original: error,
+        })
+      }
+      throw error
+    })
+    res.json({ ok: true })
+  }
+)
+
 const initiativeSchema = z.object({
   title: z.string(),
   description: z.string().optional(),
@@ -196,6 +221,29 @@ router.patch(
     const { id } = req.params
     const metadata = res.locals.metadata
     await updateInitiative(id, initiative, metadata!).catch((error) => {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2025'
+      ) {
+        throw new GarboAPIError('Initiative not found', {
+          statusCode: 404,
+          original: error,
+        })
+      }
+      throw error
+    })
+    res.json({ ok: true })
+  }
+)
+
+router.delete(
+  '/:wikidataId/initiatives/:id',
+  processRequest({
+    params: z.object({ id: z.coerce.number() }),
+  }),
+  async (req, res) => {
+    const { id } = req.params
+    await deleteInitiative(id).catch((error) => {
       if (
         error instanceof Prisma.PrismaClientKnownRequestError &&
         error.code === 'P2025'


### PR DESCRIPTION
- Add ids when selecting goals and initiatives for company details route too
- Allow metadata to be undefined, which allow empty request bodies
- Allow deleting initiatives and goals by id