### PR TITLE
Fix: Invalid image url in staging

### DIFF
--- a/k8s/base/worker.yaml
+++ b/k8s/base/worker.yaml
@@ -16,11 +16,11 @@ spec:
         - image: ghcr.io/klimatbyran/garbo
           resources:
             limits:
-              cpu: 500m
-              memory: 512Mi
+              cpu: 1
+              memory: 2Gi
             requests:
-              cpu: 250m
-              memory: 256Mi
+              cpu: 500m
+              memory: 1Gi
           command: ['npm', 'run', 'workers']
           name: worker
           ports:

--- a/src/workers/nlmExtractTables.ts
+++ b/src/workers/nlmExtractTables.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs'
+import { readFileSync, statSync } from 'fs'
 import { UnrecoverableError } from 'bullmq'
 import path from 'path'
 import { mkdir } from 'fs/promises'
@@ -105,11 +105,14 @@ const nlmExtractTables = new DiscordWorker(
       const tables: { page_idx: number; markdown: string }[] =
         await pages.reduce(async (resultsPromise, { pageNumber, filename }) => {
           const results = await resultsPromise
+          if (statSync(filename).size === 0) {
+            console.warn(`⚠️ Skipping empty image: ${filename}`)
+            return results
+          }
           const lastPageMarkdown = results.at(-1)?.markdown || ''
-          const markdown = await extractTextViaVisionAPI(
-            { filename },
-            lastPageMarkdown
-          ) ?? "";
+          const markdown =
+            (await extractTextViaVisionAPI({ filename }, lastPageMarkdown)) ??
+            ''
           // TODO: Send to s3 bucket (images)
           return [
             ...results,
@@ -118,7 +121,7 @@ const nlmExtractTables = new DiscordWorker(
               markdown,
             },
           ]
-        }, Promise.resolve([] as {page_idx: number, markdown: string}[]))
+        }, Promise.resolve([] as { page_idx: number; markdown: string }[]))
 
       job.log('Extracted tables: ' + tables.map((t) => t.markdown).join(', '))
 


### PR DESCRIPTION
⚠️ In Garbo staging we got error: "Invalid image url"
🕵️ When logging the temp folder within the log i noticed that it contained some empty images.
💡 I added a safety check to not process empty images, I also added a log for observability
🤖 I doubled the resources for garbo workers ensuring that it is not resource constraint related error