### PR TITLE
Improve querytexts for emissions

### DIFF
--- a/src/api/routes/company.goals.ts
+++ b/src/api/routes/company.goals.ts
@@ -43,8 +43,6 @@ export async function companyGoalsRoutes(app: FastifyInstance) {
     ) => {
       const { goals, metadata } = request.body
 
-      console.log('company.goals', goals)
-
       if (goals?.length) {
         const { wikidataId } = request.params
         const user = request.user

--- a/src/api/routes/company.goals.ts
+++ b/src/api/routes/company.goals.ts
@@ -43,6 +43,8 @@ export async function companyGoalsRoutes(app: FastifyInstance) {
     ) => {
       const { goals, metadata } = request.body
 
+      console.log('company.goals', goals)
+
       if (goals?.length) {
         const { wikidataId } = request.params
         const user = request.user

--- a/src/prompts/followUp/scope12.ts
+++ b/src/prompts/followUp/scope12.ts
@@ -67,6 +67,7 @@ const queryTexts = [
   'Scope 1 and 2 emissions',
   'Market-based and location-based emissions',
   'GHG protocol Scope 1 and 2 data',
+  'carbon emissions CO2',
 ]
 
 export default { prompt, schema, queryTexts }

--- a/src/prompts/followUp/scope3.ts
+++ b/src/prompts/followUp/scope3.ts
@@ -103,6 +103,7 @@ const queryTexts = [
   downstreamTransportationAndDistribution processingOfSoldProducts 
   useOfSoldProducts endOfLifeTreatmentOfSoldProducts downstreamLeasedAssets 
   franchises investments other`,
+  'carbon emissions CO2',
 ]
 
 export default { prompt, schema, queryTexts }

--- a/src/workers/followUp.ts
+++ b/src/workers/followUp.ts
@@ -18,8 +18,6 @@ const followUp = new DiscordWorker<FollowUpJob>(
   'followUp',
   async (job: FollowUpJob) => {
     const { type, url, previousAnswer } = job.data
-    console.log('followup: job.data.type', job.data.type)
-
     const {
       default: { schema, prompt, queryTexts },
     } = await import(resolve(import.meta.dirname, `../prompts/${type}`))

--- a/src/workers/followUp.ts
+++ b/src/workers/followUp.ts
@@ -18,6 +18,7 @@ const followUp = new DiscordWorker<FollowUpJob>(
   'followUp',
   async (job: FollowUpJob) => {
     const { type, url, previousAnswer } = job.data
+    console.log('followup: job.data.type', job.data.type)
 
     const {
       default: { schema, prompt, queryTexts },


### PR DESCRIPTION
## Improve context by updating query texts
🌍 Added co2 keywords to the querytexts for context retrieval
🌍 Verified that it improved garbo by checking 10 companies ( huge improvement in some cases) 

🌵 Caution: At first I added even more querytexts related to fixing issues where garbo misses data. However this has to be done carefully as I saw firsthand that might fix it for a specific company but actually losing accuracy when running multiple companies 😓 This will be easier when we add some kind of measurement of garbo in our pipeline!