### PR TITLE
Fix/dont return empty emissions for reporting period (#499)

### DIFF
--- a/src/routes/readCompanies.ts
+++ b/src/routes/readCompanies.ts
@@ -28,6 +28,10 @@ const metadata = {
   },
 }
 
+function removeEmptyValues(obj: Record<any, any>) {
+  return Object.fromEntries(Object.entries(obj).filter(([_, v]) => v != null))
+}
+
 // ## DÖLJ DESSA från API:et
 const HIDDEN_FROM_API = new Set([
   'Q22629259', // GARO
@@ -234,22 +238,25 @@ router.get(
                     }) ||
                     undefined,
                   scope3:
-                    (reportingPeriod.emissions?.scope3 && {
-                      ...reportingPeriod.emissions.scope3,
-                      calculatedTotalEmissions:
-                        reportingPeriod.emissions.scope3.categories.some((c) =>
-                          Boolean(c.metadata.verifiedBy)
-                        )
-                          ? reportingPeriod.emissions.scope3.categories.reduce(
-                              (total, category) =>
-                                isNumber(category.total)
-                                  ? category.total + total
-                                  : total,
-                              0
-                            )
-                          : reportingPeriod.emissions.scope3
-                              .statedTotalEmissions?.total ?? 0,
-                    }) ||
+                    (reportingPeriod.emissions?.scope3 &&
+                      Object.keys(
+                        removeEmptyValues(reportingPeriod.emissions?.scope3)
+                      ).length && {
+                        ...removeEmptyValues(reportingPeriod.emissions.scope3),
+                        calculatedTotalEmissions:
+                          reportingPeriod.emissions.scope3.categories.some(
+                            (c) => Boolean(c.metadata.verifiedBy)
+                          )
+                            ? reportingPeriod.emissions.scope3.categories.reduce(
+                                (total, category) =>
+                                  isNumber(category.total)
+                                    ? category.total + total
+                                    : total,
+                                0
+                              )
+                            : reportingPeriod.emissions.scope3
+                                .statedTotalEmissions?.total ?? 0,
+                      }) ||
                     undefined,
                 },
                 metadata: reportingPeriod.metadata[0],
@@ -275,24 +282,30 @@ router.get(
             reportingPeriods: company.reportingPeriods.map(
               (reportingPeriod) => ({
                 ...reportingPeriod,
-                emissions: {
-                  ...reportingPeriod.emissions,
-                  calculatedTotalEmissions:
-                    // If either scope 1 and scope 2 have verification, then we use them for the total.
-                    // Otherwise, we use the combined scope1And2 if it exists
-                    (Boolean(
-                      reportingPeriod.emissions?.scope1?.metadata?.verifiedBy
-                    ) ||
-                    Boolean(
-                      reportingPeriod.emissions?.scope2?.metadata?.verifiedBy
-                    )
-                      ? (reportingPeriod.emissions?.scope1?.total || 0) +
-                        (reportingPeriod.emissions?.scope2
-                          ?.calculatedTotalEmissions || 0)
-                      : reportingPeriod.emissions?.scope1And2?.total || 0) +
-                    (reportingPeriod.emissions?.scope3
-                      ?.calculatedTotalEmissions || 0),
-                },
+                emissions: Object.keys(
+                  removeEmptyValues(reportingPeriod.emissions)
+                ).length
+                  ? {
+                      ...removeEmptyValues(reportingPeriod.emissions),
+                      calculatedTotalEmissions:
+                        // If either scope 1 and scope 2 have verification, then we use them for the total.
+                        // Otherwise, we use the combined scope1And2 if it exists
+                        (Boolean(
+                          reportingPeriod.emissions?.scope1?.metadata
+                            ?.verifiedBy
+                        ) ||
+                        Boolean(
+                          reportingPeriod.emissions?.scope2?.metadata
+                            ?.verifiedBy
+                        )
+                          ? (reportingPeriod.emissions?.scope1?.total || 0) +
+                            (reportingPeriod.emissions?.scope2
+                              ?.calculatedTotalEmissions || 0)
+                          : reportingPeriod.emissions?.scope1And2?.total || 0) +
+                        (reportingPeriod.emissions?.scope3
+                          ?.calculatedTotalEmissions || 0),
+                    }
+                  : null,
               })
             ),
           }))
@@ -488,22 +501,25 @@ router.get(
                     }) ||
                     undefined,
                   scope3:
-                    (reportingPeriod.emissions?.scope3 && {
-                      ...reportingPeriod.emissions.scope3,
-                      calculatedTotalEmissions:
-                        reportingPeriod.emissions.scope3.categories.some((c) =>
-                          Boolean(c.metadata.verifiedBy)
-                        )
-                          ? reportingPeriod.emissions.scope3.categories.reduce(
-                              (total, category) =>
-                                isNumber(category.total)
-                                  ? category.total + total
-                                  : total,
-                              0
-                            )
-                          : reportingPeriod.emissions.scope3
-                              .statedTotalEmissions?.total ?? 0,
-                    }) ||
+                    (reportingPeriod.emissions?.scope3 &&
+                      Object.keys(
+                        removeEmptyValues(reportingPeriod.emissions?.scope3)
+                      ).length && {
+                        ...removeEmptyValues(reportingPeriod.emissions.scope3),
+                        calculatedTotalEmissions:
+                          reportingPeriod.emissions.scope3.categories.some(
+                            (c) => Boolean(c.metadata.verifiedBy)
+                          )
+                            ? reportingPeriod.emissions.scope3.categories.reduce(
+                                (total, category) =>
+                                  isNumber(category.total)
+                                    ? category.total + total
+                                    : total,
+                                0
+                              )
+                            : reportingPeriod.emissions.scope3
+                                .statedTotalEmissions?.total ?? 0,
+                      }) ||
                     undefined,
                 },
                 metadata: reportingPeriod.metadata[0],
@@ -529,24 +545,30 @@ router.get(
             reportingPeriods: company.reportingPeriods.map(
               (reportingPeriod) => ({
                 ...reportingPeriod,
-                emissions: {
-                  ...reportingPeriod.emissions,
-                  calculatedTotalEmissions:
-                    // if either scope 1 and scope 2 have verification, then we use them for the total.
-                    // Otherwise, we use the combined scope1And2 if it exists
-                    (Boolean(
-                      reportingPeriod.emissions?.scope1?.metadata?.verifiedBy
-                    ) ||
-                    Boolean(
-                      reportingPeriod.emissions?.scope2?.metadata?.verifiedBy
-                    )
-                      ? (reportingPeriod.emissions?.scope1?.total || 0) +
-                        (reportingPeriod.emissions?.scope2
-                          ?.calculatedTotalEmissions || 0)
-                      : reportingPeriod.emissions?.scope1And2?.total || 0) +
-                    (reportingPeriod.emissions?.scope3
-                      ?.calculatedTotalEmissions || 0),
-                },
+                emissions: Object.keys(
+                  removeEmptyValues(reportingPeriod.emissions)
+                ).length
+                  ? {
+                      ...removeEmptyValues(reportingPeriod.emissions),
+                      calculatedTotalEmissions:
+                        // if either scope 1 and scope 2 have verification, then we use them for the total.
+                        // Otherwise, we use the combined scope1And2 if it exists
+                        (Boolean(
+                          reportingPeriod.emissions?.scope1?.metadata
+                            ?.verifiedBy
+                        ) ||
+                        Boolean(
+                          reportingPeriod.emissions?.scope2?.metadata
+                            ?.verifiedBy
+                        )
+                          ? (reportingPeriod.emissions?.scope1?.total || 0) +
+                            (reportingPeriod.emissions?.scope2
+                              ?.calculatedTotalEmissions || 0)
+                          : reportingPeriod.emissions?.scope1And2?.total || 0) +
+                        (reportingPeriod.emissions?.scope3
+                          ?.calculatedTotalEmissions || 0),
+                    }
+                  : null,
               })
             ),
           }))


### PR DESCRIPTION
* Fix #498 - Only return `emissions` for a reportingPeriod if it includes actual data
* Fix #487 - Only include properties if they have data, and otherwise exclude them from the response
* Also remove empty values for scope 3 categories