### PR TITLE
Add redis caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,25 @@ Get everything up and running with one command (with all output in one terminal)
 npm run dev
 ```
 
+#### 4) (Optional) Redis Insights
+
+a). **Start Redis Insight**  
+Run the following Docker command to start Redis Insight:
+
+docker run -d --name redisinsight -p 5540:5540 redislabs/redisinsight:latest
+
+---
+
+b). **Connect Redis Insight to Redis**
+
+- **Host**: `garbo_redis` (or the Redis container IP, e.g., `172.17.0.2`)
+- **Port**: `6379`
+- **Username**: Leave empty or use `default`.
+- **Password**: Leave empty.
+
+c). **Access Redis Insight**
+Go to [http://localhost:5540](http://localhost:5540) in your browser and add the Redis database using the above connection details.
+
 ### Setup completed 🎉
 
 Well done! You've now set up the `garbo` backend and are ready to start development :)

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "pdf2pic": "^3.1.3",
         "pino-http": "^10.4.0",
         "prisma-zod-generator": "^0.8.13",
+        "redis": "^4.7.0",
         "sharp": "^0.33.5",
         "tsx": "^4.19.2",
         "wikibase-sdk": "^10.2.1",
@@ -1510,6 +1511,65 @@
     "node_modules/@prisma/prisma-fmt-wasm": {
       "version": "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81",
       "license": "Apache-2.0"
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.0.tgz",
+      "integrity": "sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
     },
     "node_modules/@sapphire/async-queue": {
       "version": "1.5.3",
@@ -3136,6 +3196,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/get-caller-file": {
@@ -4922,6 +4991,23 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/redis": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.0.tgz",
+      "integrity": "sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.0",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
+      }
+    },
     "node_modules/redis-errors": {
       "version": "1.2.0",
       "license": "MIT",
@@ -5875,6 +5961,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "pdf2pic": "^3.1.3",
     "pino-http": "^10.4.0",
     "prisma-zod-generator": "^0.8.13",
+    "redis": "^4.7.0",
     "sharp": "^0.33.5",
     "tsx": "^4.19.2",
     "wikibase-sdk": "^10.2.1",

--- a/src/api/routes/company.delete.ts
+++ b/src/api/routes/company.delete.ts
@@ -14,7 +14,7 @@ import {
 } from '../schemas'
 import { getTags } from '../../config/openapi'
 import { GarboEntityId, WikidataIdParams } from '../types'
-import { eTagCache } from '../..'
+import { redisCache } from '../..'
 
 export async function companyDeleteRoutes(app: FastifyInstance) {
   app.delete(
@@ -36,7 +36,7 @@ export async function companyDeleteRoutes(app: FastifyInstance) {
       reply
     ) => {
       const { wikidataId } = request.params
-      eTagCache.clear()
+      redisCache.clear()
       await companyService.deleteCompany(wikidataId)
       reply.status(204).send()
     }
@@ -61,7 +61,7 @@ export async function companyDeleteRoutes(app: FastifyInstance) {
       reply
     ) => {
       const { id } = request.params
-      eTagCache.clear()
+      redisCache.clear()
       await goalService.deleteGoal(id)
       reply.status(204).send()
     }
@@ -86,7 +86,7 @@ export async function companyDeleteRoutes(app: FastifyInstance) {
       reply
     ) => {
       const { wikidataId } = request.params
-      eTagCache.clear()
+      redisCache.clear()
       await industryService.deleteIndustry(wikidataId)
       reply.status(204).send()
     }
@@ -110,7 +110,7 @@ export async function companyDeleteRoutes(app: FastifyInstance) {
       reply
     ) => {
       const { id } = req.params
-      eTagCache.clear()
+      redisCache.clear()
       await initiativeService.deleteInitiative(id)
       reply.code(204).send()
     }
@@ -135,7 +135,7 @@ export async function companyDeleteRoutes(app: FastifyInstance) {
       reply
     ) => {
       const { id } = request.params
-      eTagCache.clear()
+      redisCache.clear()
       await reportingPeriodService.deleteReportingPeriod(id)
       reply.code(204).send()
     }
@@ -160,7 +160,7 @@ export async function companyDeleteRoutes(app: FastifyInstance) {
       reply
     ) => {
       const { id } = request.params
-      eTagCache.clear()
+      redisCache.clear()
       await emissionsService.deleteStatedTotalEmissions(id)
       reply.code(204).send()
     }
@@ -185,7 +185,7 @@ export async function companyDeleteRoutes(app: FastifyInstance) {
       reply
     ) => {
       const { id } = request.params
-      eTagCache.clear()
+      redisCache.clear()
       await emissionsService.deleteBiogenicEmissions(id)
       reply.code(204).send()
     }
@@ -210,7 +210,7 @@ export async function companyDeleteRoutes(app: FastifyInstance) {
       reply
     ) => {
       const { id } = request.params
-      eTagCache.clear()
+      redisCache.clear()
       await emissionsService.deleteScope1(id)
       reply.code(204).send()
     }
@@ -235,7 +235,7 @@ export async function companyDeleteRoutes(app: FastifyInstance) {
       reply
     ) => {
       const { id } = request.params
-      eTagCache.clear()
+      redisCache.clear()
       await emissionsService.deleteScope1And2(id)
       reply.code(204).send()
     }
@@ -260,7 +260,7 @@ export async function companyDeleteRoutes(app: FastifyInstance) {
       reply
     ) => {
       const { id } = request.params
-      eTagCache.clear()
+      redisCache.clear()
       await emissionsService.deleteScope2(id)
       reply.code(204).send()
     }
@@ -285,7 +285,7 @@ export async function companyDeleteRoutes(app: FastifyInstance) {
       reply
     ) => {
       const { id } = request.params
-      eTagCache.clear()
+      redisCache.clear()
       await emissionsService.deleteScope3(id)
       reply.code(204).send()
     }
@@ -310,7 +310,7 @@ export async function companyDeleteRoutes(app: FastifyInstance) {
       reply
     ) => {
       const { id } = request.params
-      eTagCache.clear()
+      redisCache.clear()
       await emissionsService.deleteScope3Category(id)
       reply.code(204).send()
     }

--- a/src/api/routes/company.read.ts
+++ b/src/api/routes/company.read.ts
@@ -138,6 +138,7 @@ export async function companyReadRoutes(app: FastifyInstance) {
       const cacheKey = 'companies:etag'
 
       let currentEtag = await eTagCache.get(cacheKey)
+
       const latestMetadata = await prisma.metadata.findFirst({
         select: { updatedAt: true },
         orderBy: { updatedAt: 'desc' },

--- a/src/api/routes/company.read.ts
+++ b/src/api/routes/company.read.ts
@@ -136,7 +136,6 @@ export async function companyReadRoutes(app: FastifyInstance) {
     async (request, reply) => {
       const clientEtag = request.headers['if-none-match']
       const cacheKey = 'companies:etag'
-      const dataCacheKey = 'companies:data'
 
       let currentEtag = await redisCache.get(cacheKey)
 
@@ -153,6 +152,8 @@ export async function companyReadRoutes(app: FastifyInstance) {
       }
 
       if (clientEtag === currentEtag) return reply.code(304).send()
+
+      const dataCacheKey = `companies:data:${latestMetadataUpdatedAt}`
 
       let companies = await redisCache.get(dataCacheKey)
       if (companies) {

--- a/src/api/routes/company.read.ts
+++ b/src/api/routes/company.read.ts
@@ -156,6 +156,7 @@ export async function companyReadRoutes(app: FastifyInstance) {
       const dataCacheKey = `companies:data:${latestMetadataUpdatedAt}`
 
       let companies = await redisCache.get(dataCacheKey)
+
       if (companies) {
         companies = JSON.parse(companies)
       } else {

--- a/src/api/routes/municipality.read.ts
+++ b/src/api/routes/municipality.read.ts
@@ -10,6 +10,7 @@ import {
   MunicipalityNameParamSchema,
 } from '../schemas'
 import { municipalityService } from '../services/municipalityService'
+import { redisCache } from '../..'
 
 export async function municipalityReadRoutes(app: FastifyInstance) {
   app.register(cachePlugin)
@@ -20,7 +21,7 @@ export async function municipalityReadRoutes(app: FastifyInstance) {
       schema: {
         summary: 'Get all municipalities',
         description:
-          'Retrieve a list of all municipalities with data about their emissions, carbon budget, climate plans, bike infrastructure, procurements and much more.',
+          'Retrieve a list of all municipalities with data about their emissions, carbon budget, climate plans, bike infrastructure, procurements, and much more.',
         tags: getTags('Municipalities'),
 
         response: {
@@ -29,15 +30,24 @@ export async function municipalityReadRoutes(app: FastifyInstance) {
       },
     },
     async (request, reply) => {
-      const eTag = 'municipalities:etag'
+      const cacheKey = 'municipalities:data'
       const clientEtag = request.headers['if-none-match']
 
-      if (clientEtag === eTag) {
-        return reply.code(304).send()
+      const eTag = 'static-etag-for-municipalities'
+
+      if (clientEtag === eTag) return reply.code(304).send()
+
+      let municipalities = await redisCache.get(cacheKey)
+
+      if (municipalities) {
+        municipalities = JSON.parse(municipalities)
+      } else {
+        municipalities = municipalityService.getMunicipalities()
+        await redisCache.set(cacheKey, JSON.stringify(municipalities))
       }
 
       reply.header('ETag', eTag)
-      reply.send(municipalityService.getMunicipalities())
+      reply.send(municipalities)
     }
   )
 

--- a/src/api/schemas/response.ts
+++ b/src/api/schemas/response.ts
@@ -14,7 +14,9 @@ export const MetadataSchema = z.object({
     .nullable()
     .openapi({ description: 'Comment about the data' }),
   source: z.string().nullable().openapi({ description: 'Source of the data' }),
-  updatedAt: z.date().openapi({ description: 'Last update timestamp' }),
+  updatedAt: z
+    .union([z.date(), z.string()])
+    .openapi({ description: 'Last update timestamp' }),
   user: z.object({
     name: z
       .string()
@@ -224,9 +226,11 @@ export const InitiativeSchema = z.object({
 export const ReportingPeriodSchema = z.object({
   id: z.string(),
   startDate: z
-    .date()
+    .union([z.date(), z.string()])
     .openapi({ description: 'Start date of reporting period' }),
-  endDate: z.date().openapi({ description: 'End date of reporting period' }),
+  endDate: z
+    .union([z.date(), z.string()])
+    .openapi({ description: 'End date of reporting period' }),
   reportURL: z
     .string()
     .nullable()

--- a/src/api/schemas/response.ts
+++ b/src/api/schemas/response.ts
@@ -4,6 +4,13 @@ import { wikidataIdSchema } from './common'
 
 extendZodWithOpenApi(z)
 
+const dateStringSchema = z.union([
+  z.date(),
+  z.string().refine((val) => !isNaN(Date.parse(val)), {
+    message: 'Invalid date string',
+  }),
+])
+
 export const okResponseSchema = z.object({ ok: z.boolean() })
 export const emptyBodySchema = z.undefined()
 
@@ -14,9 +21,7 @@ export const MetadataSchema = z.object({
     .nullable()
     .openapi({ description: 'Comment about the data' }),
   source: z.string().nullable().openapi({ description: 'Source of the data' }),
-  updatedAt: z
-    .union([z.date(), z.string()])
-    .openapi({ description: 'Last update timestamp' }),
+  updatedAt: dateStringSchema.openapi({ description: 'Last update timestamp' }),
   user: z.object({
     name: z
       .string()
@@ -225,12 +230,12 @@ export const InitiativeSchema = z.object({
 
 export const ReportingPeriodSchema = z.object({
   id: z.string(),
-  startDate: z
-    .union([z.date(), z.string()])
-    .openapi({ description: 'Start date of reporting period' }),
-  endDate: z
-    .union([z.date(), z.string()])
-    .openapi({ description: 'End date of reporting period' }),
+  startDate: dateStringSchema.openapi({
+    description: 'Start date of reporting period',
+  }),
+  endDate: dateStringSchema.openapi({
+    description: 'End date of reporting period',
+  }),
   reportURL: z
     .string()
     .nullable()

--- a/src/createCache.ts
+++ b/src/createCache.ts
@@ -1,28 +1,33 @@
 import { createClient } from 'redis'
 import redisConfig from './config/redis'
 
+// Note: This prefix is a good seperator from the bullMQ jobs
+export const API_REDIS_PREFIX = 'redis_api/'
+
 const redis = createClient({ ...redisConfig })
 redis.connect()
 
 export function createServerCache({ maxAge }: { maxAge: number }) {
   return {
     async set(key: string, value: any) {
-      await redis.set(key, JSON.stringify(value), {
-        PX: maxAge,
-      })
+      const namespacedKey = `${API_REDIS_PREFIX}${key}`
+      await redis.set(namespacedKey, JSON.stringify(value), { PX: maxAge })
     },
     async get(key: string) {
-      const cached = await redis.get(key)
+      const namespacedKey = `${API_REDIS_PREFIX}${key}`
+      const cached = await redis.get(namespacedKey)
       return cached ? JSON.parse(cached) : null
     },
     async has(key: string) {
-      return (await redis.exists(key)) === 1
+      const namespacedKey = `${API_REDIS_PREFIX}${key}`
+      return (await redis.exists(namespacedKey)) === 1
     },
     async delete(key: string) {
-      await redis.del(key)
+      const namespacedKey = `${API_REDIS_PREFIX}${key}`
+      await redis.del(namespacedKey)
     },
     async clear() {
-      const keys = await redis.keys('*')
+      const keys = await redis.keys(`${API_REDIS_PREFIX}*`)
       if (keys.length > 0) await redis.del(keys)
     },
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import apiConfig from './config/api'
 import openAPIConfig from './config/openapi'
 import { createServerCache } from './createCache'
 
-export const eTagCache = createServerCache({ maxAge: 24 * 60 * 60 * 1000 })
+export const redisCache = createServerCache({ maxAge: 24 * 60 * 60 * 1000 })
 
 const { values } = parseArgs({
   options: {


### PR DESCRIPTION
#### Add Redis Caching

🌍  This PR introduces Redis-based caching for better performance and reduced database load.

Key Updates:
	🌍 Companies API: 
                 - Implements Redis cache with dynamic keys tied to latestMetadataUpdatedAt.
                 - Reduces redundant database queries by serving cached data when available.
	🌍 Municipalities API:
                 - Adds Redis cache with a static key since data is immutable.
                 - Enhances performance with faster responses for repeated requests.

Benefits:
        🌍 Optimized server performance.
	🌍 Simplified cache management with automatic invalidation for updates.
	🌍 Scalable design leveraging Redis.
	
🏠 Updated the readme with a quick setup for redis insight. Where you can inspect you redis data 

Testing:
	✅ Verified caching works for /companies and /municipalities APIs.
	✅ Ensured no impact on existing ETag implementation.