### PR TITLE
fix: Handle API tokens and JWT tokens separately in auth plugin

### DIFF
--- a/src/api/plugins/auth.ts
+++ b/src/api/plugins/auth.ts
@@ -26,14 +26,19 @@ async function authPlugin(app: FastifyInstance) {
     try {
       const token = request.headers['authorization']?.replace('Bearer ', '')
 
-      if (!token || !apiConfig.tokens?.includes(token)) {
-        request.log.error('No token', {
-          token,
-          apiConfigTokens: apiConfig.tokens,
-        })
+      if (!token) {
+        request.log.error('No token provided')
         return reply.status(401).send(unauthorizedError)
       }
-
+      
+      // Check if it's a simple API token
+      if (apiConfig.tokens?.includes(token)) {
+        // For API tokens, we don't have user information
+        request.user = null
+        return
+      }
+      
+      // Otherwise, try to verify as JWT
       const { user, newToken } = authService.verifyUser(token)
 
       if (newToken !== undefined) {


### PR DESCRIPTION
After examining the code, I found the issue in the auth plugin. The problem is in how the token is being verified. The
code is trying to verify API tokens using JWT verification, but these appear to be two different authentication
mechanisms.

* Improved token verification logic by separating the handling of simple API tokens from JWT tokens.
* Added a check to see if the token is a simple API token and, if so, set `request.user` to null and return early.
* Simplified the error logging when no token is provided by removing unnecessary details.