### PR TITLE
Redo Migration Job for Garbo

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ npm run prisma migrate dev
 ### Optional: Restoring a database backup with test data
 
 > [!NOTE]
-> This step is very helpful to get a good starting point for developing and testing the frontend and/or the API. However, you may also skip it if you want to start with a clean database
+> This step is very helpful to get a good starting point for developing and testing the frontend and/or the API. However, you may also skip it if you want to start with a clean database.
 
 First, ask one of the Klimatkollen team members and they will send you a database backup.
 


### PR DESCRIPTION
- In [staging ](https://stage.klimatkollen.se/companies) we get the error: "Cannot read undefined of reportPeriod url"
- I restored the latest production backup of the data on my computer, noticed that the last two migrations seemed to be unapplied in production db. 
- These two might be correlated, so just in case we push this rc to make sure migration job finishes successfully 