### PR TITLE
Fix schema fk for economy

### DIFF
--- a/prisma/migrations/20250127132445_remove_excesive_fk_for_economy/migration.sql
+++ b/prisma/migrations/20250127132445_remove_excesive_fk_for_economy/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `turnoverId` on the `Economy` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Economy" DROP COLUMN "turnoverId";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -256,7 +256,6 @@ model Economy {
   turnover        Turnover?
   employees       Employees?
   reportingPeriod ReportingPeriod? @relation(fields: [reportingPeriodId], references: [id], onDelete: Cascade)
-  turnoverId      String?
 }
 
 model Turnover {

--- a/src/api/services/reportingPeriodService.ts
+++ b/src/api/services/reportingPeriodService.ts
@@ -18,18 +18,23 @@ class ReportingPeriodService {
       year: string
     }
   ) {
-    const reportingPeriod = await prisma.reportingPeriod.findFirst({
-      where: {
-        companyId: company.wikidataId,
-        year,
-      },
-    })
-
     return prisma.reportingPeriod.upsert({
       where: {
-        id: reportingPeriod?.id ?? '',
+        companyId_year: {
+          companyId: company.wikidataId,
+          year,
+        },
       },
-      update: {},
+      update: {
+        startDate,
+        endDate,
+        reportURL,
+        metadata: {
+          connect: {
+            id: metadata.id,
+          },
+        },
+      },
       create: {
         startDate,
         endDate,


### PR DESCRIPTION
🌍 Removed redundant foreign key: Eliminated the excessive fkTurnoverId from the Economy schema since economyId already exists on the Turnover entity.

🌍 Fixed reporting period upsert bug: Simplified and corrected the logic for upsertReportingPeriod.