### PR TITLE
Fix authorization in saveBaseYearToApiScript

### DIFF
--- a/scripts/baseYearToAPi.ts
+++ b/scripts/baseYearToAPi.ts
@@ -23,7 +23,7 @@ async function updateBaseYear(wikidataId: string, baseYear: number) {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${tokens[0]}`,
+      Authorization: `Bearer ${tokens[1]}`,
     },
     body: JSON.stringify({
       baseYear,


### PR DESCRIPTION
- Super happy that we have a staging environment right now 🌎 
- Ran the script for the importBaseYearToApi and noticed that I added the wrong token in the request causing the baseyears to appear unverified. Fixed now 👍 