### PR TITLE
Add the ability to explicitly select the staging environment for sending reports.

### DIFF
--- a/src/api/services/municipalityService.ts
+++ b/src/api/services/municipalityService.ts
@@ -39,7 +39,13 @@ class MunicipalityService {
   }
 
   getMunicipalities(): Municipality[] {
-    return this.allMunicipalities
+    return this.allMunicipalities.map(
+      (municipality) =>
+        ({
+          ...municipality,
+          electricCarChangePercent: municipality.electricCarChangePercent * 100,
+        } satisfies Municipality)
+    )
   }
 
   getMunicipality(name: Municipality['name']): Municipality | null {

--- a/src/api/services/municipalityService.ts
+++ b/src/api/services/municipalityService.ts
@@ -39,13 +39,7 @@ class MunicipalityService {
   }
 
   getMunicipalities(): Municipality[] {
-    return this.allMunicipalities.map(
-      (municipality) =>
-        ({
-          ...municipality,
-          electricCarChangePercent: municipality.electricCarChangePercent * 100,
-        } satisfies Municipality)
-    )
+    return this.allMunicipalities
   }
 
   getMunicipality(name: Municipality['name']): Municipality | null {

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -34,6 +34,7 @@ const productionOrigins = [
   'https://beta.klimatkollen.se',
   'https://klimatkollen.se',
   'https://api.klimatkollen.se',
+  'https://stage-api.klimatkollen.se',
   'https://stage.klimatkollen.se',
 ] as const
 

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -29,13 +29,13 @@ const ONE_DAY = 1000 * 60 * 60 * 24
 const developmentOrigins = [
   'http://localhost:4321',
   'http://localhost:3000',
+  'https://stage-api.klimatkollen.se',
+  'https://stage.klimatkollen.se',
 ] as const
 const productionOrigins = [
   'https://beta.klimatkollen.se',
   'https://klimatkollen.se',
   'https://api.klimatkollen.se',
-  'https://stage-api.klimatkollen.se',
-  'https://stage.klimatkollen.se',
 ] as const
 
 const baseLoggerOptions: FastifyServerOptions['logger'] = {

--- a/src/discord/commands/pdfs.ts
+++ b/src/discord/commands/pdfs.ts
@@ -14,10 +14,17 @@ export default {
         .setDescription('URLs to PDF files. Separate with comma or new lines.')
         .setRequired(true)
     )
-    .setDescription(
-      'Skicka in en eller flera årsredovisningar och få tillbaka utsläppsdata.'
-    ),
-
+    .addStringOption((option) =>
+      option
+        .setName('environment')
+        .setDescription('Target environment: staging or production')
+        .setRequired(true)
+        .addChoices(
+          { name: 'Staging', value: 'staging' },
+          { name: 'Production', value: 'production' }
+        )
+    )
+    .setDescription('Submit PDFs for processing and emission extraction.'),
   async execute(interaction: ChatInputCommandInteraction) {
     try {
       await interaction.deferReply({ ephemeral: true })
@@ -44,6 +51,7 @@ export default {
       //   `Processing ${urls.length} PDFs...`
       // )
 
+      const environment = interaction.options.getString('environment', true)
       urls.forEach(async (url) => {
         const thread = await (
           interaction.channel as TextChannel
@@ -59,6 +67,7 @@ export default {
           {
             url: url.trim(),
             threadId: thread.id,
+            environment,
           },
           {
             backoff: {

--- a/src/lib/DiscordWorker.ts
+++ b/src/lib/DiscordWorker.ts
@@ -9,6 +9,7 @@ export class DiscordJob extends Job {
     threadId: string
     channelId: string
     messageId?: string
+    environment?: 'staging' | 'production'
   }
 
   message: any

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4,6 +4,7 @@ const GARBO_TOKEN = apiConfig.tokens.find((token) => token.startsWith('garbo'))
 
 export async function apiFetch(
   endpoint: string,
+  environment = 'production',
   { body, ...customConfig }: Omit<RequestInit, 'body'> & { body?: any } = {}
 ) {
   const headers = {
@@ -22,7 +23,11 @@ export async function apiFetch(
     config.body = typeof body !== 'string' ? JSON.stringify(body) : body
   }
 
-  const response = await fetch(`${apiConfig.baseURL}${endpoint}`, config)
+  const baseUrl =
+    environment === 'staging'
+      ? 'https://stage-api.klimatkollen.se/api'
+      : apiConfig.baseURL
+  const response = await fetch(`${baseUrl}${endpoint}`, config)
   if (response.ok) {
     return response.json()
   } else {

--- a/src/workers/checkDB.ts
+++ b/src/workers/checkDB.ts
@@ -26,6 +26,7 @@ const checkDB = new DiscordWorker('checkDB', async (job: CheckDBJob) => {
     wikidata,
     threadId,
     channelId,
+    environment,
   } = job.data
 
   const childrenValues = await job.getChildrenEntries()
@@ -54,7 +55,7 @@ const checkDB = new DiscordWorker('checkDB', async (job: CheckDBJob) => {
       metadata,
     }
 
-    await apiFetch(`/companies`, { body })
+    await apiFetch(`/companies`, job.data.environment, { body })
 
     await job.sendMessage(
       `✅ Företaget har skapats! Se resultatet här: ${getCompanyURL(
@@ -77,6 +78,7 @@ const checkDB = new DiscordWorker('checkDB', async (job: CheckDBJob) => {
       wikidata,
       threadId,
       channelId,
+      environment,
     },
     opts: {
       attempts: 3,

--- a/src/workers/saveToAPI.ts
+++ b/src/workers/saveToAPI.ts
@@ -26,6 +26,9 @@ export const saveToAPI = new DiscordWorker<SaveToApiJob>(
         body,
         apiSubEndpoint,
       } = job.data
+
+      console.log('job.data: saveToAPI', job.data)
+
       const wikidataId = wikidata.node
 
       // If approval is not required or already approved, proceed with saving
@@ -63,9 +66,13 @@ export const saveToAPI = new DiscordWorker<SaveToApiJob>(
 
       if (!requiresApproval || approved) {
         console.log(`Saving approved data for ${wikidataId} to API`)
-        await apiFetch(`/companies/${wikidataId}/${apiSubEndpoint}`, {
-          body: removeNullValuesFromGarbo(body),
-        })
+        await apiFetch(
+          `/companies/${wikidataId}/${apiSubEndpoint}`,
+          job.data.environment,
+          {
+            body: removeNullValuesFromGarbo(body),
+          }
+        )
         return { success: true }
       }
 


### PR DESCRIPTION
🌍 Added functionality to select the target environment (staging or production) for processing and saving reports directly from Discord commands.
🌍 Updated the apiFetch function to dynamically adjust the base URL based on the chosen environment, ensuring flexibility and accurate data routing.
🌍 Adjusted Discord job workflows to pass the selected environment throughout the process, enabling comprehensive testing in staging before production deployment.

⚠️ Would be cleaner to have the staging url as an env in berget, looking at that
