### PR TITLE
Add enum option to support tCO2 when tCO2e suffix is not available

### DIFF
--- a/src/api/schemas/common.ts
+++ b/src/api/schemas/common.ts
@@ -32,3 +32,5 @@ export function getErrorSchemas(...codes: ErrorCode[]) {
     return acc
   }, {} as Record<ErrorCode, typeof errorSchema>)
 }
+
+export const emissionUnitSchema = z.enum(['tCO2e', 'tCO2']).default('tCO2e')

--- a/src/api/schemas/common.ts
+++ b/src/api/schemas/common.ts
@@ -35,7 +35,7 @@ export function getErrorSchemas(...codes: ErrorCode[]) {
 
 const validEmissionsUnits = z.enum(['tCO2e', 'tCO2'])
 
-export const emissionUnitSchemaGarbo = validEmissionsUnits.nullable().optional()
+export const emissionUnitSchemaGarbo = validEmissionsUnits.nullable()
 
 export const emissionUnitSchemaWithDefault =
   validEmissionsUnits.default('tCO2e')

--- a/src/api/schemas/common.ts
+++ b/src/api/schemas/common.ts
@@ -33,4 +33,9 @@ export function getErrorSchemas(...codes: ErrorCode[]) {
   }, {} as Record<ErrorCode, typeof errorSchema>)
 }
 
-export const emissionUnitSchema = z.enum(['tCO2e', 'tCO2']).default('tCO2e')
+const validEmissionsUnits = z.enum(['tCO2e', 'tCO2'])
+
+export const emissionUnitSchemaGarbo = validEmissionsUnits.nullable().optional()
+
+export const emissionUnitSchemaWithDefault =
+  validEmissionsUnits.default('tCO2e')

--- a/src/api/schemas/request.ts
+++ b/src/api/schemas/request.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { wikidataIdSchema } from './common'
+import { emissionUnitSchema, wikidataIdSchema } from './common'
 
 const createMetadataSchema = z.object({
   metadata: z
@@ -74,7 +74,7 @@ export const postIndustrySchema = z
   .merge(createMetadataSchema)
 
 export const statedTotalEmissionsSchema = z
-  .object({ total: z.number(), unit: z.enum(['tCO2e', 'tCO2']) })
+  .object({ total: z.number(), unit: emissionUnitSchema })
   .optional()
 
 export const emissionsSchema = z
@@ -82,7 +82,7 @@ export const emissionsSchema = z
     scope1: z
       .object({
         total: z.number(),
-        unit: z.enum(['tCO2e', 'tCO2']),
+        unit: emissionUnitSchema,
       })
       .optional(),
     scope2: z
@@ -96,7 +96,7 @@ export const emissionsSchema = z
         unknown: z
           .number({ description: 'Unspecified Scope 2 emissions' })
           .optional(),
-        unit: z.enum(['tCO2e', 'tCO2']),
+        unit: emissionUnitSchema,
       })
       .optional(),
     scope3: z
@@ -106,7 +106,7 @@ export const emissionsSchema = z
             z.object({
               category: z.number().int().min(1).max(16),
               total: z.number(),
-              unit: z.enum(['tCO2e', 'tCO2']),
+              unit: emissionUnitSchema,
             })
           )
           .optional(),
@@ -114,11 +114,11 @@ export const emissionsSchema = z
       })
       .optional(),
     biogenic: z
-      .object({ total: z.number(), unit: z.enum(['tCO2e', 'tCO2']) })
+      .object({ total: z.number(), unit: emissionUnitSchema })
       .optional(),
     statedTotalEmissions: statedTotalEmissionsSchema,
     scope1And2: z
-      .object({ total: z.number(), unit: z.enum(['tCO2e', 'tCO2']) })
+      .object({ total: z.number(), unit: emissionUnitSchema })
       .optional(),
   })
   .optional()

--- a/src/api/schemas/request.ts
+++ b/src/api/schemas/request.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { emissionUnitSchema, wikidataIdSchema } from './common'
+import { emissionUnitSchemaWithDefault, wikidataIdSchema } from './common'
 
 const createMetadataSchema = z.object({
   metadata: z
@@ -74,7 +74,7 @@ export const postIndustrySchema = z
   .merge(createMetadataSchema)
 
 export const statedTotalEmissionsSchema = z
-  .object({ total: z.number(), unit: emissionUnitSchema })
+  .object({ total: z.number(), unit: emissionUnitSchemaWithDefault })
   .optional()
 
 export const emissionsSchema = z
@@ -82,7 +82,7 @@ export const emissionsSchema = z
     scope1: z
       .object({
         total: z.number(),
-        unit: emissionUnitSchema,
+        unit: emissionUnitSchemaWithDefault,
       })
       .optional(),
     scope2: z
@@ -96,8 +96,16 @@ export const emissionsSchema = z
         unknown: z
           .number({ description: 'Unspecified Scope 2 emissions' })
           .optional(),
-        unit: emissionUnitSchema,
+        unit: emissionUnitSchemaWithDefault,
       })
+      .refine(
+        ({ mb, lb, unknown }) =>
+          mb !== undefined || lb !== undefined || unknown !== undefined,
+        {
+          message:
+            'At least one property of `mb`, `lb` and `unknown` must be defined if scope2 is provided',
+        }
+      )
       .optional(),
     scope3: z
       .object({
@@ -106,7 +114,7 @@ export const emissionsSchema = z
             z.object({
               category: z.number().int().min(1).max(16),
               total: z.number(),
-              unit: emissionUnitSchema,
+              unit: emissionUnitSchemaWithDefault,
             })
           )
           .optional(),
@@ -114,11 +122,11 @@ export const emissionsSchema = z
       })
       .optional(),
     biogenic: z
-      .object({ total: z.number(), unit: emissionUnitSchema })
+      .object({ total: z.number(), unit: emissionUnitSchemaWithDefault })
       .optional(),
     statedTotalEmissions: statedTotalEmissionsSchema,
     scope1And2: z
-      .object({ total: z.number(), unit: emissionUnitSchema })
+      .object({ total: z.number(), unit: emissionUnitSchemaWithDefault })
       .optional(),
   })
   .optional()

--- a/src/api/schemas/request.ts
+++ b/src/api/schemas/request.ts
@@ -74,7 +74,7 @@ export const postIndustrySchema = z
   .merge(createMetadataSchema)
 
 export const statedTotalEmissionsSchema = z
-  .object({ total: z.number() })
+  .object({ total: z.number(), unit: z.enum(['tCO2e', 'tCO2']) })
   .optional()
 
 export const emissionsSchema = z
@@ -82,6 +82,7 @@ export const emissionsSchema = z
     scope1: z
       .object({
         total: z.number(),
+        unit: z.enum(['tCO2e', 'tCO2']),
       })
       .optional(),
     scope2: z
@@ -95,15 +96,8 @@ export const emissionsSchema = z
         unknown: z
           .number({ description: 'Unspecified Scope 2 emissions' })
           .optional(),
+        unit: z.enum(['tCO2e', 'tCO2']),
       })
-      .refine(
-        ({ mb, lb, unknown }) =>
-          mb !== undefined || lb !== undefined || unknown !== undefined,
-        {
-          message:
-            'At least one property of `mb`, `lb` and `unknown` must be defined if scope2 is provided',
-        }
-      )
       .optional(),
     scope3: z
       .object({
@@ -112,15 +106,20 @@ export const emissionsSchema = z
             z.object({
               category: z.number().int().min(1).max(16),
               total: z.number(),
+              unit: z.enum(['tCO2e', 'tCO2']),
             })
           )
           .optional(),
         statedTotalEmissions: statedTotalEmissionsSchema,
       })
       .optional(),
-    biogenic: z.object({ total: z.number() }).optional(),
+    biogenic: z
+      .object({ total: z.number(), unit: z.enum(['tCO2e', 'tCO2']) })
+      .optional(),
     statedTotalEmissions: statedTotalEmissionsSchema,
-    scope1And2: z.object({ total: z.number() }).optional(),
+    scope1And2: z
+      .object({ total: z.number(), unit: z.enum(['tCO2e', 'tCO2']) })
+      .optional(),
   })
   .optional()
 

--- a/src/api/services/companyService.ts
+++ b/src/api/services/companyService.ts
@@ -70,14 +70,14 @@ class CompanyService {
     metadata,
     turnover,
   }: {
-    economy: Economy
+    economy: DefaultEconomyType
     metadata: Metadata
     turnover: Partial<
       Omit<Turnover, 'id' | 'metadataId' | 'unit' | 'economyId'>
     >
   }) {
     return prisma.turnover.upsert({
-      where: { id: economy.turnoverId ?? '' },
+      where: { id: economy.turnover?.id ?? '' },
       create: {
         ...turnover,
         metadata: {

--- a/src/api/services/emissionsService.ts
+++ b/src/api/services/emissionsService.ts
@@ -12,7 +12,7 @@ import { DefaultEmissions } from '../types'
 import { prisma } from '../../lib/prisma'
 import { emissionsArgs } from '../args'
 
-const TONNES_CO2_UNIT = 'tCO2e'
+export const TONNES_CO2E_UNIT = 'tCO2e'
 
 class EmissionsService {
   async upsertEmissions({
@@ -38,7 +38,7 @@ class EmissionsService {
 
   async upsertScope1(
     emissions: DefaultEmissions,
-    scope1: Omit<Scope1, 'id' | 'metadataId' | 'unit' | 'emissionsId'>,
+    scope1: Omit<Scope1, 'id' | 'metadataId' | 'emissionsId'>,
     metadata: Metadata
   ) {
     const existingScope1Id = emissions.scope1?.id
@@ -59,7 +59,6 @@ class EmissionsService {
       : prisma.scope1.create({
           data: {
             ...scope1,
-            unit: TONNES_CO2_UNIT,
             metadata: {
               connect: {
                 id: metadata.id,
@@ -85,7 +84,9 @@ class EmissionsService {
       lb?: number
       mb?: number
       unknown?: number
+      unit: 'tCO2e' | 'tCO2'
     },
+
     metadata: Metadata
   ) {
     const existingScope2Id = emissions.scope2?.id
@@ -106,7 +107,6 @@ class EmissionsService {
       : prisma.scope2.create({
           data: {
             ...scope2,
-            unit: TONNES_CO2_UNIT,
             metadata: {
               connect: {
                 id: metadata.id,
@@ -128,7 +128,7 @@ class EmissionsService {
 
   async upsertScope1And2(
     emissions: DefaultEmissions,
-    scope1And2: Omit<Scope1And2, 'id' | 'metadataId' | 'unit' | 'emissionsId'>,
+    scope1And2: Omit<Scope1And2, 'id' | 'metadataId' | 'emissionsId'>,
     metadata: Metadata
   ) {
     const existingScope1And2Id = emissions.scope1And2?.id
@@ -149,7 +149,6 @@ class EmissionsService {
       : prisma.scope1And2.create({
           data: {
             ...scope1And2,
-            unit: TONNES_CO2_UNIT,
             metadata: {
               connect: {
                 id: metadata.id,
@@ -172,10 +171,10 @@ class EmissionsService {
   async upsertScope3(
     emissions: DefaultEmissions,
     scope3: {
-      categories?: { category: number; total: number }[]
+      categories?: { category: number; total: number; unit: string }[]
       statedTotalEmissions?: Omit<
         StatedTotalEmissions,
-        'id' | 'metadataId' | 'unit' | 'scope3Id' | 'emissionsId'
+        'id' | 'metadataId' | 'scope3Id' | 'emissionsId'
       >
     },
     createMetadata: () => Promise<Metadata>
@@ -236,7 +235,6 @@ class EmissionsService {
           },
           create: {
             ...scope3Category,
-            unit: TONNES_CO2_UNIT,
             scope3: {
               connect: {
                 id: updatedScope3.id,
@@ -274,7 +272,7 @@ class EmissionsService {
   async upsertBiogenic(
     emissions: DefaultEmissions,
     biogenic: OptionalNullable<
-      Omit<BiogenicEmissions, 'id' | 'metadataId' | 'unit' | 'emissionsId'>
+      Omit<BiogenicEmissions, 'id' | 'metadataId' | 'emissionsId'>
     >,
     metadata: Metadata
   ) {
@@ -298,7 +296,6 @@ class EmissionsService {
       : await prisma.biogenicEmissions.create({
           data: {
             ...biogenic,
-            unit: TONNES_CO2_UNIT,
             metadata: {
               connect: {
                 id: metadata.id,
@@ -323,7 +320,7 @@ class EmissionsService {
     metadata: Metadata,
     statedTotalEmissions?: Omit<
       StatedTotalEmissions,
-      'id' | 'metadataId' | 'unit' | 'scope3Id' | 'emissionsId'
+      'id' | 'metadataId' | 'scope3Id' | 'emissionsId'
     >,
     scope3?: Scope3 & { statedTotalEmissions: { id: string } | null }
   ) {
@@ -335,7 +332,7 @@ class EmissionsService {
       where: { id: statedTotalEmissionsId ?? '' },
       create: {
         ...statedTotalEmissions,
-        unit: TONNES_CO2_UNIT,
+        unit: statedTotalEmissions?.unit || TONNES_CO2E_UNIT,
         emissions: scope3
           ? undefined
           : {

--- a/src/api/services/emissionsService.ts
+++ b/src/api/services/emissionsService.ts
@@ -12,8 +12,6 @@ import { DefaultEmissions } from '../types'
 import { prisma } from '../../lib/prisma'
 import { emissionsArgs } from '../args'
 
-export const TONNES_CO2E_UNIT = 'tCO2e'
-
 class EmissionsService {
   async upsertEmissions({
     emissionsId,
@@ -318,7 +316,7 @@ class EmissionsService {
   async upsertStatedTotalEmissions(
     emissions: DefaultEmissions,
     metadata: Metadata,
-    statedTotalEmissions?: Omit<
+    statedTotalEmissions: Omit<
       StatedTotalEmissions,
       'id' | 'metadataId' | 'scope3Id' | 'emissionsId'
     >,
@@ -332,7 +330,6 @@ class EmissionsService {
       where: { id: statedTotalEmissionsId ?? '' },
       create: {
         ...statedTotalEmissions,
-        unit: statedTotalEmissions?.unit || TONNES_CO2E_UNIT,
         emissions: scope3
           ? undefined
           : {

--- a/src/prompts/followUp/biogenic.ts
+++ b/src/prompts/followUp/biogenic.ts
@@ -2,12 +2,16 @@ import { z } from 'zod'
 
 const schema = z.object({
   biogenic: z.array(
-    z.object({
-      year: z.number(),
-      biogenic: z
-        .object({ total: z.number(), unit: z.enum(['tCO2e', 'tCO2']) })
-        .optional(),
-    })
+    z
+      .object({
+        year: z.number(),
+        biogenic: z
+          .object({ total: z.number(), unit: z.enum(['tCO2e', 'tCO2']) })
+          .nullable()
+          .optional(),
+      })
+      .nullable()
+      .optional()
   ),
 })
 
@@ -31,7 +35,7 @@ NEVER CALCULATE ANY EMISSIONS. ONLY REPORT THE DATA AS IT IS IN THE PDF.
 
 
 
-If you can't find any information about biogenic emissions, report it as an empty array.
+If you can't find any information about biogenic emissions, report it as null.
 If you find biogenic emissions for some years but not for others, report the years you find and leave the others out.
 
 Json example:

--- a/src/prompts/followUp/biogenic.ts
+++ b/src/prompts/followUp/biogenic.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { emissionUnitSchema } from '../../api/schemas'
+import { emissionUnitSchemaGarbo } from '../../api/schemas'
 
 const schema = z.object({
   biogenic: z.array(
@@ -7,7 +7,7 @@ const schema = z.object({
       .object({
         year: z.number(),
         biogenic: z
-          .object({ total: z.number(), unit: emissionUnitSchema })
+          .object({ total: z.number(), unit: emissionUnitSchemaGarbo })
           .nullable()
           .optional(),
       })

--- a/src/prompts/followUp/biogenic.ts
+++ b/src/prompts/followUp/biogenic.ts
@@ -4,7 +4,9 @@ const schema = z.object({
   biogenic: z.array(
     z.object({
       year: z.number(),
-      biogenic: z.object({ total: z.number() }).optional(),
+      biogenic: z
+        .object({ total: z.number(), unit: z.enum(['tCO2e', 'tCO2']) })
+        .optional(),
     })
   ),
 })
@@ -12,9 +14,22 @@ const schema = z.object({
 const prompt = `BIOGENIC EMISSIONS
 Biogenic emissions are emissions from the combustion of biomass, not to be confused with fossil fuel emissions.
 
-Extract biogenic emissions according to the GHG protocol (CO2e). Include all years you can find and never exclude the latest year.
+Extract biogenic emissions according to the GHG protocol. Include all years you can find and never exclude the latest year.
 Always use tonnes CO2e as the unit, so if emissions are presented in other units (for example, in kilotonnes), convert this to tonnes.
 NEVER CALCULATE ANY EMISSIONS. ONLY REPORT THE DATA AS IT IS IN THE PDF.
+
+**Units**:
+- Always report emissions in metric tons (**tCO2e** or **tCO2**). The unit **tCO2e** (tons of CO2 equivalent) is preferred.
+- If a company explicitly reports emissions without the "e" suffix (e.g., **tCO2**), use **tCO2** as the unit. However, if no unit is specified or it is unclear, assume the unit is **tCO2e**.
+- All values must be converted to metric tons if they are provided in other units:
+  - Example: 
+    - 1000 CO2e → 1 tCO2e
+    - 1000 CO2 → 1 tCO2
+    - 1 kton CO2e → 1000 tCO2e
+    - 1 Mton CO2 → 1,000,000 tCO2
+- Use **tCO2** only if it is explicitly reported without the "e" suffix, otherwise default to **tCO2e**.
+
+
 
 If you can't find any information about biogenic emissions, report it as an empty array.
 If you find biogenic emissions for some years but not for others, report the years you find and leave the others out.
@@ -24,7 +39,9 @@ Json example:
   "biogenic": [{
     "year": 2021,
     "biogenic": {
-      "total: 12.3
+      "total: 12.3,
+      "unit": "tCO2e"
+      
     }
   }]
 }

--- a/src/prompts/followUp/biogenic.ts
+++ b/src/prompts/followUp/biogenic.ts
@@ -2,18 +2,21 @@ import { z } from 'zod'
 import { emissionUnitSchemaGarbo } from '../../api/schemas'
 
 const schema = z.object({
-  biogenic: z.array(
-    z
-      .object({
+  biogenic: z
+    .array(
+      z.object({
         year: z.number(),
         biogenic: z
-          .object({ total: z.number(), unit: emissionUnitSchemaGarbo })
+          .object({
+            total: z.number(),
+            unit: emissionUnitSchemaGarbo,
+          })
           .nullable()
           .optional(),
       })
-      .nullable()
-      .optional()
-  ),
+    )
+    .nullable()
+    .optional(),
 })
 
 const prompt = `BIOGENIC EMISSIONS

--- a/src/prompts/followUp/biogenic.ts
+++ b/src/prompts/followUp/biogenic.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { emissionUnitSchema } from '../../api/schemas'
 
 const schema = z.object({
   biogenic: z.array(
@@ -6,7 +7,7 @@ const schema = z.object({
       .object({
         year: z.number(),
         biogenic: z
-          .object({ total: z.number(), unit: z.enum(['tCO2e', 'tCO2']) })
+          .object({ total: z.number(), unit: emissionUnitSchema })
           .nullable()
           .optional(),
       })

--- a/src/prompts/followUp/scope12.ts
+++ b/src/prompts/followUp/scope12.ts
@@ -7,6 +7,7 @@ const schema = z.object({
       scope1: z
         .object({
           total: z.number(),
+          unit: z.enum(['tCO2e', 'tCO2']),
         })
         .nullable()
         .optional(),
@@ -24,15 +25,12 @@ const schema = z.object({
             .number({ description: 'Unspecified Scope 2 emissions' })
             .nullable()
             .optional(),
+          unit: z.enum(['tCO2e', 'tCO2']),
         })
-        .refine(
-          ({ mb, lb, unknown }) =>
-            mb !== undefined || lb !== undefined || unknown !== undefined,
-          {
-            message:
-              'At least one property of `mb`, `lb` and `unknown` must be defined if scope2 is provided',
-          }
-        )
+        .refine(({ mb, lb, unknown }) => mb || lb || unknown, {
+          message:
+            'At least one property of `mb`, `lb` and `unknown` must be defined if scope2 is provided',
+        })
         .nullable()
         .optional(),
     })
@@ -46,9 +44,17 @@ const prompt = `
 Extract scope 1 and 2 emissions according to the GHG protocol (CO2e). Include all years you can find and never exclude the latest year.
 Include market-based and location-based in scope 2. 
 
-Always use tonnes CO2e as the unit, so if emissions are presented in other units (for example, in kilotonnes), convert this to tonnes.
-- 1 kton → 1000 tCO2
-- 1 Mton → 1000000 tCO2
+**Units**:
+- Always report emissions in metric tons (**tCO2e** or **tCO2**). The unit **tCO2e** (tons of CO2 equivalent) is preferred.
+- If a company explicitly reports emissions without the "e" suffix (e.g., **tCO2**), use **tCO2** as the unit. However, if no unit is specified or it is unclear, assume the unit is **tCO2e**.
+- All values must be converted to metric tons if they are provided in other units:
+  - Example: 
+    - 1000 CO2e → 1 tCO2e
+    - 1000 CO2 → 1 tCO2
+    - 1 kton CO2e → 1000 tCO2e
+    - 1 Mton CO2 → 1,000,000 tCO2
+- Use **tCO2** only if it is explicitly reported without the "e" suffix, otherwise default to **tCO2e**.
+
 
 NEVER CALCULATE ANY EMISSIONS. ONLY REPORT THE DATA AS IT IS IN THE PDF. If you can't find any data or if you are uncertain, report it as null. Do not use markdown in the output.
 
@@ -58,12 +64,14 @@ This is only an example format; do not include this specific data in the output 
   "scope12": [{
     "year": 2023,
     "scope1": {
-      "total": 12.3
+      "total": 12.3,
+      "unit": "tCO2e"
     },
     "scope2": {
       "mb": 23.4,
       "lb": 34.5,
       "unknown": null
+      "unit": "tCO2e"
     }
   }]
 `

--- a/src/prompts/followUp/scope12.ts
+++ b/src/prompts/followUp/scope12.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { emissionUnitSchema } from '../../api/schemas'
 
 const schema = z.object({
   scope12: z.array(
@@ -7,7 +8,7 @@ const schema = z.object({
       scope1: z
         .object({
           total: z.number(),
-          unit: z.enum(['tCO2e', 'tCO2']),
+          unit: emissionUnitSchema,
         })
         .nullable()
         .optional(),
@@ -25,7 +26,7 @@ const schema = z.object({
             .number({ description: 'Unspecified Scope 2 emissions' })
             .nullable()
             .optional(),
-          unit: z.enum(['tCO2e', 'tCO2']),
+          unit: emissionUnitSchema,
         })
         .refine(({ mb, lb, unknown }) => mb || lb || unknown, {
           message:

--- a/src/prompts/followUp/scope12.ts
+++ b/src/prompts/followUp/scope12.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { emissionUnitSchema } from '../../api/schemas'
+import { emissionUnitSchemaGarbo } from '../../api/schemas'
 
 const schema = z.object({
   scope12: z.array(
@@ -8,7 +8,7 @@ const schema = z.object({
       scope1: z
         .object({
           total: z.number(),
-          unit: emissionUnitSchema,
+          unit: emissionUnitSchemaGarbo,
         })
         .nullable()
         .optional(),
@@ -26,7 +26,7 @@ const schema = z.object({
             .number({ description: 'Unspecified Scope 2 emissions' })
             .nullable()
             .optional(),
-          unit: emissionUnitSchema,
+          unit: emissionUnitSchemaGarbo,
         })
         .refine(({ mb, lb, unknown }) => mb || lb || unknown, {
           message:

--- a/src/prompts/followUp/scope3.ts
+++ b/src/prompts/followUp/scope3.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { emissionUnitSchema } from '../../api/schemas'
 
 export const schema = z.object({
   scope3: z.array(
@@ -11,13 +12,13 @@ export const schema = z.object({
               z.object({
                 category: z.number().int(),
                 total: z.number(),
-                unit: z.enum(['tCO2e', 'tCO2']),
+                unit: emissionUnitSchema,
               })
             )
             .nullable()
             .optional(),
           statedTotalEmissions: z
-            .object({ total: z.number(), unit: z.enum(['tCO2e', 'tCO2']) })
+            .object({ total: z.number(), unit: emissionUnitSchema })
             .nullable()
             .optional(),
         })

--- a/src/prompts/followUp/scope3.ts
+++ b/src/prompts/followUp/scope3.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { emissionUnitSchema } from '../../api/schemas'
+import { emissionUnitSchemaGarbo } from '../../api/schemas'
 
 export const schema = z.object({
   scope3: z.array(
@@ -12,13 +12,13 @@ export const schema = z.object({
               z.object({
                 category: z.number().int(),
                 total: z.number(),
-                unit: emissionUnitSchema,
+                unit: emissionUnitSchemaGarbo,
               })
             )
             .nullable()
             .optional(),
           statedTotalEmissions: z
-            .object({ total: z.number(), unit: emissionUnitSchema })
+            .object({ total: z.number(), unit: emissionUnitSchemaGarbo })
             .nullable()
             .optional(),
         })

--- a/src/prompts/followUp/scope3.ts
+++ b/src/prompts/followUp/scope3.ts
@@ -11,12 +11,13 @@ export const schema = z.object({
               z.object({
                 category: z.number().int(),
                 total: z.number(),
+                unit: z.enum(['tCO2e', 'tCO2']),
               })
             )
             .nullable()
             .optional(),
           statedTotalEmissions: z
-            .object({ total: z.number() })
+            .object({ total: z.number(), unit: z.enum(['tCO2e', 'tCO2']) })
             .nullable()
             .optional(),
         })
@@ -60,7 +61,15 @@ Extract scope 3 emissions according to the GHG Protocol and organize them by yea
 - Extract values only if explicitly available in the context. Do not infer or create data. Leave optional fields absent or explicitly set to null if no data is provided.
 
 3. **Units**:
-  Report all emissions in metric tons of CO2 equivalent. If the data is provided in a different unit (kton = 1000 tCO2, Mton = 1000000 tCO2), convert it. This is the only permitted calculation.
+- Always report emissions in metric tons (**tCO2e** or **tCO2**). The unit **tCO2e** (tons of CO2 equivalent) is preferred.
+- If a company explicitly reports emissions without the "e" suffix (e.g., **tCO2**), use **tCO2** as the unit. However, if no unit is specified or it is unclear, assume the unit is **tCO2e**.
+- All values must be converted to metric tons if they are provided in other units:
+  - Example: 
+    - 1000 CO2e → 1 tCO2e
+    - 1000 CO2 → 1 tCO2
+    - 1 kton CO2e → 1000 tCO2e
+    - 1 Mton CO2 → 1,000,000 tCO2
+- Use **tCO2** only if it is explicitly reported without the "e" suffix, otherwise default to **tCO2e**.
 
 4. **Financial Institutions**:
   If the company is a financial institution, look specifically for emissions data related to investments, portfolio, or financed emissions. These may be located in separate sections of the report.
@@ -81,12 +90,12 @@ Extract scope 3 emissions according to the GHG Protocol and organize them by yea
     "year": 2021,
     "scope3": {
       "categories": [
-        { "category": 1, "total": 10 },
-        { "category": 2, "total": 20 },
-        { "category": 3, "total": 40 },
-        { "category": 14, "total": 40 }
+        { "category": 1, "total": 10, "unit": "tCO2e" },
+        { "category": 2, "total": 20, "unit": "tCO2e" },
+        { "category": 3, "total": 40, "unit": "tCO2e" },
+        { "category": 14, "total": 40, "unit": "tCO2e" }
       ],
-      "statedTotalEmissions": { "total": 110 }
+      "statedTotalEmissions": { "total": 110, "unit": "tCO2e" }
     }
   },
   {


### PR DESCRIPTION
🌍 Updated schema to support both tCO2e (preferred) and tCO2 as valid units for emissions reporting.
🌍 Ensured tCO2 is only used when explicitly reported without the “e” suffix.
🌍 Included unit conversion for tCO2 and tCO2e to ensure all values are consistently reported in metric tons.

Closes #533 
Closes: #569 