### PR TITLE
Improve scope3 categories and table reading

### DIFF
--- a/src/api/routes/company.industry.ts
+++ b/src/api/routes/company.industry.ts
@@ -38,8 +38,6 @@ export async function companyIndustryRoutes(app: FastifyInstance) {
       } = request.body
       const { wikidataId } = request.params
 
-      console.log('subIndustryCode', subIndustryCode)
-
       const current = await prisma.industry.findFirst({
         where: { companyWikidataId: wikidataId },
       })

--- a/src/api/routes/company.industry.ts
+++ b/src/api/routes/company.industry.ts
@@ -38,7 +38,9 @@ export async function companyIndustryRoutes(app: FastifyInstance) {
       } = request.body
       const { wikidataId } = request.params
 
-      const current = await prisma.industry.findFirstOrThrow({
+      console.log('subIndustryCode', subIndustryCode)
+
+      const current = await prisma.industry.findFirst({
         where: { companyWikidataId: wikidataId },
       })
 

--- a/src/prompts/followUp/scope3.ts
+++ b/src/prompts/followUp/scope3.ts
@@ -35,22 +35,26 @@ Extract scope 3 emissions according to the GHG Protocol and organize them by yea
   Always report data according to the official GHG Protocol categories. If a reported category does not match the official list, include it under "16: Other."
 
   GHG Categories:
-   1: Purchased Goods
-   2: Capital Goods
-   3: Fuel And Energy Related Activities
-   4: Upstream Transportation And Distribution
-   5: Waste Generated In Operations
-   6: Business Travel
-   7: Employee Commuting
-   8: Upstream Leased Assets
-   9: Downstream Transportation And Distribution
-   10: Processing Of Sold Products
-   11: Use Of Sold Products
-   12: End Of Life Treatment Of Sold Products
-   13: Downstream Leased Assets
-   14: Franchises
-   15: Investments
-   16: Other
+  
+  Upstream: 
+  1.	Purchased Goods and Services: Emissions from the production and transportation of goods and services purchased by the company, such as raw materials and office supplies.
+	2.	Capital Goods: Emissions from the production and transportation of long-term assets purchased by the company, such as machinery, vehicles, or buildings.
+	3.	Fuel- and Energy-Related Activities (not included in Scope 1 or 2): Emissions from the extraction, production, and transportation of fuels and electricity purchased by the company, not directly consumed.
+	4.	Upstream Transportation and Distribution: Emissions from the transport and distribution of goods before they reach the company, including supplier deliveries.
+	5.	Waste Generated in Operations: Emissions from the treatment and disposal of waste generated during business operations, such as landfilling, recycling, or incineration.
+	6.	Business Travel: Emissions from employee travel in vehicles not owned by the company, such as flights or rental cars.
+	7.	Employee Commuting: Emissions from employees traveling between home and work, regardless of transport mode.
+	8.	Upstream Leased Assets: Emissions from the operation of leased assets used by the company but owned by another entity, such as leased office spaces.
+	9.	Downstream Transportation and Distribution: Emissions from the transport and distribution of sold goods after they leave the company, including delivery to end-users.
+
+  Downstream:
+	10.	Processing of Sold Products: Emissions that occur when customers further process the sold products, such as refining crude oil sold by the company.
+	11.	Use of Sold Products: Emissions from the use of the company’s sold products, especially those that emit greenhouse gases during use, like fuels.
+	12.	End-of-Life Treatment of Sold Products: Emissions from the disposal or recycling of the company’s sold products after they’ve been used.
+	13.	Downstream Leased Assets: Emissions from the operation of assets leased to others, such as buildings or equipment owned by the company but operated by tenants.
+	14.	Franchises: Emissions from franchise operations operating under the company’s brand, such as emissions from franchised restaurants or retail stores.
+	15.	Investments: Emissions related to the company’s investments, such as those from financed projects or portfolio companies.
+	16.	Other: Any other relevant emissions sources not covered by the categories above, such as outsourced activities or unique business processes.
 
 2. **Missing Or Incomplete Data**:
 - Extract values only if explicitly available in the context. Do not infer or create data. Leave optional fields absent or explicitly set to null if no data is provided.

--- a/src/prompts/followUp/scope3.ts
+++ b/src/prompts/followUp/scope3.ts
@@ -37,24 +37,24 @@ Extract scope 3 emissions according to the GHG Protocol and organize them by yea
   GHG Categories:
   
   Upstream: 
-  1.	Purchased Goods and Services: Emissions from the production and transportation of goods and services purchased by the company, such as raw materials and office supplies.
-	2.	Capital Goods: Emissions from the production and transportation of long-term assets purchased by the company, such as machinery, vehicles, or buildings.
-	3.	Fuel- and Energy-Related Activities (not included in Scope 1 or 2): Emissions from the extraction, production, and transportation of fuels and electricity purchased by the company, not directly consumed.
-	4.	Upstream Transportation and Distribution: Emissions from the transport and distribution of goods before they reach the company, including supplier deliveries.
-	5.	Waste Generated in Operations: Emissions from the treatment and disposal of waste generated during business operations, such as landfilling, recycling, or incineration.
-	6.	Business Travel: Emissions from employee travel in vehicles not owned by the company, such as flights or rental cars.
-	7.	Employee Commuting: Emissions from employees traveling between home and work, regardless of transport mode.
-	8.	Upstream Leased Assets: Emissions from the operation of leased assets used by the company but owned by another entity, such as leased office spaces.
+  1. Purchased Goods and Services: Emissions from the production of goods and services purchased by the company, such as raw materials and office supplies.
+  2. Capital Goods: Emissions from the production and transportation of long-term assets purchased by the company, such as machinery, vehicles, or buildings.
+  3.Fuel- and Energy-Related Activities (not included in Scope 1 or 2): Emissions from the extraction, production, and transportation of fuels and electricity purchased by the company, not directly consumed.
+  4.Upstream Transportation and Distribution: Emissions from transport and distribution services purchased by the company, either for transport of goods purchased by the company, or supplier deliveries that the company has operational control over.
+  5.Waste Generated in Operations: Emissions from the treatment and disposal of waste generated during business operations, such as landfilling, recycling, or incineration.
+  6.Business Travel: Emissions from employee travel in vehicles not owned by the company, such as flights or rental cars.
+  7.Employee Commuting: Emissions from employees traveling between home and work, regardless of transport mode. This also includes emissions from working from home.
+  8.Upstream Leased Assets: Emissions from the operation of leased assets used by the company but owned by another entity, such as leased vehicles.
   
   Downstream:
-	9.	Downstream Transportation and Distribution: Emissions from the transport and distribution of sold goods after they leave the company, including delivery to end-users.
-	10.	Processing of Sold Products: Emissions that occur when customers further process the sold products, such as refining crude oil sold by the company.
-	11.	Use of Sold Products: Emissions from the use of the company’s sold products, especially those that emit greenhouse gases during use, like fuels.
-	12.	End-of-Life Treatment of Sold Products: Emissions from the disposal or recycling of the company’s sold products after they’ve been used.
-	13.	Downstream Leased Assets: Emissions from the operation of assets leased to others, such as buildings or equipment owned by the company but operated by tenants.
-	14.	Franchises: Emissions from franchise operations operating under the company’s brand, such as emissions from franchised restaurants or retail stores.
-	15.	Investments: Emissions related to the company’s investments, such as those from financed projects or portfolio companies.
-	16.	Other: Any other relevant emissions sources not covered by the categories above, such as outsourced activities or unique business processes.
+  9. Downstream Transportation and Distribution: Emissions from the transport and distribution of sold goods after they leave the company, including delivery to end-users. Note that if the company pays for the service, it falls under category 4 (upstream).
+  10. Processing of Sold Products: Emissions that occur when customers further process the sold products, such as refining crude oil sold by the company or turning raw paper into newspaper.
+  11. Use of Sold Products: Emissions from the use of the company’s sold products, especially those that emit greenhouse gases during use, like fuels or vehicles that use fuels. Another example is energy-consuming products such as machinery.
+  12. End-of-Life Treatment of Sold Products: Emissions from the disposal or recycling of the company’s sold products after they’ve been used.
+  13. Downstream Leased Assets: Emissions from the operation of assets leased to others, such as buildings or equipment owned by the company but operated by tenants.
+  14. Franchises: Emissions from franchise operations operating under the company’s brand, such as emissions from franchised restaurants or retail stores.
+  15. Investments: Emissions related to the company’s investments, such as those from financed projects or portfolio companies.
+  16. Other: Any other relevant emissions sources not covered by the categories above, such as outsourced activities or unique business processes. Note that this is not in line with the GHG protocol, but used in this process to include emissions not accurately categorised by the company.
 
 2. **Missing Or Incomplete Data**:
 - Extract values only if explicitly available in the context. Do not infer or create data. Leave optional fields absent or explicitly set to null if no data is provided.

--- a/src/prompts/followUp/scope3.ts
+++ b/src/prompts/followUp/scope3.ts
@@ -45,9 +45,9 @@ Extract scope 3 emissions according to the GHG Protocol and organize them by yea
 	6.	Business Travel: Emissions from employee travel in vehicles not owned by the company, such as flights or rental cars.
 	7.	Employee Commuting: Emissions from employees traveling between home and work, regardless of transport mode.
 	8.	Upstream Leased Assets: Emissions from the operation of leased assets used by the company but owned by another entity, such as leased office spaces.
-	9.	Downstream Transportation and Distribution: Emissions from the transport and distribution of sold goods after they leave the company, including delivery to end-users.
-
+  
   Downstream:
+	9.	Downstream Transportation and Distribution: Emissions from the transport and distribution of sold goods after they leave the company, including delivery to end-users.
 	10.	Processing of Sold Products: Emissions that occur when customers further process the sold products, such as refining crude oil sold by the company.
 	11.	Use of Sold Products: Emissions from the use of the company’s sold products, especially those that emit greenhouse gases during use, like fuels.
 	12.	End-of-Life Treatment of Sold Products: Emissions from the disposal or recycling of the company’s sold products after they’ve been used.

--- a/src/workers/nlmExtractTables.ts
+++ b/src/workers/nlmExtractTables.ts
@@ -40,7 +40,7 @@ const extractTextViaVisionAPI = async (
       },
       {
         role: 'user',
-        content: `I have a PDF with couple of tables related to a company's CO2 emissions. Can you extract the text from screenshot. I will send you the screenshot extract the header and table contents and ignore the surrounding text if they are not related to the tables/graphs (such as header, description, footnotes or disclaimers). Use Markdown format for the table(s), only reply with markdown. OK?`,
+        content: `I have a PDF with couple of tables related to a company's CO2 emissions. Can you extract the text from screenshot. I will send you the screenshot extract the header and table contents and ignore the surrounding text if they are not related to the tables/graphs (such as header, description, footnotes or disclaimers). For missing values or skipped cells, always use a placeholder like "n.a.". Use Markdown format for the table(s), only reply with markdown. OK?`,
       },
       {
         role: 'assistant',


### PR DESCRIPTION
🌍 Scope3 categories was only defined by word and garbo could use better information on what they really mean
🌍 Giving each category a bit of a definition and clearly separating what is upstream and downstream
👏 Big thanks to Alex for helping out with these definitions ⭐ 

📈 Another significant improvement is instructing our vision-GPT to consistently use placeholders like “n.a.” for any missing cells or values in tables. This ensures table alignment and prevents values from shifting into incorrect categories, which can otherwise lead to misinterpretations or inaccuracies. Previously, many cases where we assumed Garbo was not ready for calculations were actually due to misplaced values caused by gaps in the data. This change greatly enhances the reliability and accuracy of extracted table data.

🐛 We introduced a code smell in earlier PR that makes the industry adding fail, this has been fixed here ✅ 