### PR TITLE
Increase Parsing Workers to 10 & Reduce General Workers to 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We utilise an open source queue manager called BullMQ which relies on Redis. The
 
 ## Current Status
 
-Test the app in Discord channel #reports-to-check by using the command /pdf and Garbo will be answering with a parsed JSON
+Test the app in Discord channel #reports-to-check by using the command /pdf and Garbo will be answering with a parsed JSON.
 
 ## Data Flow
 

--- a/k8s/base/nlm-ingestor.yaml
+++ b/k8s/base/nlm-ingestor.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: nlm
 spec:
-  replicas: 1
+  replicas: 10
   selector:
     matchLabels:
       app: nlm

--- a/k8s/base/worker.yaml
+++ b/k8s/base/worker.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: worker
 spec:
-  replicas: 15
+  replicas: 5
   selector:
     matchLabels:
       app: worker


### PR DESCRIPTION
- We needed more nlm parsing strength in order to run many reports at the same time