### PR TITLE
Feat/minimal list data

### DIFF
--- a/src/routes/readCompanies.ts
+++ b/src/routes/readCompanies.ts
@@ -78,7 +78,6 @@ router.get(
           wikidataId: true,
           name: true,
           description: true,
-          tags: true,
           reportingPeriods: {
             select: {
               startDate: true,
@@ -341,7 +340,6 @@ router.get(
           wikidataId: true,
           name: true,
           description: true,
-          tags: true,
           reportingPeriods: {
             select: {
               startDate: true,

--- a/src/routes/readCompanies.ts
+++ b/src/routes/readCompanies.ts
@@ -98,14 +98,14 @@ router.get(
                     select: {
                       value: true,
                       currency: true,
-                      metadata,
+                      metadata: minimalMetadata,
                     },
                   },
                   employees: {
                     select: {
                       value: true,
                       unit: true,
-                      metadata,
+                      metadata: minimalMetadata,
                     },
                   },
                 },
@@ -116,7 +116,7 @@ router.get(
                     select: {
                       total: true,
                       unit: true,
-                      metadata,
+                      metadata: minimalMetadata,
                     },
                   },
                   scope2: {
@@ -125,7 +125,7 @@ router.get(
                       mb: true,
                       unknown: true,
                       unit: true,
-                      metadata,
+                      metadata: minimalMetadata,
                     },
                   },
                   scope3: {
@@ -134,7 +134,7 @@ router.get(
                         select: {
                           total: true,
                           unit: true,
-                          metadata,
+                          metadata: minimalMetadata,
                         },
                       },
                       categories: {
@@ -142,27 +142,27 @@ router.get(
                           category: true,
                           total: true,
                           unit: true,
-                          metadata,
+                          metadata: minimalMetadata,
                         },
                         orderBy: {
                           category: 'asc',
                         },
                       },
-                      metadata,
+                      metadata: minimalMetadata,
                     },
                   },
                   biogenicEmissions: {
                     select: {
                       total: true,
                       unit: true,
-                      metadata,
+                      metadata: minimalMetadata,
                     },
                   },
                   scope1And2: {
                     select: {
                       total: true,
                       unit: true,
-                      metadata,
+                      metadata: minimalMetadata,
                     },
                   },
                   statedTotalEmissions: {
@@ -174,7 +174,7 @@ router.get(
                   },
                 },
               },
-              metadata,
+              metadata: minimalMetadata,
             },
             orderBy: {
               startDate: 'desc',

--- a/src/routes/readCompanies.ts
+++ b/src/routes/readCompanies.ts
@@ -24,7 +24,16 @@ const metadata = {
         name: true,
       },
     },
-    dataOrigin: true,
+  },
+}
+
+const minimalMetadata = {
+  select: {
+    verifiedBy: {
+      select: {
+        name: true,
+      },
+    },
   },
 }
 

--- a/src/routes/readCompanies.ts
+++ b/src/routes/readCompanies.ts
@@ -270,16 +270,6 @@ router.get(
                 metadata: reportingPeriod.metadata[0],
               })
             ),
-            // Add translations for GICS data
-            industry: company.industry
-              ? {
-                  ...company.industry,
-                  industryGics: {
-                    ...company.industry.industryGics,
-                    ...getGics(company.industry.industryGics.subIndustryCode),
-                  },
-                }
-              : undefined,
           }))
           // Calculate total emissions for each reporting period
           // This allows comparing against the statedTotalEmissions provided by the company report

--- a/src/routes/readCompanies.ts
+++ b/src/routes/readCompanies.ts
@@ -190,33 +190,7 @@ router.get(
                   subIndustryCode: true,
                 },
               },
-              metadata,
-            },
-          },
-          goals: {
-            select: {
-              id: true,
-              description: true,
-              year: true,
-              baseYear: true,
-              target: true,
-              metadata,
-            },
-            orderBy: {
-              year: 'desc',
-            },
-          },
-          initiatives: {
-            select: {
-              id: true,
-              title: true,
-              description: true,
-              year: true,
-              scope: true,
-              metadata,
-            },
-            orderBy: {
-              year: 'desc',
+              metadata: minimalMetadata,
             },
           },
         },


### PR DESCRIPTION
This reduces the size of the API response from `GET /companies` by `41%`, which means the list view should load significantly faster on cold starts.

Tested to make sure this did not impact any functionality. We also still return the detailed response for each company in the `GET /companies/:wikidataId` API route.

fix #462 