### PR TITLE
Error handling in Wikipedia worker

### DIFF
--- a/src/lib/wikipedia.ts
+++ b/src/lib/wikipedia.ts
@@ -7,7 +7,7 @@ const bot = new mw({
     protocol: "https",
     server: wikipediaConfig.apiUrl,
     path: "/w",
-    debug: false, // Set to true for verbose logging
+    debug: true, // Set to true for verbose logging
     username: wikipediaConfig.wikiUsername,
     password: wikipediaConfig.wikiPassword,
     userAgent: 'GarboBot/1.0'
@@ -15,8 +15,11 @@ const bot = new mw({
 
 
 const login = async () => {
-    bot.logIn((err, data) => {
-        if (err) throw err
+    return new Promise((resolve, reject) => {
+        bot.logIn((err, data) => {
+            if (err) throw err
+            resolve(data)
+        })
     })
 }
 
@@ -62,7 +65,7 @@ export async function updateWikipediaContent(title: string, content: { text: str
 
     let contentToAdd: string = '\n\n<span id="klimatkollen-emissions-data">' + content.text + generateWikipediaReference(content.reportURL, title) + '</span>'
 
-    const $ = cheerio.load(existingText)
+    const $ = cheerio.load(existingText || "")
     const textExists = $('span#klimatkollen-emissions-data').length > 0
 
     if (!textExists) {


### PR DESCRIPTION
Solves #673 

Added error handling for:
- Non-existent Wikipedia pages
- Non-existent emissions

The though is that this can also be used as an entry point for prompting the user when implementing the validation tool.