### PR TITLE
Feat/schema-overhaul

### DIFF
--- a/prisma/migrations/20241219131018_migrate_to_new_schema_with_proper_relations_and_cascading_effects/migration.sql
+++ b/prisma/migrations/20241219131018_migrate_to_new_schema_with_proper_relations_and_cascading_effects/migration.sql
@@ -1,0 +1,429 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `metadataId` on the `BaseYear` table. All the data in the column will be lost.
+  - You are about to drop the column `metadataId` on the `BiogenicEmissions` table. All the data in the column will be lost.
+  - You are about to drop the column `employeesId` on the `Economy` table. All the data in the column will be lost.
+  - You are about to drop the column `biogenicEmissionsId` on the `Emissions` table. All the data in the column will be lost.
+  - You are about to drop the column `scope1And2Id` on the `Emissions` table. All the data in the column will be lost.
+  - You are about to drop the column `scope1Id` on the `Emissions` table. All the data in the column will be lost.
+  - You are about to drop the column `scope2Id` on the `Emissions` table. All the data in the column will be lost.
+  - You are about to drop the column `scope3Id` on the `Emissions` table. All the data in the column will be lost.
+  - You are about to drop the column `statedTotalEmissionsId` on the `Emissions` table. All the data in the column will be lost.
+  - You are about to drop the column `metadataId` on the `Employees` table. All the data in the column will be lost.
+  - You are about to drop the column `metadataId` on the `Goal` table. All the data in the column will be lost.
+  - You are about to drop the column `metadataId` on the `Industry` table. All the data in the column will be lost.
+  - You are about to drop the column `metadataId` on the `Initiative` table. All the data in the column will be lost.
+  - The primary key for the `ReportingPeriod` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `economyId` on the `ReportingPeriod` table. All the data in the column will be lost.
+  - You are about to drop the column `emissionsId` on the `ReportingPeriod` table. All the data in the column will be lost.
+  - You are about to drop the column `metadataId` on the `ReportingPeriod` table. All the data in the column will be lost.
+  - You are about to drop the column `metadataId` on the `Scope1` table. All the data in the column will be lost.
+  - You are about to drop the column `metadataId` on the `Scope1And2` table. All the data in the column will be lost.
+  - You are about to drop the column `metadataId` on the `Scope2` table. All the data in the column will be lost.
+  - You are about to drop the column `metadataId` on the `Scope3` table. All the data in the column will be lost.
+  - You are about to drop the column `metadataId` on the `Scope3Category` table. All the data in the column will be lost.
+  - You are about to drop the column `metadataId` on the `StatedTotalEmissions` table. All the data in the column will be lost.
+  - You are about to drop the column `metadataId` on the `Turnover` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[emissionsId]` on the table `BiogenicEmissions` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[reportingPeriodId]` on the table `Economy` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[reportingPeriodId]` on the table `Emissions` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[economyId]` on the table `Employees` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[goalId]` on the table `Metadata` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[initiativeId]` on the table `Metadata` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[scope1Id]` on the table `Metadata` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[scope2Id]` on the table `Metadata` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[scope3Id]` on the table `Metadata` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[scope1And2Id]` on the table `Metadata` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[reportingPeriodId]` on the table `Metadata` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[baseYearId]` on the table `Metadata` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[biogenicEmissionsId]` on the table `Metadata` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[statedTotalEmissionsId]` on the table `Metadata` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[industryId]` on the table `Metadata` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[categoryId]` on the table `Metadata` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[turnoverId]` on the table `Metadata` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[employeesId]` on the table `Metadata` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[companyId,year]` on the table `ReportingPeriod` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[emissionsId]` on the table `Scope1` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[emissionsId]` on the table `Scope1And2` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[emissionsId]` on the table `Scope2` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[emissionsId]` on the table `Scope3` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[emissionsId]` on the table `StatedTotalEmissions` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[economyId]` on the table `Turnover` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `economyId` to the `Turnover` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "BaseYear" DROP CONSTRAINT "BaseYear_companyId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "BaseYear" DROP CONSTRAINT "BaseYear_metadataId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "BiogenicEmissions" DROP CONSTRAINT "BiogenicEmissions_metadataId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Economy" DROP CONSTRAINT "Economy_employeesId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Economy" DROP CONSTRAINT "Economy_turnoverId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Emissions" DROP CONSTRAINT "Emissions_biogenicEmissionsId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Emissions" DROP CONSTRAINT "Emissions_scope1And2Id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Emissions" DROP CONSTRAINT "Emissions_scope1Id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Emissions" DROP CONSTRAINT "Emissions_scope2Id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Emissions" DROP CONSTRAINT "Emissions_scope3Id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Emissions" DROP CONSTRAINT "Emissions_statedTotalEmissionsId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Employees" DROP CONSTRAINT "Employees_metadataId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Goal" DROP CONSTRAINT "Goal_companyId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Goal" DROP CONSTRAINT "Goal_metadataId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Industry" DROP CONSTRAINT "Industry_companyWikidataId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Industry" DROP CONSTRAINT "Industry_metadataId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Initiative" DROP CONSTRAINT "Initiative_companyId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Initiative" DROP CONSTRAINT "Initiative_metadataId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ReportingPeriod" DROP CONSTRAINT "ReportingPeriod_companyId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ReportingPeriod" DROP CONSTRAINT "ReportingPeriod_economyId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ReportingPeriod" DROP CONSTRAINT "ReportingPeriod_emissionsId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ReportingPeriod" DROP CONSTRAINT "ReportingPeriod_metadataId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Scope1" DROP CONSTRAINT "Scope1_metadataId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Scope1And2" DROP CONSTRAINT "Scope1And2_metadataId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Scope2" DROP CONSTRAINT "Scope2_metadataId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Scope3" DROP CONSTRAINT "Scope3_metadataId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Scope3Category" DROP CONSTRAINT "Scope3Category_metadataId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Scope3Category" DROP CONSTRAINT "Scope3Category_scope3Id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "StatedTotalEmissions" DROP CONSTRAINT "StatedTotalEmissions_metadataId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "StatedTotalEmissions" DROP CONSTRAINT "StatedTotalEmissions_scope3Id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Turnover" DROP CONSTRAINT "Turnover_metadataId_fkey";
+
+-- DropIndex
+DROP INDEX "Economy_employeesId_key";
+
+-- DropIndex
+DROP INDEX "Economy_turnoverId_key";
+
+-- DropIndex
+DROP INDEX "Emissions_biogenicEmissionsId_key";
+
+-- DropIndex
+DROP INDEX "Emissions_scope1And2Id_key";
+
+-- DropIndex
+DROP INDEX "Emissions_scope1Id_key";
+
+-- DropIndex
+DROP INDEX "Emissions_scope2Id_key";
+
+-- DropIndex
+DROP INDEX "Emissions_scope3Id_key";
+
+-- DropIndex
+DROP INDEX "Emissions_statedTotalEmissionsId_key";
+
+-- DropIndex
+DROP INDEX "ReportingPeriod_economyId_key";
+
+-- DropIndex
+DROP INDEX "ReportingPeriod_emissionsId_key";
+
+-- AlterTable
+ALTER TABLE "BaseYear" DROP COLUMN "metadataId";
+
+-- AlterTable
+ALTER TABLE "BiogenicEmissions" DROP COLUMN "metadataId",
+ADD COLUMN     "emissionsId" INTEGER;
+
+-- AlterTable
+ALTER TABLE "Economy" DROP COLUMN "employeesId",
+ADD COLUMN     "reportingPeriodId" INTEGER;
+
+-- AlterTable
+ALTER TABLE "Emissions" DROP COLUMN "biogenicEmissionsId",
+DROP COLUMN "scope1And2Id",
+DROP COLUMN "scope1Id",
+DROP COLUMN "scope2Id",
+DROP COLUMN "scope3Id",
+DROP COLUMN "statedTotalEmissionsId",
+ADD COLUMN     "reportingPeriodId" INTEGER;
+
+-- AlterTable
+ALTER TABLE "Employees" DROP COLUMN "metadataId",
+ADD COLUMN     "economyId" INTEGER;
+
+-- AlterTable
+ALTER TABLE "Goal" DROP COLUMN "metadataId";
+
+-- AlterTable
+ALTER TABLE "Industry" DROP COLUMN "metadataId";
+
+-- AlterTable
+ALTER TABLE "Initiative" DROP COLUMN "metadataId";
+
+-- AlterTable
+ALTER TABLE "Metadata" ADD COLUMN     "baseYearId" INTEGER,
+ADD COLUMN     "biogenicEmissionsId" INTEGER,
+ADD COLUMN     "categoryId" INTEGER,
+ADD COLUMN     "employeesId" INTEGER,
+ADD COLUMN     "goalId" INTEGER,
+ADD COLUMN     "industryId" INTEGER,
+ADD COLUMN     "initiativeId" INTEGER,
+ADD COLUMN     "reportingPeriodId" INTEGER,
+ADD COLUMN     "scope1And2Id" INTEGER,
+ADD COLUMN     "scope1Id" INTEGER,
+ADD COLUMN     "scope2Id" INTEGER,
+ADD COLUMN     "scope3Id" INTEGER,
+ADD COLUMN     "statedTotalEmissionsId" INTEGER,
+ADD COLUMN     "turnoverId" INTEGER;
+
+-- AlterTable
+ALTER TABLE "ReportingPeriod" DROP CONSTRAINT "ReportingPeriod_pkey",
+DROP COLUMN "economyId",
+DROP COLUMN "emissionsId",
+DROP COLUMN "metadataId",
+ADD COLUMN     "id" SERIAL NOT NULL,
+ADD CONSTRAINT "ReportingPeriod_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "Scope1" DROP COLUMN "metadataId",
+ADD COLUMN     "emissionsId" INTEGER;
+
+-- AlterTable
+ALTER TABLE "Scope1And2" DROP COLUMN "metadataId",
+ADD COLUMN     "emissionsId" INTEGER;
+
+-- AlterTable
+ALTER TABLE "Scope2" DROP COLUMN "metadataId",
+ADD COLUMN     "emissionsId" INTEGER;
+
+-- AlterTable
+ALTER TABLE "Scope3" DROP COLUMN "metadataId",
+ADD COLUMN     "emissionsId" INTEGER;
+
+-- AlterTable
+ALTER TABLE "Scope3Category" DROP COLUMN "metadataId";
+
+-- AlterTable
+ALTER TABLE "StatedTotalEmissions" DROP COLUMN "metadataId",
+ADD COLUMN     "emissionsId" INTEGER;
+
+-- AlterTable
+ALTER TABLE "Turnover" DROP COLUMN "metadataId",
+ADD COLUMN     "economyId" INTEGER NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BiogenicEmissions_emissionsId_key" ON "BiogenicEmissions"("emissionsId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Economy_reportingPeriodId_key" ON "Economy"("reportingPeriodId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Emissions_reportingPeriodId_key" ON "Emissions"("reportingPeriodId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Employees_economyId_key" ON "Employees"("economyId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Metadata_goalId_key" ON "Metadata"("goalId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Metadata_initiativeId_key" ON "Metadata"("initiativeId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Metadata_scope1Id_key" ON "Metadata"("scope1Id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Metadata_scope2Id_key" ON "Metadata"("scope2Id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Metadata_scope3Id_key" ON "Metadata"("scope3Id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Metadata_scope1And2Id_key" ON "Metadata"("scope1And2Id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Metadata_reportingPeriodId_key" ON "Metadata"("reportingPeriodId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Metadata_baseYearId_key" ON "Metadata"("baseYearId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Metadata_biogenicEmissionsId_key" ON "Metadata"("biogenicEmissionsId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Metadata_statedTotalEmissionsId_key" ON "Metadata"("statedTotalEmissionsId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Metadata_industryId_key" ON "Metadata"("industryId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Metadata_categoryId_key" ON "Metadata"("categoryId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Metadata_turnoverId_key" ON "Metadata"("turnoverId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Metadata_employeesId_key" ON "Metadata"("employeesId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ReportingPeriod_companyId_year_key" ON "ReportingPeriod"("companyId", "year");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Scope1_emissionsId_key" ON "Scope1"("emissionsId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Scope1And2_emissionsId_key" ON "Scope1And2"("emissionsId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Scope2_emissionsId_key" ON "Scope2"("emissionsId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Scope3_emissionsId_key" ON "Scope3"("emissionsId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StatedTotalEmissions_emissionsId_key" ON "StatedTotalEmissions"("emissionsId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Turnover_economyId_key" ON "Turnover"("economyId");
+
+-- AddForeignKey
+ALTER TABLE "BaseYear" ADD CONSTRAINT "BaseYear_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "Company"("wikidataId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Industry" ADD CONSTRAINT "Industry_companyWikidataId_fkey" FOREIGN KEY ("companyWikidataId") REFERENCES "Company"("wikidataId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ReportingPeriod" ADD CONSTRAINT "ReportingPeriod_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "Company"("wikidataId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Emissions" ADD CONSTRAINT "Emissions_reportingPeriodId_fkey" FOREIGN KEY ("reportingPeriodId") REFERENCES "ReportingPeriod"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StatedTotalEmissions" ADD CONSTRAINT "StatedTotalEmissions_emissionsId_fkey" FOREIGN KEY ("emissionsId") REFERENCES "Emissions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StatedTotalEmissions" ADD CONSTRAINT "StatedTotalEmissions_scope3Id_fkey" FOREIGN KEY ("scope3Id") REFERENCES "Scope3"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Scope1And2" ADD CONSTRAINT "Scope1And2_emissionsId_fkey" FOREIGN KEY ("emissionsId") REFERENCES "Emissions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BiogenicEmissions" ADD CONSTRAINT "BiogenicEmissions_emissionsId_fkey" FOREIGN KEY ("emissionsId") REFERENCES "Emissions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Scope1" ADD CONSTRAINT "Scope1_emissionsId_fkey" FOREIGN KEY ("emissionsId") REFERENCES "Emissions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Scope2" ADD CONSTRAINT "Scope2_emissionsId_fkey" FOREIGN KEY ("emissionsId") REFERENCES "Emissions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Scope3" ADD CONSTRAINT "Scope3_emissionsId_fkey" FOREIGN KEY ("emissionsId") REFERENCES "Emissions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Scope3Category" ADD CONSTRAINT "Scope3Category_scope3Id_fkey" FOREIGN KEY ("scope3Id") REFERENCES "Scope3"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Economy" ADD CONSTRAINT "Economy_reportingPeriodId_fkey" FOREIGN KEY ("reportingPeriodId") REFERENCES "ReportingPeriod"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Turnover" ADD CONSTRAINT "Turnover_economyId_fkey" FOREIGN KEY ("economyId") REFERENCES "Economy"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Employees" ADD CONSTRAINT "Employees_economyId_fkey" FOREIGN KEY ("economyId") REFERENCES "Economy"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Goal" ADD CONSTRAINT "Goal_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "Company"("wikidataId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Initiative" ADD CONSTRAINT "Initiative_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "Company"("wikidataId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Metadata" ADD CONSTRAINT "Metadata_goalId_fkey" FOREIGN KEY ("goalId") REFERENCES "Goal"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Metadata" ADD CONSTRAINT "Metadata_initiativeId_fkey" FOREIGN KEY ("initiativeId") REFERENCES "Initiative"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Metadata" ADD CONSTRAINT "Metadata_scope1Id_fkey" FOREIGN KEY ("scope1Id") REFERENCES "Scope1"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Metadata" ADD CONSTRAINT "Metadata_scope2Id_fkey" FOREIGN KEY ("scope2Id") REFERENCES "Scope2"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Metadata" ADD CONSTRAINT "Metadata_scope3Id_fkey" FOREIGN KEY ("scope3Id") REFERENCES "Scope3"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Metadata" ADD CONSTRAINT "Metadata_scope1And2Id_fkey" FOREIGN KEY ("scope1And2Id") REFERENCES "Scope1And2"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Metadata" ADD CONSTRAINT "Metadata_reportingPeriodId_fkey" FOREIGN KEY ("reportingPeriodId") REFERENCES "ReportingPeriod"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Metadata" ADD CONSTRAINT "Metadata_baseYearId_fkey" FOREIGN KEY ("baseYearId") REFERENCES "BaseYear"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Metadata" ADD CONSTRAINT "Metadata_biogenicEmissionsId_fkey" FOREIGN KEY ("biogenicEmissionsId") REFERENCES "BiogenicEmissions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Metadata" ADD CONSTRAINT "Metadata_statedTotalEmissionsId_fkey" FOREIGN KEY ("statedTotalEmissionsId") REFERENCES "StatedTotalEmissions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Metadata" ADD CONSTRAINT "Metadata_industryId_fkey" FOREIGN KEY ("industryId") REFERENCES "Industry"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Metadata" ADD CONSTRAINT "Metadata_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Scope3Category"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Metadata" ADD CONSTRAINT "Metadata_turnoverId_fkey" FOREIGN KEY ("turnoverId") REFERENCES "Turnover"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Metadata" ADD CONSTRAINT "Metadata_employeesId_fkey" FOREIGN KEY ("employeesId") REFERENCES "Employees"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,8 +55,8 @@ model BaseYear {
   scope     Int // 1-3
   companyId String
 
-  metadata Metadata?
-  company  Company   @relation(fields: [companyId], references: [wikidataId], onDelete: Cascade)
+  metadata Metadata[]
+  company  Company    @relation(fields: [companyId], references: [wikidataId], onDelete: Cascade)
 }
 
 /// Connecting a company to a specific industry and metadata
@@ -66,8 +66,8 @@ model Industry {
   gicsSubIndustryCode String
   companyWikidataId   String @unique
 
-  company  Company   @relation(fields: [companyWikidataId], references: [wikidataId], onDelete: Cascade)
-  metadata Metadata?
+  company  Company    @relation(fields: [companyWikidataId], references: [wikidataId], onDelete: Cascade)
+  metadata Metadata[]
 
   // industryGics is an interesting candidate for the cascade option, I bet these codes are rarely changed... But in that case
   // lets be sure to make a migration to the new code without cascading all current industries
@@ -98,7 +98,7 @@ model ReportingPeriod {
 
   companyId String
 
-  metadata  Metadata?
+  metadata  Metadata[]
   economy   Economy?
   emissions Emissions?
   company   Company    @relation(fields: [companyId], references: [wikidataId], onDelete: Cascade)
@@ -133,7 +133,7 @@ model StatedTotalEmissions {
   emissionsId Int?   @unique
 
   emissions Emissions? @relation(fields: [emissionsId], references: [id], onDelete: Cascade)
-  metadata  Metadata?
+  metadata  Metadata[]
   scope3    Scope3?    @relation(fields: [scope3Id], references: [id], onDelete: Cascade)
 }
 
@@ -145,7 +145,7 @@ model Scope1And2 {
 
   unit      String
   emissions Emissions? @relation(fields: [emissionsId], references: [id], onDelete: Cascade)
-  metadata  Metadata?
+  metadata  Metadata[]
 }
 
 /// Biogenic emissions are reported separately from scope 1-3
@@ -156,7 +156,7 @@ model BiogenicEmissions {
   emissionsId Int?   @unique
 
   emissions Emissions? @relation(fields: [emissionsId], references: [id], onDelete: Cascade)
-  metadata  Metadata?
+  metadata  Metadata[]
 }
 
 model Scope1 {
@@ -166,7 +166,7 @@ model Scope1 {
   emissionsId Int?   @unique
 
   emissions Emissions? @relation(fields: [emissionsId], references: [id], onDelete: Cascade)
-  metadata  Metadata?
+  metadata  Metadata[]
 }
 
 /// For scope 2 emissions, we choose either market-based, location-based or unknown (if the company didn't specify if mb or lb)
@@ -180,7 +180,7 @@ model Scope2 {
   emissionsId Int?   @unique
 
   emissions Emissions? @relation(fields: [emissionsId], references: [id], onDelete: Cascade)
-  metadata  Metadata?
+  metadata  Metadata[]
 }
 
 model Scope3 {
@@ -197,7 +197,7 @@ model Scope3 {
   statedTotalEmissions StatedTotalEmissions?
   emissions            Emissions?            @relation(fields: [emissionsId], references: [id], onDelete: Cascade)
   categories           Scope3Category[]
-  metadata             Metadata?
+  metadata             Metadata[]
 }
 
 /// Details about scope 3 categories. Here's a list of valid categories and their names:
@@ -235,8 +235,8 @@ model Scope3Category {
   scope3Id Int
   unit     String
 
-  scope3   Scope3    @relation(fields: [scope3Id], references: [id], onDelete: Cascade)
-  metadata Metadata?
+  scope3   Scope3     @relation(fields: [scope3Id], references: [id], onDelete: Cascade)
+  metadata Metadata[]
 }
 
 model Economy {
@@ -256,8 +256,8 @@ model Turnover {
   currency  String?
   economyId Int     @unique
 
-  economy  Economy   @relation(fields: [economyId], references: [id], onDelete: Cascade)
-  metadata Metadata?
+  economy  Economy    @relation(fields: [economyId], references: [id], onDelete: Cascade)
+  metadata Metadata[]
 }
 
 model Employees {
@@ -268,8 +268,8 @@ model Employees {
   unit      String?
   economyId Int?    @unique
 
-  economy  Economy?  @relation(fields: [economyId], references: [id], onDelete: Cascade)
-  metadata Metadata?
+  economy  Economy?   @relation(fields: [economyId], references: [id], onDelete: Cascade)
+  metadata Metadata[]
 }
 
 model Goal {
@@ -285,8 +285,8 @@ model Goal {
   companyId   String
 
   /// Marked as optional because the foreign key resides in the Metadata model, making the relationship managed from that side. (Eventhough every goal needs to have metadata)
-  metadata Metadata?
-  company  Company   @relation(fields: [companyId], references: [wikidataId], onDelete: Cascade)
+  metadata Metadata[]
+  company  Company    @relation(fields: [companyId], references: [wikidataId], onDelete: Cascade)
 }
 
 model Initiative {
@@ -297,8 +297,8 @@ model Initiative {
   scope       String?
   companyId   String
 
-  company  Company   @relation(fields: [companyId], references: [wikidataId], onDelete: Cascade)
-  metadata Metadata?
+  company  Company    @relation(fields: [companyId], references: [wikidataId], onDelete: Cascade)
+  metadata Metadata[]
 }
 
 /// Every datapoint has associated metadata about who changed it, when, and using what source

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -334,22 +334,22 @@ model Metadata {
   turnoverId             Int? @unique
   employeesId            Int? @unique
 
-  goal                 Goal?                 @relation(fields: [goalId], references: [id], onDelete: Cascade)
-  initiative           Initiative?           @relation(fields: [initiativeId], references: [id], onDelete: Cascade)
-  scope1               Scope1?               @relation(fields: [scope1Id], references: [id], onDelete: Cascade)
-  scope2               Scope2?               @relation(fields: [scope2Id], references: [id], onDelete: Cascade)
-  scope3               Scope3?               @relation(fields: [scope3Id], references: [id], onDelete: Cascade)
-  scope1And2           Scope1And2?           @relation(fields: [scope1And2Id], references: [id], onDelete: Cascade)
-  reportingPeriod      ReportingPeriod?      @relation(fields: [reportingPeriodId], references: [id], onDelete: Cascade)
-  baseYear             BaseYear?             @relation(fields: [baseYearId], references: [id], onDelete: Cascade)
-  biogenicEmissions    BiogenicEmissions?    @relation(fields: [biogenicEmissionsId], references: [id], onDelete: Cascade)
-  statedTotalEmissions StatedTotalEmissions? @relation(fields: [statedTotalEmissionsId], references: [id], onDelete: Cascade)
+  goal                 Goal?                 @relation(fields: [goalId], references: [id])
+  initiative           Initiative?           @relation(fields: [initiativeId], references: [id])
+  scope1               Scope1?               @relation(fields: [scope1Id], references: [id])
+  scope2               Scope2?               @relation(fields: [scope2Id], references: [id])
+  scope3               Scope3?               @relation(fields: [scope3Id], references: [id])
+  scope1And2           Scope1And2?           @relation(fields: [scope1And2Id], references: [id])
+  reportingPeriod      ReportingPeriod?      @relation(fields: [reportingPeriodId], references: [id])
+  baseYear             BaseYear?             @relation(fields: [baseYearId], references: [id])
+  biogenicEmissions    BiogenicEmissions?    @relation(fields: [biogenicEmissionsId], references: [id])
+  statedTotalEmissions StatedTotalEmissions? @relation(fields: [statedTotalEmissionsId], references: [id])
   user                 User                  @relation("metadata_user_id", fields: [userId], references: [id])
   verifiedBy           User?                 @relation("metadata_verified_by", fields: [verifiedByUserId], references: [id])
-  industry             Industry?             @relation(fields: [industryId], references: [id], onDelete: Cascade)
-  category             Scope3Category?       @relation(fields: [categoryId], references: [id], onDelete: Cascade)
-  turnover             Turnover?             @relation(fields: [turnoverId], references: [id], onDelete: Cascade)
-  employees            Employees?            @relation(fields: [employeesId], references: [id], onDelete: Cascade)
+  industry             Industry?             @relation(fields: [industryId], references: [id])
+  category             Scope3Category?       @relation(fields: [categoryId], references: [id])
+  turnover             Turnover?             @relation(fields: [turnoverId], references: [id])
+  employees            Employees?            @relation(fields: [employeesId], references: [id])
 }
 
 model User {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,8 +66,11 @@ model Industry {
   gicsSubIndustryCode String
   companyWikidataId   String @unique
 
-  company      Company      @relation(fields: [companyWikidataId], references: [wikidataId])
-  metadata     Metadata?
+  company  Company   @relation(fields: [companyWikidataId], references: [wikidataId], onDelete: Cascade)
+  metadata Metadata?
+
+  // industryGics is an interesting candidate for the cascade option, I bet these codes are rarely changed... But in that case
+  // lets be sure to make a migration to the new code without cascading all current industries
   industryGics IndustryGics @relation(fields: [gicsSubIndustryCode], references: [subIndustryCode])
 }
 
@@ -93,13 +96,11 @@ model ReportingPeriod {
   /// At the same time, we also want to refer back to the actual reports from a given reporting period for comparisons.
   reportURL String?
 
-  companyId   String
-  emissionsId Int?   @unique
-  economyId   Int?   @unique
+  companyId String
 
   metadata  Metadata?
-  economy   Economy?   @relation(fields: [economyId], references: [id])
-  emissions Emissions? @relation(fields: [emissionsId], references: [id])
+  economy   Economy?
+  emissions Emissions?
   company   Company    @relation(fields: [companyId], references: [wikidataId], onDelete: Cascade)
 
   @@unique([companyId, year])
@@ -107,23 +108,16 @@ model ReportingPeriod {
 
 /// Reported emissions for a specific reporting period
 model Emissions {
-  id                     Int  @id @default(autoincrement())
-  // NOTE: If we remove the @unique requirement here, we could perhaps add more scope1 values for the same ReportingPeriod, but only show one at a time
-  // This might help us if we want to keep one scope1 extracted by garbo, one estimated by exiobase and one manually entered. However, this would get complicated.
-  scope1Id               Int? @unique
-  scope2Id               Int? @unique
-  scope3Id               Int? @unique
-  biogenicEmissionsId    Int? @unique
-  scope1And2Id           Int? @unique
-  statedTotalEmissionsId Int? @unique
+  id                Int  @id @default(autoincrement())
+  reportingPeriodId Int? @unique
 
-  statedTotalEmissions StatedTotalEmissions? @relation(fields: [statedTotalEmissionsId], references: [id])
-  scope1And2           Scope1And2?           @relation(fields: [scope1And2Id], references: [id])
-  biogenicEmissions    BiogenicEmissions?    @relation(fields: [biogenicEmissionsId], references: [id])
-  reportingPeriod      ReportingPeriod?
-  scope1               Scope1?               @relation(fields: [scope1Id], references: [id])
-  scope2               Scope2?               @relation(fields: [scope2Id], references: [id])
-  scope3               Scope3?               @relation(fields: [scope3Id], references: [id])
+  scope1               Scope1?
+  scope2               Scope2?
+  scope3               Scope3?
+  scope1And2           Scope1And2?
+  statedTotalEmissions StatedTotalEmissions?
+  biogenicEmissions    BiogenicEmissions?
+  reportingPeriod      ReportingPeriod?      @relation(fields: [reportingPeriodId], references: [id], onDelete: Cascade)
 }
 
 /// This is used when companies only report a total number for either overall- or scope 3 emissions.
@@ -132,78 +126,77 @@ model Emissions {
 /// specifically for the stated totals from the report. For example if the company changes an incorrect statedTotal that does not match the actual calculated total.
 /// Not sure if this is worth it, in this structure though. Might be too complicated.
 model StatedTotalEmissions {
-  id       Int    @id @default(autoincrement())
-  total    Float?
-  scope3Id Int?   @unique
+  id          Int    @id @default(autoincrement())
+  total       Float?
+  scope3Id    Int?   @unique
+  unit        String
+  emissionsId Int?   @unique
 
-  unit      String
-  emissions Emissions?
+  emissions Emissions? @relation(fields: [emissionsId], references: [id], onDelete: Cascade)
   metadata  Metadata?
-  scope3    Scope3?    @relation(fields: [scope3Id], references: [id])
+  scope3    Scope3?    @relation(fields: [scope3Id], references: [id], onDelete: Cascade)
 }
 
 /// This is used when companies have bad reporting where they have combined scope 1+2 as one value
 model Scope1And2 {
-  id    Int    @id @default(autoincrement())
-  total Float?
+  id          Int    @id @default(autoincrement())
+  total       Float?
+  emissionsId Int?   @unique
 
   unit      String
-  emissions Emissions?
+  emissions Emissions? @relation(fields: [emissionsId], references: [id], onDelete: Cascade)
   metadata  Metadata?
 }
 
 /// Biogenic emissions are reported separately from scope 1-3
-/// If we want to save a more detailed breakdown (when companies reported this), we can use the metadata comment to save this context
 model BiogenicEmissions {
-  id        Int        @id @default(autoincrement())
-  /// Sometimes companies break it down into scope 1-3 - however these should always be stored as a total number according to the GHG protocol.
-  total     Float?
-  unit      String
-  emissions Emissions?
+  id          Int    @id @default(autoincrement())
+  total       Float?
+  unit        String
+  emissionsId Int?   @unique
+
+  emissions Emissions? @relation(fields: [emissionsId], references: [id], onDelete: Cascade)
   metadata  Metadata?
 }
 
 model Scope1 {
-  id    Int    @id @default(autoincrement())
-  total Float?
+  id          Int    @id @default(autoincrement())
+  total       Float?
+  unit        String
+  emissionsId Int?   @unique
 
-  unit      String
-  emissions Emissions?
+  emissions Emissions? @relation(fields: [emissionsId], references: [id], onDelete: Cascade)
   metadata  Metadata?
 }
 
 /// For scope 2 emissions, we choose either market-based, location-based or unknown (if the company didn't specify if mb or lb)
 /// We generally prefer using market-based emissions, but if that doesn't exist we could use location-based ones, and finally unknown.
 model Scope2 {
-  id      Int    @id @default(autoincrement())
-  /// Market-based emissions
-  mb      Float?
-  /// Location-based emissions
-  lb      Float?
-  /// Unknown scope 2 emissions could be either market-based or location-based
-  unknown Float?
+  id          Int    @id @default(autoincrement())
+  mb          Float?
+  lb          Float?
+  unknown     Float?
+  unit        String
+  emissionsId Int?   @unique
 
-  unit      String
-  emissions Emissions?
+  emissions Emissions? @relation(fields: [emissionsId], references: [id], onDelete: Cascade)
   metadata  Metadata?
 }
 
-// TODO: We need to separate scope3 into separate categories, because we need metadata for each scope 3 category value.
-
-/// Scope 3 emissions according to the GHG protocol.
 model Scope3 {
   id Int @id @default(autoincrement())
 
   /// Sometimes, companies only report a total value for scope 3 emissions without disclosing the scope 3 categories.
   /// Other times, they might report both, but their stated total scope 3 emissions might be different than the actual sum of their scope 3 categories.
   /// To get around this, we separate statedTotalEmissions from the actual mathematical total that we summarize during runtime.
+  emissionsId            Int? @unique
   statedTotalEmissionsId Int? @unique
 
   // The scope 3 categories, both reported and estimated.
   // TODO: Add validation so there can only be one for each category, and max 16 entries.
-  categories           Scope3Category[]
   statedTotalEmissions StatedTotalEmissions?
-  emissions            Emissions?
+  emissions            Emissions?            @relation(fields: [emissionsId], references: [id], onDelete: Cascade)
+  categories           Scope3Category[]
   metadata             Metadata?
 }
 
@@ -240,40 +233,42 @@ model Scope3Category {
   // based on the composition for each scope 3 category. This would simplify the review process if we could automatically find errors.
   total    Float?
   scope3Id Int
-
   unit     String
-  scope3   Scope3    @relation(fields: [scope3Id], references: [id])
+
+  scope3   Scope3    @relation(fields: [scope3Id], references: [id], onDelete: Cascade)
   metadata Metadata?
 }
 
 model Economy {
-  id          Int  @id @default(autoincrement())
-  turnoverId  Int? @unique
-  employeesId Int? @unique
+  id                Int  @id @default(autoincrement())
+  reportingPeriodId Int? @unique
 
-  turnover        Turnover?        @relation(fields: [turnoverId], references: [id])
-  employees       Employees?       @relation(fields: [employeesId], references: [id])
-  reportingPeriod ReportingPeriod?
+  turnover        Turnover?
+  employees       Employees?
+  reportingPeriod ReportingPeriod? @relation(fields: [reportingPeriodId], references: [id], onDelete: Cascade)
+  turnoverId      Int?
 }
 
 model Turnover {
-  id       Int     @id @default(autoincrement())
+  id        Int     @id @default(autoincrement())
   // IDEA: Should we store turnover with another datatype to prevent rounding errors? Money doesn't seem to be a good fit for storing as floats.
-  value    Float?
-  currency String?
+  value     Float?
+  currency  String?
+  economyId Int     @unique
 
-  economy  Economy?
+  economy  Economy   @relation(fields: [economyId], references: [id], onDelete: Cascade)
   metadata Metadata?
 }
 
 model Employees {
-  id    Int     @id @default(autoincrement())
-  /// Number of employees (using various methods)
-  value Float?
+  id        Int     @id @default(autoincrement())
+  /// Number of employees
+  value     Float?
   /// How the number of employees were calculated, e.g. Full-time equivalents (FTE) or similar.
-  unit  String?
+  unit      String?
+  economyId Int?    @unique
 
-  economy  Economy?
+  economy  Economy?  @relation(fields: [economyId], references: [id], onDelete: Cascade)
   metadata Metadata?
 }
 
@@ -291,7 +286,7 @@ model Goal {
 
   /// Marked as optional because the foreign key resides in the Metadata model, making the relationship managed from that side. (Eventhough every goal needs to have metadata)
   metadata Metadata?
-  company  Company   @relation(fields: [companyId], references: [wikidataId])
+  company  Company   @relation(fields: [companyId], references: [wikidataId], onDelete: Cascade)
 }
 
 model Initiative {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,15 +49,14 @@ model Company {
 // TODO: Improve structure of base years to handle the case where we have the same value for all scopes.
 // The simple solution is to always store three BaseYears, even if they have the same value. This adds more data, to be processed and transferred, but will be simpler to understand and work with.
 model BaseYear {
-  id         Int    @id @default(autoincrement())
+  id        Int    @id @default(autoincrement())
   // IDEA: maybe the year here should be in relation to a specific reporting period, since we need to account for special cases where reporting periods are not just one year
-  year       Int
-  scope      Int // 1-3
-  companyId  String
-  metadataId Int
+  year      Int
+  scope     Int // 1-3
+  companyId String
 
-  metadata Metadata @relation(fields: [metadataId], references: [id])
-  company  Company  @relation(fields: [companyId], references: [wikidataId])
+  metadata Metadata?
+  company  Company   @relation(fields: [companyId], references: [wikidataId], onDelete: Cascade)
 }
 
 /// Connecting a company to a specific industry and metadata
@@ -65,11 +64,10 @@ model BaseYear {
 model Industry {
   id                  Int    @id @default(autoincrement())
   gicsSubIndustryCode String
-  metadataId          Int
   companyWikidataId   String @unique
 
   company      Company      @relation(fields: [companyWikidataId], references: [wikidataId])
-  metadata     Metadata     @relation(fields: [metadataId], references: [id])
+  metadata     Metadata?
   industryGics IndustryGics @relation(fields: [gicsSubIndustryCode], references: [subIndustryCode])
 }
 
@@ -85,6 +83,7 @@ model IndustryGics {
 
 /// A reporting period is a timespan for accounting emissions as well as financial data
 model ReportingPeriod {
+  id        Int      @id @default(autoincrement())
   startDate DateTime
   endDate   DateTime
   /// The year needs to be the same year as the endDate.
@@ -97,15 +96,13 @@ model ReportingPeriod {
   companyId   String
   emissionsId Int?   @unique
   economyId   Int?   @unique
-  metadataId  Int
 
-  metadata  Metadata   @relation(fields: [metadataId], references: [id])
+  metadata  Metadata?
   economy   Economy?   @relation(fields: [economyId], references: [id])
   emissions Emissions? @relation(fields: [emissionsId], references: [id])
-  company   Company    @relation(fields: [companyId], references: [wikidataId])
+  company   Company    @relation(fields: [companyId], references: [wikidataId], onDelete: Cascade)
 
-  /// Compound id based on meaningful data
-  @@id(name: "reportingPeriodId", [companyId, year])
+  @@unique([companyId, year])
 }
 
 /// Reported emissions for a specific reporting period
@@ -135,66 +132,60 @@ model Emissions {
 /// specifically for the stated totals from the report. For example if the company changes an incorrect statedTotal that does not match the actual calculated total.
 /// Not sure if this is worth it, in this structure though. Might be too complicated.
 model StatedTotalEmissions {
-  id         Int    @id @default(autoincrement())
-  total      Float?
-  metadataId Int
-  scope3Id   Int?   @unique
+  id       Int    @id @default(autoincrement())
+  total    Float?
+  scope3Id Int?   @unique
 
   unit      String
   emissions Emissions?
-  metadata  Metadata   @relation(fields: [metadataId], references: [id])
+  metadata  Metadata?
   scope3    Scope3?    @relation(fields: [scope3Id], references: [id])
 }
 
 /// This is used when companies have bad reporting where they have combined scope 1+2 as one value
 model Scope1And2 {
-  id         Int    @id @default(autoincrement())
-  total      Float?
-  metadataId Int
+  id    Int    @id @default(autoincrement())
+  total Float?
 
   unit      String
   emissions Emissions?
-  metadata  Metadata   @relation(fields: [metadataId], references: [id])
+  metadata  Metadata?
 }
 
 /// Biogenic emissions are reported separately from scope 1-3
 /// If we want to save a more detailed breakdown (when companies reported this), we can use the metadata comment to save this context
 model BiogenicEmissions {
-  id         Int    @id @default(autoincrement())
+  id        Int        @id @default(autoincrement())
   /// Sometimes companies break it down into scope 1-3 - however these should always be stored as a total number according to the GHG protocol.
-  total      Float?
-  metadataId Int
-
+  total     Float?
   unit      String
   emissions Emissions?
-  metadata  Metadata   @relation(fields: [metadataId], references: [id])
+  metadata  Metadata?
 }
 
 model Scope1 {
-  id         Int    @id @default(autoincrement())
-  total      Float?
-  metadataId Int
+  id    Int    @id @default(autoincrement())
+  total Float?
 
   unit      String
   emissions Emissions?
-  metadata  Metadata   @relation(fields: [metadataId], references: [id])
+  metadata  Metadata?
 }
 
 /// For scope 2 emissions, we choose either market-based, location-based or unknown (if the company didn't specify if mb or lb)
 /// We generally prefer using market-based emissions, but if that doesn't exist we could use location-based ones, and finally unknown.
 model Scope2 {
-  id         Int    @id @default(autoincrement())
+  id      Int    @id @default(autoincrement())
   /// Market-based emissions
-  mb         Float?
+  mb      Float?
   /// Location-based emissions
-  lb         Float?
+  lb      Float?
   /// Unknown scope 2 emissions could be either market-based or location-based
-  unknown    Float?
-  metadataId Int
+  unknown Float?
 
   unit      String
   emissions Emissions?
-  metadata  Metadata   @relation(fields: [metadataId], references: [id])
+  metadata  Metadata?
 }
 
 // TODO: We need to separate scope3 into separate categories, because we need metadata for each scope 3 category value.
@@ -207,14 +198,13 @@ model Scope3 {
   /// Other times, they might report both, but their stated total scope 3 emissions might be different than the actual sum of their scope 3 categories.
   /// To get around this, we separate statedTotalEmissions from the actual mathematical total that we summarize during runtime.
   statedTotalEmissionsId Int? @unique
-  metadataId             Int
 
   // The scope 3 categories, both reported and estimated.
   // TODO: Add validation so there can only be one for each category, and max 16 entries.
   categories           Scope3Category[]
   statedTotalEmissions StatedTotalEmissions?
   emissions            Emissions?
-  metadata             Metadata              @relation(fields: [metadataId], references: [id])
+  metadata             Metadata?
 }
 
 /// Details about scope 3 categories. Here's a list of valid categories and their names:
@@ -248,13 +238,12 @@ model Scope3Category {
   // knowing the composition of cat 6. business travel, and how it changes across different years.
   // This would also make easier to detect discrepancies between stated emissions and the actual calculated total value
   // based on the composition for each scope 3 category. This would simplify the review process if we could automatically find errors.
-  total      Float?
-  scope3Id   Int
-  metadataId Int
+  total    Float?
+  scope3Id Int
 
   unit     String
-  scope3   Scope3   @relation(fields: [scope3Id], references: [id])
-  metadata Metadata @relation(fields: [metadataId], references: [id])
+  scope3   Scope3    @relation(fields: [scope3Id], references: [id])
+  metadata Metadata?
 }
 
 model Economy {
@@ -268,26 +257,24 @@ model Economy {
 }
 
 model Turnover {
-  id         Int     @id @default(autoincrement())
+  id       Int     @id @default(autoincrement())
   // IDEA: Should we store turnover with another datatype to prevent rounding errors? Money doesn't seem to be a good fit for storing as floats.
-  value      Float?
-  currency   String?
-  metadataId Int
+  value    Float?
+  currency String?
 
   economy  Economy?
-  metadata Metadata @relation(fields: [metadataId], references: [id])
+  metadata Metadata?
 }
 
 model Employees {
-  id         Int     @id @default(autoincrement())
+  id    Int     @id @default(autoincrement())
   /// Number of employees (using various methods)
-  value      Float?
+  value Float?
   /// How the number of employees were calculated, e.g. Full-time equivalents (FTE) or similar.
-  unit       String?
-  metadataId Int
+  unit  String?
 
   economy  Economy?
-  metadata Metadata @relation(fields: [metadataId], references: [id])
+  metadata Metadata?
 }
 
 model Goal {
@@ -300,11 +287,11 @@ model Goal {
   // Thus, we in some cases need to reference something else than the reporting periods
   // For now, let's store them as strings, but in the future maybe use another representation.
   baseYear    String?
-  metadataId  Int
   companyId   String
 
-  metadata Metadata @relation(fields: [metadataId], references: [id])
-  company  Company  @relation(fields: [companyId], references: [wikidataId])
+  /// Marked as optional because the foreign key resides in the Metadata model, making the relationship managed from that side. (Eventhough every goal needs to have metadata)
+  metadata Metadata?
+  company  Company   @relation(fields: [companyId], references: [wikidataId])
 }
 
 model Initiative {
@@ -314,10 +301,9 @@ model Initiative {
   year        String?
   scope       String?
   companyId   String
-  metadataId  Int
 
-  company  Company  @relation(fields: [companyId], references: [wikidataId])
-  metadata Metadata @relation(fields: [metadataId], references: [id])
+  company  Company   @relation(fields: [companyId], references: [wikidataId], onDelete: Cascade)
+  metadata Metadata?
 }
 
 /// Every datapoint has associated metadata about who changed it, when, and using what source
@@ -338,22 +324,37 @@ model Metadata {
   /// Value is a string enum with vlaues like `garbo`, `manual`, `estimated:exiobase`
   dataOrigin String?
 
-  goal                 Goal[]
-  initiative           Initiative[]
-  scope1               Scope1[]
-  scope2               Scope2[]
-  scope3               Scope3[]
-  reportingPeriod      ReportingPeriod[]
-  baseYear             BaseYear[]
-  biogenicEmissions    BiogenicEmissions[]
-  scope1And2           Scope1And2[]
-  statedTotalEmissions StatedTotalEmissions[]
-  user                 User                   @relation("metadata_user_id", fields: [userId], references: [id])
-  verifiedBy           User?                  @relation("metadata_verified_by", fields: [verifiedByUserId], references: [id])
-  industries           Industry[]
-  categories           Scope3Category[]
-  turnover             Turnover[]
-  employees            Employees[]
+  goalId                 Int? @unique
+  initiativeId           Int? @unique
+  scope1Id               Int? @unique
+  scope2Id               Int? @unique
+  scope3Id               Int? @unique
+  scope1And2Id           Int? @unique
+  reportingPeriodId      Int? @unique
+  baseYearId             Int? @unique
+  biogenicEmissionsId    Int? @unique
+  statedTotalEmissionsId Int? @unique
+  industryId             Int? @unique
+  categoryId             Int? @unique
+  turnoverId             Int? @unique
+  employeesId            Int? @unique
+
+  goal                 Goal?                 @relation(fields: [goalId], references: [id], onDelete: Cascade)
+  initiative           Initiative?           @relation(fields: [initiativeId], references: [id], onDelete: Cascade)
+  scope1               Scope1?               @relation(fields: [scope1Id], references: [id], onDelete: Cascade)
+  scope2               Scope2?               @relation(fields: [scope2Id], references: [id], onDelete: Cascade)
+  scope3               Scope3?               @relation(fields: [scope3Id], references: [id], onDelete: Cascade)
+  scope1And2           Scope1And2?           @relation(fields: [scope1And2Id], references: [id], onDelete: Cascade)
+  reportingPeriod      ReportingPeriod?      @relation(fields: [reportingPeriodId], references: [id], onDelete: Cascade)
+  baseYear             BaseYear?             @relation(fields: [baseYearId], references: [id], onDelete: Cascade)
+  biogenicEmissions    BiogenicEmissions?    @relation(fields: [biogenicEmissionsId], references: [id], onDelete: Cascade)
+  statedTotalEmissions StatedTotalEmissions? @relation(fields: [statedTotalEmissionsId], references: [id], onDelete: Cascade)
+  user                 User                  @relation("metadata_user_id", fields: [userId], references: [id])
+  verifiedBy           User?                 @relation("metadata_verified_by", fields: [verifiedByUserId], references: [id])
+  industry             Industry?             @relation(fields: [industryId], references: [id], onDelete: Cascade)
+  category             Scope3Category?       @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  turnover             Turnover?             @relation(fields: [turnoverId], references: [id], onDelete: Cascade)
+  employees            Employees?            @relation(fields: [employeesId], references: [id], onDelete: Cascade)
 }
 
 model User {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,7 @@ import { parseArgs } from 'node:util'
 
 import api from './api'
 import apiConfig from './config/api'
-import { PrismaClient } from '@prisma/client'
-
-export const prisma = new PrismaClient()
+import { prisma } from './lib/prisma'
 
 const { values } = parseArgs({
   options: {

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -14,7 +14,6 @@ import {
   Scope1And2,
 } from '@prisma/client'
 import { OptionalNullable } from './type-utils'
-import { prisma } from '..'
 import {
   DefaultEconomyArgs,
   DefaultEmissions,
@@ -22,6 +21,9 @@ import {
   emissionsArgs,
   reportingPeriodArgs,
 } from '../routes/types'
+import { PrismaClient } from '@prisma/client'
+
+export const prisma = new PrismaClient()
 
 const tCO2e = 'tCO2e'
 

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -656,15 +656,23 @@ export async function upsertReportingPeriod(
     endDate,
     reportURL,
     year,
-  }: { startDate: Date; endDate: Date; reportURL?: string; year: string }
+  }: {
+    startDate: Date
+    endDate: Date
+    reportURL?: string
+    year: string
+  }
 ) {
-  return prisma.reportingPeriod.upsert({
+  const reportingPeriod = await prisma.reportingPeriod.findFirst({
     where: {
-      id: 329329, // MAJOR REMINDER TO FIX
       companyId: company.wikidataId,
       year,
-      // NOTE: Maybe only check it's the same year of the endDate, instead of requiring the exact date to be provided in the request body.
-      // We might want to allow just sending a GET request to for example /2023/emissions.
+    },
+  })
+
+  return prisma.reportingPeriod.upsert({
+    where: {
+      id: reportingPeriod?.id ?? 0,
     },
     update: {},
     create: {
@@ -715,12 +723,10 @@ export async function updateReportingPeriodReportURL(
 
 export async function upsertEmissions({
   emissionsId,
-  year,
-  companyId,
+  reportingPeriodId,
 }: {
   emissionsId: number
-  year: string
-  companyId: string
+  reportingPeriodId: number
 }) {
   return prisma.emissions.upsert({
     where: { id: emissionsId },
@@ -728,11 +734,7 @@ export async function upsertEmissions({
     create: {
       reportingPeriod: {
         connect: {
-          id: 1234,
-          // reportingPeriodId: {
-          //   year,
-          //   companyId,
-          // },
+          id: reportingPeriodId,
         },
       },
     },

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -15,26 +15,34 @@ import {
 } from '@prisma/client'
 import { OptionalNullable } from './type-utils'
 import { prisma } from '..'
+import {
+  DefaultEconomyArgs,
+  economyArgs,
+  emissionsArgs,
+  ExtendedEmissions,
+} from '../routes/types'
 
 const tCO2e = 'tCO2e'
 
 export async function upsertScope1(
-  emissions: Emissions,
-  scope1: OptionalNullable<Omit<Scope1, 'id' | 'metadataId' | 'unit'>> | null,
+  emissions: ExtendedEmissions,
+  scope1: Omit<Scope1, 'id' | 'metadataId' | 'unit' | 'emissionsId'> | null,
   metadata: Metadata
 ) {
+  const existingScope1Id = emissions.scope1?.id
+
   if (scope1 === null) {
-    if (emissions.scope1Id) {
+    if (existingScope1Id) {
       await prisma.scope1.delete({
-        where: { id: emissions.scope1Id },
+        where: { id: existingScope1Id },
       })
     }
     return null
   }
 
-  return emissions.scope1Id
+  return existingScope1Id
     ? prisma.scope1.update({
-        where: { id: emissions.scope1Id },
+        where: { id: existingScope1Id },
         data: {
           ...scope1,
           metadata: {
@@ -65,7 +73,7 @@ export async function upsertScope1(
 }
 
 export async function upsertScope2(
-  emissions: Emissions,
+  emissions: ExtendedEmissions,
   scope2: {
     lb?: number | null
     mb?: number | null
@@ -73,18 +81,20 @@ export async function upsertScope2(
   } | null,
   metadata: Metadata
 ) {
+  const existingScope2Id = emissions.scope2?.id
+
   if (scope2 === null) {
-    if (emissions.scope2Id) {
+    if (existingScope2Id) {
       await prisma.scope2.delete({
-        where: { id: emissions.scope2Id },
+        where: { id: existingScope2Id },
       })
     }
     return null
   }
 
-  return emissions.scope2Id
+  return existingScope2Id
     ? prisma.scope2.update({
-        where: { id: emissions.scope2Id },
+        where: { id: existingScope2Id },
         data: {
           ...scope2,
           metadata: {
@@ -115,24 +125,27 @@ export async function upsertScope2(
 }
 
 export async function upsertScope1And2(
-  emissions: Emissions,
-  scope1And2: OptionalNullable<
-    Omit<Scope1And2, 'id' | 'metadataId' | 'unit'>
+  emissions: ExtendedEmissions,
+  scope1And2: Omit<
+    Scope1And2,
+    'id' | 'metadataId' | 'unit' | 'emissionsId'
   > | null,
   metadata: Metadata
 ) {
+  const existingScope1And2Id = emissions.scope1And2?.id
+
   if (scope1And2 === null) {
-    if (emissions.scope1And2Id) {
+    if (existingScope1And2Id) {
       await prisma.scope1And2.delete({
-        where: { id: emissions.scope1And2Id },
+        where: { id: existingScope1And2Id },
       })
     }
     return null
   }
 
-  return emissions.scope1And2Id
+  return existingScope1And2Id
     ? prisma.scope1And2.update({
-        where: { id: emissions.scope1And2Id },
+        where: { id: existingScope1And2Id },
         data: {
           ...scope1And2,
           metadata: {
@@ -163,7 +176,7 @@ export async function upsertScope1And2(
 }
 
 export async function upsertScope3(
-  emissions: Emissions,
+  emissions: ExtendedEmissions,
   scope3: {
     categories?: { category: number; total: number | null }[]
     statedTotalEmissions?: OptionalNullable<
@@ -172,8 +185,10 @@ export async function upsertScope3(
   },
   metadata: Metadata
 ) {
+  const existingScope3Id = emissions.scope3?.id
+
   const updatedScope3 = await prisma.scope3.upsert({
-    where: { id: emissions.scope3Id ?? 0 },
+    where: { id: existingScope3Id ?? 0 },
     update: {},
     create: {
       metadata: {
@@ -262,25 +277,27 @@ export async function upsertScope3(
 }
 
 export async function upsertBiogenic(
-  emissions: Emissions,
+  emissions: ExtendedEmissions,
   biogenic: OptionalNullable<
-    Omit<BiogenicEmissions, 'id' | 'metadataId' | 'unit'>
+    Omit<BiogenicEmissions, 'id' | 'metadataId' | 'unit' | 'emissionsId'>
   > | null,
   metadata: Metadata
 ) {
+  const existingBiogenicEmissionsId = emissions.biogenicEmissions?.id
+
   if (biogenic === null) {
-    if (emissions.biogenicEmissionsId) {
+    if (existingBiogenicEmissionsId) {
       await prisma.biogenicEmissions.delete({
-        where: { id: emissions.biogenicEmissionsId },
+        where: { id: existingBiogenicEmissionsId },
       })
     }
     return null
   }
 
-  return emissions.biogenicEmissionsId
+  return existingBiogenicEmissionsId
     ? prisma.biogenicEmissions.update({
         where: {
-          id: emissions.biogenicEmissionsId,
+          id: existingBiogenicEmissionsId,
         },
         data: {
           ...biogenic,
@@ -312,16 +329,19 @@ export async function upsertBiogenic(
 }
 
 export async function upsertStatedTotalEmissions(
-  emissions: Emissions,
+  emissions: ExtendedEmissions,
   statedTotalEmissions: OptionalNullable<
-    Omit<StatedTotalEmissions, 'id' | 'metadataId' | 'unit' | 'scope3Id'>
+    Omit<
+      StatedTotalEmissions,
+      'id' | 'metadataId' | 'unit' | 'scope3Id' | 'emissionsId'
+    >
   > | null,
   metadata: Metadata,
   scope3?: Scope3 & { statedTotalEmissions: { id: number } | null }
 ) {
   const statedTotalEmissionsId = scope3
     ? scope3.statedTotalEmissionsId || scope3?.statedTotalEmissions?.id
-    : emissions.statedTotalEmissionsId
+    : emissions.statedTotalEmissions?.id
 
   if (statedTotalEmissions === null) {
     if (statedTotalEmissionsId) {
@@ -504,7 +524,7 @@ export async function deleteInitiative(id: Initiative['id']) {
 export async function upsertTurnover(
   economy: Economy,
   turnover: OptionalNullable<
-    Omit<Turnover, 'id' | 'metadataId' | 'unit'>
+    Omit<Turnover, 'id' | 'metadataId' | 'unit' | 'economyId'>
   > | null,
   metadata: Metadata
 ) {
@@ -539,21 +559,25 @@ export async function upsertTurnover(
 }
 
 export async function upsertEmployees(
-  economy: Economy,
-  employees: OptionalNullable<Omit<Employees, 'id' | 'metadataId'>> | null,
+  economy: DefaultEconomyArgs,
+  employees: OptionalNullable<
+    Omit<Employees, 'id' | 'metadataId' | 'economyId'>
+  > | null,
   metadata: Metadata
 ) {
+  const existingEmployeesId = economy.employees?.id
+
   if (employees === null) {
-    if (economy.employeesId) {
+    if (existingEmployeesId) {
       await prisma.employees.delete({
-        where: { id: economy.employeesId },
+        where: { id: existingEmployeesId },
       })
     }
     return null
   }
 
   return prisma.employees.upsert({
-    where: { id: economy.employeesId ?? 0 },
+    where: { id: existingEmployeesId ?? 0 },
     create: {
       ...employees,
       metadata: {
@@ -633,10 +657,9 @@ export async function upsertReportingPeriod(
 ) {
   return prisma.reportingPeriod.upsert({
     where: {
-      reportingPeriodId: {
-        companyId: company.wikidataId,
-        year,
-      },
+      id: 329329, // MAJOR REMINDER TO FIX
+      companyId: company.wikidataId,
+      year,
       // NOTE: Maybe only check it's the same year of the endDate, instead of requiring the exact date to be provided in the request body.
       // We might want to allow just sending a GET request to for example /2023/emissions.
     },
@@ -657,6 +680,25 @@ export async function upsertReportingPeriod(
         },
       },
     },
+    include: {
+      emissions: {
+        include: {
+          biogenicEmissions: { select: { id: true } },
+          scope1: { select: { id: true } },
+          scope1And2: { select: { id: true } },
+          scope2: { select: { id: true } },
+          scope3: { select: { id: true } },
+          statedTotalEmissions: { select: { id: true } },
+        },
+      },
+      economy: {
+        include: {
+          employees: { select: { id: true } },
+          turnover: { select: { id: true } },
+        },
+      },
+      company: { select: { wikidataId: true } },
+    },
   })
 }
 
@@ -665,12 +707,10 @@ export async function updateReportingPeriodReportURL(
   year: string,
   reportURL: string
 ) {
-  const reportingPeriod = await prisma.reportingPeriod.findUnique({
+  const reportingPeriod = await prisma.reportingPeriod.findFirst({
     where: {
-      reportingPeriodId: {
-        companyId: company.wikidataId,
-        year,
-      },
+      companyId: company.wikidataId,
+      year,
     },
   })
 
@@ -680,10 +720,7 @@ export async function updateReportingPeriodReportURL(
 
   return prisma.reportingPeriod.update({
     where: {
-      reportingPeriodId: {
-        companyId: company.wikidataId,
-        year,
-      },
+      id: reportingPeriod.id,
     },
     data: {
       reportURL,
@@ -706,13 +743,15 @@ export async function upsertEmissions({
     create: {
       reportingPeriod: {
         connect: {
-          reportingPeriodId: {
-            year,
-            companyId,
-          },
+          id: 1234,
+          // reportingPeriodId: {
+          //   year,
+          //   companyId,
+          // },
         },
       },
     },
+    ...emissionsArgs,
   })
 }
 
@@ -731,12 +770,10 @@ export async function upsertEconomy({
     create: {
       reportingPeriod: {
         connect: {
-          reportingPeriodId: {
-            year,
-            companyId,
-          },
+          id: 1234,
         },
       },
     },
+    ...economyArgs,
   })
 }

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -17,15 +17,16 @@ import { OptionalNullable } from './type-utils'
 import { prisma } from '..'
 import {
   DefaultEconomyArgs,
+  DefaultEmissions,
   economyArgs,
   emissionsArgs,
-  ExtendedEmissions,
+  reportingPeriodArgs,
 } from '../routes/types'
 
 const tCO2e = 'tCO2e'
 
 export async function upsertScope1(
-  emissions: ExtendedEmissions,
+  emissions: DefaultEmissions,
   scope1: Omit<Scope1, 'id' | 'metadataId' | 'unit' | 'emissionsId'> | null,
   metadata: Metadata
 ) {
@@ -73,7 +74,7 @@ export async function upsertScope1(
 }
 
 export async function upsertScope2(
-  emissions: ExtendedEmissions,
+  emissions: DefaultEmissions,
   scope2: {
     lb?: number | null
     mb?: number | null
@@ -125,7 +126,7 @@ export async function upsertScope2(
 }
 
 export async function upsertScope1And2(
-  emissions: ExtendedEmissions,
+  emissions: DefaultEmissions,
   scope1And2: Omit<
     Scope1And2,
     'id' | 'metadataId' | 'unit' | 'emissionsId'
@@ -176,7 +177,7 @@ export async function upsertScope1And2(
 }
 
 export async function upsertScope3(
-  emissions: ExtendedEmissions,
+  emissions: DefaultEmissions,
   scope3: {
     categories?: { category: number; total: number | null }[]
     statedTotalEmissions?: OptionalNullable<
@@ -277,7 +278,7 @@ export async function upsertScope3(
 }
 
 export async function upsertBiogenic(
-  emissions: ExtendedEmissions,
+  emissions: DefaultEmissions,
   biogenic: OptionalNullable<
     Omit<BiogenicEmissions, 'id' | 'metadataId' | 'unit' | 'emissionsId'>
   > | null,
@@ -329,7 +330,7 @@ export async function upsertBiogenic(
 }
 
 export async function upsertStatedTotalEmissions(
-  emissions: ExtendedEmissions,
+  emissions: DefaultEmissions,
   statedTotalEmissions: OptionalNullable<
     Omit<
       StatedTotalEmissions,
@@ -680,25 +681,7 @@ export async function upsertReportingPeriod(
         },
       },
     },
-    include: {
-      emissions: {
-        include: {
-          biogenicEmissions: { select: { id: true } },
-          scope1: { select: { id: true } },
-          scope1And2: { select: { id: true } },
-          scope2: { select: { id: true } },
-          scope3: { select: { id: true } },
-          statedTotalEmissions: { select: { id: true } },
-        },
-      },
-      economy: {
-        include: {
-          employees: { select: { id: true } },
-          turnover: { select: { id: true } },
-        },
-      },
-      company: { select: { wikidataId: true } },
-    },
+    ...reportingPeriodArgs,
   })
 }
 
@@ -757,12 +740,10 @@ export async function upsertEmissions({
 
 export async function upsertEconomy({
   economyId,
-  companyId,
-  year,
+  reportingPeriodId,
 }: {
   economyId: number
-  companyId: string
-  year: string
+  reportingPeriodId: number
 }) {
   return prisma.economy.upsert({
     where: { id: economyId },
@@ -770,7 +751,7 @@ export async function upsertEconomy({
     create: {
       reportingPeriod: {
         connect: {
-          id: 1234,
+          id: reportingPeriodId,
         },
       },
     },

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,8 +1,6 @@
 import {
-  PrismaClient,
   Metadata,
   Scope1,
-  Scope2,
   Company,
   Emissions,
   BiogenicEmissions,
@@ -16,8 +14,7 @@ import {
   Scope1And2,
 } from '@prisma/client'
 import { OptionalNullable } from './type-utils'
-
-export const prisma = new PrismaClient()
+import { prisma } from '..'
 
 const tCO2e = 'tCO2e'
 

--- a/src/routes/middlewares.ts
+++ b/src/routes/middlewares.ts
@@ -19,6 +19,7 @@ import {
 } from '../lib/prisma'
 import { GarboAPIError } from '../lib/garbo-api-error'
 import apiConfig from '../config/api'
+import { DefaultEconomyArgs, ExtendedEmissions } from './types'
 
 declare global {
   namespace Express {
@@ -27,8 +28,8 @@ declare global {
       company: Company
       reportingPeriod: ReportingPeriod
       metadata?: Metadata
-      emissions?: Emissions
-      economy?: Economy
+      emissions?: ExtendedEmissions
+      economy?: DefaultEconomyArgs
     }
   }
 }

--- a/src/routes/middlewares.ts
+++ b/src/routes/middlewares.ts
@@ -1,13 +1,5 @@
 import { NextFunction, Request, Response } from 'express'
-import {
-  Company,
-  Economy,
-  Emissions,
-  Metadata,
-  PrismaClient,
-  ReportingPeriod,
-  User,
-} from '@prisma/client'
+import { Company, Metadata, PrismaClient, User } from '@prisma/client'
 import { validateRequest, validateRequestBody } from './zod-middleware'
 import { z, ZodError } from 'zod'
 import cors, { CorsOptionsDelegate } from 'cors'
@@ -19,16 +11,20 @@ import {
 } from '../lib/prisma'
 import { GarboAPIError } from '../lib/garbo-api-error'
 import apiConfig from '../config/api'
-import { DefaultEconomyArgs, ExtendedEmissions } from './types'
+import {
+  DefaultEconomyArgs,
+  DefaultEmissions,
+  DefaultReportingPeriod,
+} from './types'
 
 declare global {
   namespace Express {
     interface Locals {
       user: User
       company: Company
-      reportingPeriod: ReportingPeriod
+      reportingPeriod: DefaultReportingPeriod
       metadata?: Metadata
-      emissions?: ExtendedEmissions
+      emissions?: DefaultEmissions
       economy?: DefaultEconomyArgs
     }
   }
@@ -190,7 +186,7 @@ export const ensureEmissionsExists =
     const reportingPeriod = res.locals.reportingPeriod
 
     const emissions = await upsertEmissions({
-      emissionsId: reportingPeriod.emissionsId ?? 0,
+      emissionsId: reportingPeriod.emissions?.id ?? 0,
       companyId: res.locals.company.wikidataId,
       year: reportingPeriod.year,
     })
@@ -205,9 +201,8 @@ export const ensureEconomyExists =
     const reportingPeriod = res.locals.reportingPeriod
 
     const economy = await upsertEconomy({
-      economyId: reportingPeriod.economyId ?? 0,
-      companyId: reportingPeriod.companyId,
-      year: reportingPeriod.year,
+      economyId: reportingPeriod.economy?.id ?? 0,
+      reportingPeriodId: reportingPeriod.id,
     })
 
     res.locals.economy = economy

--- a/src/routes/readCompanies.ts
+++ b/src/routes/readCompanies.ts
@@ -4,8 +4,8 @@ import { validateRequestParams } from './zod-middleware'
 import { getGics } from '../lib/gics'
 import { cache, enableCors } from './middlewares'
 import { wikidataIdParamSchema } from './companySchemas'
-import { prisma } from '../lib/prisma'
 import { GarboAPIError } from '../lib/garbo-api-error'
+import { prisma } from '..'
 
 const router = express.Router()
 

--- a/src/routes/readCompanies.ts
+++ b/src/routes/readCompanies.ts
@@ -5,7 +5,7 @@ import { getGics } from '../lib/gics'
 import { cache, enableCors } from './middlewares'
 import { wikidataIdParamSchema } from './companySchemas'
 import { GarboAPIError } from '../lib/garbo-api-error'
-import { prisma } from '..'
+import { prisma } from '../lib/prisma'
 
 const router = express.Router()
 

--- a/src/routes/types.ts
+++ b/src/routes/types.ts
@@ -1,0 +1,23 @@
+import { Prisma } from '@prisma/client'
+
+export const emissionsArgs = {
+  include: {
+    scope1: { select: { id: true } },
+    scope2: { select: { id: true } },
+    scope3: { select: { id: true } },
+    biogenicEmissions: { select: { id: true } },
+    scope1And2: { select: { id: true } },
+    statedTotalEmissions: { select: { id: true } },
+  },
+} satisfies Prisma.EmissionsDefaultArgs
+
+export type ExtendedEmissions = Prisma.EmissionsGetPayload<typeof emissionsArgs>
+
+export const economyArgs = {
+  include: {
+    employees: { select: { id: true } },
+    turnover: { select: { id: true } },
+  },
+} satisfies Prisma.EconomyDefaultArgs
+
+export type DefaultEconomyArgs = Prisma.EconomyGetPayload<typeof economyArgs>

--- a/src/routes/types.ts
+++ b/src/routes/types.ts
@@ -11,7 +11,7 @@ export const emissionsArgs = {
   },
 } satisfies Prisma.EmissionsDefaultArgs
 
-export type ExtendedEmissions = Prisma.EmissionsGetPayload<typeof emissionsArgs>
+export type DefaultEmissions = Prisma.EmissionsGetPayload<typeof emissionsArgs>
 
 export const economyArgs = {
   include: {
@@ -21,3 +21,29 @@ export const economyArgs = {
 } satisfies Prisma.EconomyDefaultArgs
 
 export type DefaultEconomyArgs = Prisma.EconomyGetPayload<typeof economyArgs>
+
+export const reportingPeriodArgs = {
+  include: {
+    emissions: {
+      include: {
+        biogenicEmissions: { select: { id: true } },
+        scope1: { select: { id: true } },
+        scope1And2: { select: { id: true } },
+        scope2: { select: { id: true } },
+        scope3: { select: { id: true } },
+        statedTotalEmissions: { select: { id: true } },
+      },
+    },
+    economy: {
+      include: {
+        employees: { select: { id: true } },
+        turnover: { select: { id: true } },
+      },
+    },
+    company: { select: { wikidataId: true } },
+  },
+} satisfies Prisma.ReportingPeriodDefaultArgs
+
+export type DefaultReportingPeriod = Prisma.ReportingPeriodGetPayload<
+  typeof reportingPeriodArgs
+>

--- a/src/routes/updateCompanies.ts
+++ b/src/routes/updateCompanies.ts
@@ -24,6 +24,7 @@ import {
   deleteInitiative,
   deleteGoal,
   updateReportingPeriodReportURL,
+  prisma,
 } from '../lib/prisma'
 import {
   createMetadata,
@@ -34,7 +35,6 @@ import {
   validateMetadata,
   ensureEconomyExists,
 } from './middlewares'
-import { prisma } from '..'
 import { Company, Prisma } from '@prisma/client'
 import { wikidataIdParamSchema, wikidataIdSchema } from './companySchemas'
 import { GarboAPIError } from '../lib/garbo-api-error'

--- a/src/routes/updateCompanies.ts
+++ b/src/routes/updateCompanies.ts
@@ -460,8 +460,7 @@ router.post(
               }),
               upsertEconomy({
                 economyId: reportingPeriod.economy?.id ?? 0,
-                companyId: company.wikidataId,
-                year,
+                reportingPeriodId: reportingPeriod.id,
               }),
             ])
 

--- a/src/routes/updateCompanies.ts
+++ b/src/routes/updateCompanies.ts
@@ -455,8 +455,7 @@ router.post(
             const [dbEmissions, dbEconomy] = await Promise.all([
               upsertEmissions({
                 emissionsId: reportingPeriod.emissions?.id ?? 0,
-                companyId: company.wikidataId,
-                year,
+                reportingPeriodId: reportingPeriod.id,
               }),
               upsertEconomy({
                 economyId: reportingPeriod.economy?.id ?? 0,

--- a/src/routes/updateCompanies.ts
+++ b/src/routes/updateCompanies.ts
@@ -34,7 +34,7 @@ import {
   validateMetadata,
   ensureEconomyExists,
 } from './middlewares'
-import { prisma } from '../lib/prisma'
+import { prisma } from '..'
 import { Company, Prisma } from '@prisma/client'
 import { wikidataIdParamSchema, wikidataIdSchema } from './companySchemas'
 import { GarboAPIError } from '../lib/garbo-api-error'
@@ -454,12 +454,12 @@ router.post(
 
             const [dbEmissions, dbEconomy] = await Promise.all([
               upsertEmissions({
-                emissionsId: reportingPeriod.emissionsId ?? 0,
+                emissionsId: reportingPeriod.emissions?.id ?? 0,
                 companyId: company.wikidataId,
                 year,
               }),
               upsertEconomy({
-                economyId: reportingPeriod.economyId ?? 0,
+                economyId: reportingPeriod.economy?.id ?? 0,
                 companyId: company.wikidataId,
                 year,
               }),


### PR DESCRIPTION
- Obs: This PR is not ready for review, but if you're curios you can look at the schema.prisma file to see how we might want to restructure our database schema
- In this schema we take fully advantages of the relational db where we can use cascading effects
- In order to do this we have to move the fk in lots of places so it the correct child entity cascades if the parent is deleted
- Still lots some stuff to cleanup in the routes but I think this will enable us to offer a more robust and maintainable api 
- Bonus: This will enable us to to use null for garboAI since we can migrate to using actual deletes instead of sending in null for cruD operations

TLDR:
New Schema design --> Hopefully more sustainable :) 