### PR TITLE
Static e-tag for municipalities

### DIFF
--- a/src/api/routes/municipality.read.ts
+++ b/src/api/routes/municipality.read.ts
@@ -29,6 +29,14 @@ export async function municipalityReadRoutes(app: FastifyInstance) {
       },
     },
     async (request, reply) => {
+      const eTag = 'municipalities:etag'
+      const clientEtag = request.headers['if-none-match']
+
+      if (clientEtag === eTag) {
+        return reply.code(304).send()
+      }
+
+      reply.header('ETag', eTag)
       reply.send(municipalityService.getMunicipalities())
     }
   )


### PR DESCRIPTION
🌍 Let’s optimize data transfer by implementing an ETag for the getAllMunicipalities route.
🌍 Since the data is currently static, a simple static ETag without any time restriction should suffice for now.
🌍 In the future, when municipalities are stored in the database, we can revisit this and implement dynamic ETag generation based on data changes.