### PR TITLE
Add /auth/token endpoint for service to exchange secret for api token

### DIFF
--- a/prisma/migrations/20250306091254_add_bot_flag_to_user_entity/migration.sql
+++ b/prisma/migrations/20250306091254_add_bot_flag_to_user_entity/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "bot" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -354,6 +354,7 @@ model User {
   name  String
   githubId   String? @unique
   githubImageUrl String?
+  bot   Boolean @default(false)
 
   // TODO: connect with github ID
   // TODO: store github profile image - or get it via API

--- a/src/api/routes/auth.ts
+++ b/src/api/routes/auth.ts
@@ -1,40 +1,62 @@
 import { FastifyInstance, FastifyRequest } from "fastify"
 import { getTags } from "../../config/openapi";
-import { authenticationBodySchema, AuthentificationResponseScheme, getErrorSchemas } from "../schemas";
-import { authenticationBody } from "../types";
+import { userAuthenticationBodySchema, AuthentificationResponseScheme, getErrorSchemas, serviceAuthenticationBodySchema } from "../schemas";
+import { userAuthenticationBody, serviceAuthenticationBody } from "../types";
 import { authService } from "../services/authService";
 
-const unauthorizedError = {
-    message: 'Unauthorized',
-  }
-  
-
 export async function authentificationRoutes(app: FastifyInstance) {
-    app.post(
-      '/github',
-      {
-        schema: {
-          summary: 'Auth User with Github Identity',
-          description: 'Authenticates a user using a Github access code',
-          tags: getTags('Auth'),
-          response: {
-            200: AuthentificationResponseScheme,
-            ...getErrorSchemas(401)
-          },
-          body: authenticationBodySchema
+  app.post(
+    '/github',
+    {
+      schema: {
+        summary: 'Auth User with Github Identity',
+        description: 'Authenticates a user using a Github access code',
+        tags: getTags('Auth'),
+        response: {
+          200: AuthentificationResponseScheme,
+          ...getErrorSchemas(401)
         },
+        body: userAuthenticationBodySchema
       },
-      async (
-        request: FastifyRequest<{Body: authenticationBody}>,
-        reply
-      ) => {
-        try {
-            const token = await authService.authUser(request.body.code);
-            reply.status(200).send({token});
-        } catch(error) {
-            console.log(error);
-            return reply.status(401).send()
-        }
+    },
+    async (
+      request: FastifyRequest<{Body: userAuthenticationBody}>,
+      reply
+    ) => {
+      try {
+          const token = await authService.authorizeUser(request.body.code);
+          reply.status(200).send({token});
+      } catch(error) {
+          console.log(error);
+          return reply.status(401).send()
       }
-    )
-  }
+    }
+  )
+  app.post(
+    '/token',
+    {
+      schema: {
+        summary: 'Auth Client with API Secret',
+        description: 'Authenticates a client using a service secret',
+        tags: getTags('Auth'),
+        response: {
+          200: AuthentificationResponseScheme,
+          ...getErrorSchemas(401)
+        },
+        body: serviceAuthenticationBodySchema
+      },
+    },
+    async (
+      request: FastifyRequest<{Body: serviceAuthenticationBody}>,
+      reply
+    ) => {
+      try {
+          const token = await authService.authorizeService(request.body);
+          reply.status(200).send({token});
+      } catch(error) {
+          console.log(error);
+          return reply.status(401).send()
+      }
+    }
+  )
+}

--- a/src/api/schemas/request.ts
+++ b/src/api/schemas/request.ts
@@ -190,6 +190,11 @@ export const MunicipalityNameParamSchema = z.object({
   name: MunicipalityNameSchema,
 })
 
-export const authenticationBodySchema = z.object({
+export const userAuthenticationBodySchema = z.object({
   code: z.string()
+})
+
+export const serviceAuthenticationBodySchema = z.object({
+  client_id: z.string(),
+  client_secret: z.string()
 })

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -34,6 +34,10 @@ export type MunicipalityNameParams = z.infer<
   typeof schemas.MunicipalityNameParamSchema
 >
 
-export type authenticationBody = z.infer<
-  typeof schemas.authenticationBodySchema
+export type userAuthenticationBody = z.infer<
+  typeof schemas.userAuthenticationBodySchema
+>
+
+export type serviceAuthenticationBody = z.infer<
+  typeof schemas.serviceAuthenticationBodySchema
 >

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -10,7 +10,7 @@ const envSchema = z.object({
    * Comma-separated list of API tokens. E.g. garbo:lk3h2k1,alex:ax32bg4
    * NOTE: This is only relevant during import with alex data, and then we switch to proper auth tokens.
    */
-  API_TOKENS: z.string().transform((tokens) => tokens.split(',')),
+  API_SECRET: z.string(),
   FRONTEND_URL: z
     .string()
     .default(
@@ -72,7 +72,7 @@ const apiConfig = {
       ? productionOrigins
       : developmentOrigins,
 
-  tokens: env.API_TOKENS,
+  secret: env.API_SECRET,
   frontendURL: env.FRONTEND_URL,
   baseURL: env.API_BASE_URL,
   port: env.PORT,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,23 @@
 import apiConfig from '../config/api'
 
-const GARBO_TOKEN = apiConfig.tokens.find((token) => token.startsWith('garbo'))
+const GARBO_TOKEN = await getApiToken(apiConfig.secret)
+
+async function getApiToken(secret: string) {
+  const response = await fetch(`${apiConfig.baseURL}/auth/token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      client_id: 'garbo',
+      client_secret: secret,
+    }),
+  })
+
+  const token = (await response.json()).token
+  console.log(token)
+  return token
+}
 
 export async function apiFetch(
   endpoint: string,


### PR DESCRIPTION
# Fix client missing client authentication
- Add /auth/token endpoint for services, users still use /auth/github to retrieve tokens
- Introduce a secret (stored as ENV variable `API_SECRET` currently)
- introduce `bot: boolean` field in User entity