### PR TITLE
Update garbo production

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -264,9 +264,18 @@ export async function upsertBiogenic(
   emissions: Emissions,
   biogenic: OptionalNullable<
     Omit<BiogenicEmissions, 'id' | 'metadataId' | 'unit'>
-  >,
+  > | null,
   metadata: Metadata
 ) {
+  if (biogenic === null) {
+    if (emissions.biogenicEmissionsId) {
+      await prisma.biogenicEmissions.delete({
+        where: { id: emissions.biogenicEmissionsId },
+      })
+    }
+    return null
+  }
+
   return emissions.biogenicEmissionsId
     ? prisma.biogenicEmissions.update({
         where: {
@@ -493,78 +502,74 @@ export async function deleteInitiative(id: Initiative['id']) {
 
 export async function upsertTurnover(
   economy: Economy,
-  turnover: OptionalNullable<Omit<Turnover, 'id' | 'metadataId' | 'unit'>>,
+  turnover: OptionalNullable<
+    Omit<Turnover, 'id' | 'metadataId' | 'unit'>
+  > | null,
   metadata: Metadata
 ) {
-  return economy.turnoverId
-    ? prisma.turnover.update({
-        where: {
-          id: economy.turnoverId,
-        },
-        data: {
-          ...turnover,
-          metadata: {
-            connect: {
-              id: metadata.id,
-            },
-          },
-        },
-        select: { id: true },
+  if (turnover === null) {
+    if (economy.turnoverId) {
+      await prisma.turnover.delete({
+        where: { id: economy.turnoverId },
       })
-    : prisma.turnover.create({
-        data: {
-          ...turnover,
-          metadata: {
-            connect: {
-              id: metadata.id,
-            },
-          },
-          economy: {
-            connect: {
-              id: economy.id,
-            },
-          },
-        },
-        select: { id: true },
-      })
+    }
+    return null
+  }
+
+  return prisma.turnover.upsert({
+    where: { id: economy.turnoverId ?? 0 },
+    create: {
+      ...turnover,
+      metadata: {
+        connect: { id: metadata.id },
+      },
+      economy: {
+        connect: { id: economy.id },
+      },
+    },
+    update: {
+      ...turnover,
+      metadata: {
+        connect: { id: metadata.id },
+      },
+    },
+    select: { id: true },
+  })
 }
 
 export async function upsertEmployees(
   economy: Economy,
-  employees: OptionalNullable<Omit<Employees, 'id' | 'metadataId'>>,
+  employees: OptionalNullable<Omit<Employees, 'id' | 'metadataId'>> | null,
   metadata: Metadata
 ) {
-  return economy.employeesId
-    ? prisma.employees.update({
-        where: {
-          id: economy.employeesId,
-        },
-        data: {
-          ...employees,
-          metadata: {
-            connect: {
-              id: metadata.id,
-            },
-          },
-        },
-        select: { id: true },
+  if (employees === null) {
+    if (economy.employeesId) {
+      await prisma.employees.delete({
+        where: { id: economy.employeesId },
       })
-    : prisma.employees.create({
-        data: {
-          ...employees,
-          metadata: {
-            connect: {
-              id: metadata.id,
-            },
-          },
-          economy: {
-            connect: {
-              id: economy.id,
-            },
-          },
-        },
-        select: { id: true },
-      })
+    }
+    return null
+  }
+
+  return prisma.employees.upsert({
+    where: { id: economy.employeesId ?? 0 },
+    create: {
+      ...employees,
+      metadata: {
+        connect: { id: metadata.id },
+      },
+      economy: {
+        connect: { id: economy.id },
+      },
+    },
+    update: {
+      ...employees,
+      metadata: {
+        connect: { id: metadata.id },
+      },
+    },
+    select: { id: true },
+  })
 }
 
 export async function createIndustry(

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -432,6 +432,10 @@ export async function updateGoal(
   })
 }
 
+export async function deleteGoal(id: Goal['id']) {
+  return prisma.goal.delete({ where: { id } })
+}
+
 export async function createInitiatives(
   wikidataId: Company['wikidataId'],
   initiatives: OptionalNullable<
@@ -481,6 +485,10 @@ export async function updateInitiative(
     },
     select: { id: true },
   })
+}
+
+export async function deleteInitiative(id: Initiative['id']) {
+  return prisma.initiative.delete({ where: { id } })
 }
 
 export async function upsertTurnover(

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -23,9 +23,18 @@ const tCO2e = 'tCO2e'
 
 export async function upsertScope1(
   emissions: Emissions,
-  scope1: OptionalNullable<Omit<Scope1, 'id' | 'metadataId' | 'unit'>>,
+  scope1: OptionalNullable<Omit<Scope1, 'id' | 'metadataId' | 'unit'>> | null,
   metadata: Metadata
 ) {
+  if (scope1 === null) {
+    if (emissions.scope1Id) {
+      await prisma.scope1.delete({
+        where: { id: emissions.scope1Id },
+      })
+    }
+    return null
+  }
+
   return emissions.scope1Id
     ? prisma.scope1.update({
         where: { id: emissions.scope1Id },
@@ -60,9 +69,18 @@ export async function upsertScope1(
 
 export async function upsertScope2(
   emissions: Emissions,
-  scope2: OptionalNullable<Omit<Scope2, 'id' | 'metadataId' | 'unit'>>,
+  scope2: OptionalNullable<Omit<Scope2, 'id' | 'metadataId' | 'unit'>> | null,
   metadata: Metadata
 ) {
+  if (scope2 === null) {
+    if (emissions.scope2Id) {
+      await prisma.scope2.delete({
+        where: { id: emissions.scope2Id },
+      })
+    }
+    return null
+  }
+
   return emissions.scope2Id
     ? prisma.scope2.update({
         where: { id: emissions.scope2Id },
@@ -97,9 +115,20 @@ export async function upsertScope2(
 
 export async function upsertScope1And2(
   emissions: Emissions,
-  scope1And2: OptionalNullable<Omit<Scope1And2, 'id' | 'metadataId' | 'unit'>>,
+  scope1And2: OptionalNullable<
+    Omit<Scope1And2, 'id' | 'metadataId' | 'unit'>
+  > | null,
   metadata: Metadata
 ) {
+  if (scope1And2 === null) {
+    if (emissions.scope1And2Id) {
+      await prisma.scope1And2.delete({
+        where: { id: emissions.scope1And2Id },
+      })
+    }
+    return null
+  }
+
   return emissions.scope1And2Id
     ? prisma.scope1And2.update({
         where: { id: emissions.scope1And2Id },

--- a/src/routes/middlewares.ts
+++ b/src/routes/middlewares.ts
@@ -70,15 +70,17 @@ export const fakeAuth =
 
 export const validateMetadata = () =>
   validateRequestBody(
-    z.object({
-      metadata: z
-        .object({
-          comment: z.string().optional(),
-          source: z.string().optional(),
-          dataOrigin: z.string().optional(),
-        })
-        .optional(),
-    })
+    z
+      .object({
+        metadata: z
+          .object({
+            comment: z.string().optional(),
+            source: z.string().optional(),
+            dataOrigin: z.string().optional(),
+          })
+          .optional(),
+      })
+      .optional()
   )
 
 const editMethods = new Set(['POST', 'PATCH', 'PUT'])

--- a/src/routes/readCompanies.ts
+++ b/src/routes/readCompanies.ts
@@ -437,6 +437,7 @@ router.get(
           },
           goals: {
             select: {
+              id: true,
               description: true,
               year: true,
               baseYear: true,
@@ -449,6 +450,7 @@ router.get(
           },
           initiatives: {
             select: {
+              id: true,
               title: true,
               description: true,
               year: true,

--- a/src/routes/readCompanies.ts
+++ b/src/routes/readCompanies.ts
@@ -183,6 +183,7 @@ router.get(
           },
           goals: {
             select: {
+              id: true,
               description: true,
               year: true,
               baseYear: true,
@@ -195,6 +196,7 @@ router.get(
           },
           initiatives: {
             select: {
+              id: true,
               title: true,
               description: true,
               year: true,

--- a/src/routes/updateCompanies.ts
+++ b/src/routes/updateCompanies.ts
@@ -361,7 +361,11 @@ export const emissionsSchema = z
         statedTotalEmissions: statedTotalEmissionsSchema,
       })
       .optional(),
-    biogenic: z.object({ total: z.number() }).optional(),
+    biogenic: z
+      .object({ total: z.number() })
+      .optional()
+      .nullable()
+      .describe('Sending null means deleting the biogenic'),
     statedTotalEmissions: statedTotalEmissionsSchema,
     scope1And2: z
       .object({ total: z.number() })
@@ -378,13 +382,17 @@ const economySchema = z
         value: z.number().optional(),
         currency: z.string().optional(),
       })
-      .optional(),
+      .optional()
+      .nullable()
+      .describe('Sending null means deleting the turnover'),
     employees: z
       .object({
         value: z.number().optional(),
         unit: z.string().optional(),
       })
-      .optional(),
+      .optional()
+      .nullable()
+      .describe('Sending null means deleting the employees data'),
   })
   .optional()
 
@@ -471,16 +479,20 @@ router.post(
               scope2 !== undefined &&
                 upsertScope2(dbEmissions, scope2, metadata),
               scope3 && upsertScope3(dbEmissions, scope3, metadata),
-              statedTotalEmissions &&
+              statedTotalEmissions !== undefined &&
                 upsertStatedTotalEmissions(
                   dbEmissions,
                   statedTotalEmissions,
                   metadata
                 ),
-              biogenic && upsertBiogenic(dbEmissions, biogenic, metadata),
-              scope1And2 && upsertScope1And2(dbEmissions, scope1And2, metadata),
-              turnover && upsertTurnover(dbEconomy, turnover, metadata),
-              employees && upsertEmployees(dbEconomy, employees, metadata),
+              biogenic !== undefined &&
+                upsertBiogenic(dbEmissions, biogenic, metadata),
+              scope1And2 !== undefined &&
+                upsertScope1And2(dbEmissions, scope1And2, metadata),
+              turnover !== undefined &&
+                upsertTurnover(dbEconomy, turnover, metadata),
+              employees !== undefined &&
+                upsertEmployees(dbEconomy, employees, metadata),
             ])
           }
         )
@@ -544,7 +556,8 @@ router.post(
             statedTotalEmissions,
             metadata
           ),
-        biogenic && upsertBiogenic(dbEmissions, biogenic, metadata),
+        biogenic !== undefined &&
+          upsertBiogenic(dbEmissions, biogenic, metadata),
       ])
     } catch (error) {
       throw new GarboAPIError('Failed to update emissions', {
@@ -579,8 +592,9 @@ router.post(
     try {
       // Only update if the input contains relevant changes
       await Promise.allSettled([
-        turnover && upsertTurnover(economy, turnover, metadata),
-        employees && upsertEmployees(economy, employees, metadata),
+        turnover !== undefined && upsertTurnover(economy, turnover, metadata),
+        employees !== undefined &&
+          upsertEmployees(economy, employees, metadata),
       ])
     } catch (error) {
       throw new GarboAPIError('Failed to update economy', {

--- a/src/routes/updateCompanies.ts
+++ b/src/routes/updateCompanies.ts
@@ -21,6 +21,8 @@ import {
   upsertEmissions,
   upsertEconomy,
   upsertScope1And2,
+  deleteInitiative,
+  deleteGoal,
 } from '../lib/prisma'
 import {
   createMetadata,
@@ -157,6 +159,29 @@ router.patch(
   }
 )
 
+router.delete(
+  '/:wikidataId/goals/:id',
+  processRequest({
+    params: z.object({ id: z.coerce.number() }),
+  }),
+  async (req, res) => {
+    const { id } = req.params
+    await deleteGoal(id).catch((error) => {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2025'
+      ) {
+        throw new GarboAPIError('Goal not found', {
+          statusCode: 404,
+          original: error,
+        })
+      }
+      throw error
+    })
+    res.json({ ok: true })
+  }
+)
+
 const initiativeSchema = z.object({
   title: z.string(),
   description: z.string().optional(),
@@ -196,6 +221,29 @@ router.patch(
     const { id } = req.params
     const metadata = res.locals.metadata
     await updateInitiative(id, initiative, metadata!).catch((error) => {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2025'
+      ) {
+        throw new GarboAPIError('Initiative not found', {
+          statusCode: 404,
+          original: error,
+        })
+      }
+      throw error
+    })
+    res.json({ ok: true })
+  }
+)
+
+router.delete(
+  '/:wikidataId/initiatives/:id',
+  processRequest({
+    params: z.object({ id: z.coerce.number() }),
+  }),
+  async (req, res) => {
+    const { id } = req.params
+    await deleteInitiative(id).catch((error) => {
       if (
         error instanceof Prisma.PrismaClientKnownRequestError &&
         error.code === 'P2025'

--- a/src/routes/updateCompanies.ts
+++ b/src/routes/updateCompanies.ts
@@ -270,7 +270,9 @@ export const emissionsSchema = z
       .object({
         total: z.number(),
       })
-      .optional(),
+      .optional()
+      .nullable()
+      .describe('Sending null means deleting the scope'),
     scope2: z
       .object({
         mb: z
@@ -291,7 +293,9 @@ export const emissionsSchema = z
             'At least one property of `mb`, `lb` and `unknown` must be defined if scope2 is provided',
         }
       )
-      .optional(),
+      .optional()
+      .nullable()
+      .describe('Sending null means deleting the scope'),
     scope3: z
       .object({
         categories: z
@@ -307,7 +311,11 @@ export const emissionsSchema = z
       .optional(),
     biogenic: z.object({ total: z.number() }).optional(),
     statedTotalEmissions: statedTotalEmissionsSchema,
-    scope1And2: z.object({ total: z.number() }).optional(),
+    scope1And2: z
+      .object({ total: z.number() })
+      .optional()
+      .nullable()
+      .describe('Sending null means deleting the scope'),
   })
   .optional()
 
@@ -471,10 +479,11 @@ router.post(
       // There seems to be a type error in zod which doesn't take into account optional objects.
 
       await Promise.allSettled([
-        scope1 && upsertScope1(dbEmissions, scope1, metadata),
-        scope2 && upsertScope2(dbEmissions, scope2, metadata),
+        scope1 !== undefined && upsertScope1(dbEmissions, scope1, metadata),
+        scope2 !== undefined && upsertScope2(dbEmissions, scope2, metadata),
         scope3 && upsertScope3(dbEmissions, scope3, metadata),
-        scope1And2 && upsertScope1And2(dbEmissions, scope1And2, metadata),
+        scope1And2 !== undefined &&
+          upsertScope1And2(dbEmissions, scope1And2, metadata),
         statedTotalEmissions &&
           upsertStatedTotalEmissions(
             dbEmissions,

--- a/src/routes/updateCompanies.ts
+++ b/src/routes/updateCompanies.ts
@@ -262,7 +262,11 @@ router.post(
   }
 )
 
-const statedTotalEmissionsSchema = z.object({ total: z.number() }).optional()
+const statedTotalEmissionsSchema = z
+  .object({ total: z.number() })
+  .optional()
+  .nullable()
+  .describe('Sending null means deleting the statedTotalEmissions')
 
 export const emissionsSchema = z
   .object({
@@ -414,8 +418,10 @@ router.post(
             }
 
             await Promise.allSettled([
-              scope1 && upsertScope1(dbEmissions, scope1, metadata),
-              scope2 && upsertScope2(dbEmissions, scope2, metadata),
+              scope1 !== undefined &&
+                upsertScope1(dbEmissions, scope1, metadata),
+              scope2 !== undefined &&
+                upsertScope2(dbEmissions, scope2, metadata),
               scope3 && upsertScope3(dbEmissions, scope3, metadata),
               statedTotalEmissions &&
                 upsertStatedTotalEmissions(
@@ -484,7 +490,7 @@ router.post(
         scope3 && upsertScope3(dbEmissions, scope3, metadata),
         scope1And2 !== undefined &&
           upsertScope1And2(dbEmissions, scope1And2, metadata),
-        statedTotalEmissions &&
+        statedTotalEmissions !== undefined &&
           upsertStatedTotalEmissions(
             dbEmissions,
             statedTotalEmissions,


### PR DESCRIPTION
- Add ids when selecting goals and initiatives for company details route too
- Allow metadata to be undefined, which allow empty request bodies
- Allow deleting initiatives and goals by id
- Feat: Deleting economy data working
- Make deletion behaviour consistent
- Allow biogenic emissions to be deleted as well