### PR TITLE
Fix #493 - Allow setting individual `scope2` values to `null` to get correct calculations of total emissions

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -69,7 +69,11 @@ export async function upsertScope1(
 
 export async function upsertScope2(
   emissions: Emissions,
-  scope2: OptionalNullable<Omit<Scope2, 'id' | 'metadataId' | 'unit'>> | null,
+  scope2: {
+    lb?: number | null
+    mb?: number | null
+    unknown?: number | null
+  } | null,
   metadata: Metadata
 ) {
   if (scope2 === null) {

--- a/src/routes/updateCompanies.ts
+++ b/src/routes/updateCompanies.ts
@@ -329,13 +329,19 @@ export const emissionsSchema = z
       .object({
         mb: z
           .number({ description: 'Market-based scope 2 emissions' })
-          .optional(),
+          .optional()
+          .nullable()
+          .describe('Sending null means deleting mb scope 2 emissions'),
         lb: z
           .number({ description: 'Location-based scope 2 emissions' })
-          .optional(),
+          .optional()
+          .nullable()
+          .describe('Sending null means deleting lb scope 2 emissions'),
         unknown: z
           .number({ description: 'Unspecified Scope 2 emissions' })
-          .optional(),
+          .optional()
+          .nullable()
+          .describe('Sending null means deleting unknown scope 2 emissions'),
       })
       .refine(
         ({ mb, lb, unknown }) =>


### PR DESCRIPTION
fix #493 