### PR TITLE
Exclude Scope 3 Category 16 Emissions Unless Verified

### DIFF
--- a/src/api/routes/company.read.ts
+++ b/src/api/routes/company.read.ts
@@ -67,13 +67,19 @@ function addCalculatedTotalEmissions(companies: any[]) {
                       reportingPeriod.emissions.scope3.categories.some((c) =>
                         Boolean(c.metadata?.verifiedBy)
                       )
-                        ? reportingPeriod.emissions.scope3.categories.reduce(
-                            (total, category) =>
-                              isNumber(category.total)
-                                ? category.total + total
-                                : total,
-                            0
-                          )
+                        ? reportingPeriod.emissions.scope3.categories
+                            .filter(
+                              (category) =>
+                                category.category !== 16 ||
+                                Boolean(category.metadata?.verifiedBy)
+                            )
+                            .reduce(
+                              (total, category) =>
+                                isNumber(category.total)
+                                  ? category.total + total
+                                  : total,
+                              0
+                            )
                         : reportingPeriod.emissions.scope3.statedTotalEmissions
                             ?.total ?? 0,
                   }) ||


### PR DESCRIPTION
🌍 Updated calculatedTotalEmissions logic to exclude Scope 3 Category 16 (other) unless verified, ensuring invisible numbers do not affect calculations.

Closes #527