### PR TITLE
[Fix] Update Company Details Response

### DIFF
--- a/src/api/routes/company.read.ts
+++ b/src/api/routes/company.read.ts
@@ -5,10 +5,14 @@ import { getGics } from '../../lib/gics'
 import { GarboAPIError } from '../../lib/garbo-api-error'
 import { prisma } from '../../lib/prisma'
 import { getTags } from '../../config/openapi'
-import { wikidataIdParamSchema, CompanyList, CompanyDetails } from '../schemas'
+import {
+  wikidataIdParamSchema,
+  CompanyList,
+  CompanyDetails,
+  emptyBodySchema,
+} from '../schemas'
 import { WikidataIdParams } from '../types'
 import { cachePlugin } from '../plugins/cache'
-import { z } from 'zod'
 
 const metadata = {
   orderBy: {
@@ -297,7 +301,8 @@ export async function companyReadRoutes(app: FastifyInstance) {
         tags: getTags('Companies'),
         params: wikidataIdParamSchema,
         response: {
-          200: z.union([CompanyDetails, z.null()]),
+          200: CompanyDetails,
+          404: emptyBodySchema,
         },
       },
     },
@@ -449,8 +454,7 @@ export async function companyReadRoutes(app: FastifyInstance) {
         })
 
         if (!company) {
-          reply.send(null)
-          return
+          return reply.status(404).send()
         }
 
         const [transformedCompany] = addCalculatedTotalEmissions([


### PR DESCRIPTION
### Background
While updating the editor tool on the FE and implementing the OpenApi for autogenerating the api paths, we found the GET companyDetails endpoint returned an empty array rather than an error code response if there were no company details found. This lead to weird handling in the FE, so we decided to modify the api response. 

### What Changed
Removed the : null handling if no company is found, and instead to return a 404 error response code on the company.read.ts file. 

Closes #564 