### PR TITLE
#698 Decouple Garbo and Workers

### DIFF
--- a/src/discord/commands/pdfs.ts
+++ b/src/discord/commands/pdfs.ts
@@ -3,7 +3,7 @@ import {
   SlashCommandBuilder,
   TextChannel,
 } from 'discord.js'
-import nlmParsePDF from '../../workers/nlmParsePDF'
+import { queues } from '../../queues';
 import { DiscordJob } from '../../lib/DiscordWorker'
 
 export default {
@@ -63,7 +63,7 @@ export default {
 
         thread.send(`PDF i kö: ${url}`)
         thread.send(`Be användaren att verifiera data: ${autoApprove ? 'Nej' : 'Ja'}`)
-        nlmParsePDF.queue.add(
+        queues.nlmParsePDF.add(
           'download ' + url.slice(-20),
           {
             url: url.trim(),

--- a/src/lib/DiscordQueue.ts
+++ b/src/lib/DiscordQueue.ts
@@ -1,0 +1,30 @@
+import { Queue, QueueOptions } from 'bullmq';
+import redis from '../config/redis';
+
+export type DiscordJobData = {
+  url: string;
+  threadId: string;
+  channelId?: string;
+  messageId?: string;
+  autoApprove?: boolean;
+  [key: string]: any;
+};
+
+export class DiscordQueue {
+  queue: Queue;
+  
+  constructor(name: string, options?: QueueOptions) {
+    this.queue = new Queue(name, {
+      connection: redis,
+      ...options,
+    });
+  }
+  
+  async add(name: string, data: DiscordJobData, options?: any) {
+    return this.queue.add(name, data, options);
+  }
+  
+  async close() {
+    return this.queue.close();
+  }
+}

--- a/src/queues.ts
+++ b/src/queues.ts
@@ -3,9 +3,12 @@ import { DiscordQueue } from './lib/DiscordQueue'
 // Queue names as constants
 export const QUEUE_NAMES = {
   NLM_PARSE_PDF: 'nlmParsePDF',
-  INDEX_MARKDOWN: 'indexMarkdown',
   NLM_EXTRACT_TABLES: 'nlmExtractTables',
+  INDEX_MARKDOWN: 'indexMarkdown',
   PRECHECK: 'precheck',
+  GUESS_WIKIDATA: 'guessWikidata',
+  FOLLOW_UP: 'followUp',
+  EXTRACT_EMISSIONS: 'extractEmissions',
   CHECK_DB: 'checkDB',
   DIFF_BASE_YEAR: 'diffBaseYear',
   DIFF_GOALS: 'diffGoals',
@@ -13,9 +16,6 @@ export const QUEUE_NAMES = {
   DIFF_INITIATIVES: 'diffInitiatives',
   DIFF_REPORTING_PERIODS: 'diffReportingPeriods',
   DIFF_TAGS: 'diffTags',
-  EXTRACT_EMISSIONS: 'extractEmissions',
-  FOLLOW_UP: 'followUp',
-  GUESS_WIKIDATA: 'guessWikidata',
   SAVE_TO_API: 'saveToAPI',
   SEND_COMPANY_LINK: 'sendCompanyLink',
   WIKIPEDIA_UPLOAD: 'wikipediaUpload',

--- a/src/queues.ts
+++ b/src/queues.ts
@@ -1,0 +1,43 @@
+import { DiscordQueue } from './lib/DiscordQueue'
+
+// Queue names as constants
+export const QUEUE_NAMES = {
+  NLM_PARSE_PDF: 'nlmParsePDF',
+  INDEX_MARKDOWN: 'indexMarkdown',
+  NLM_EXTRACT_TABLES: 'nlmExtractTables',
+  PRECHECK: 'precheck',
+  CHECK_DB: 'checkDB',
+  DIFF_BASE_YEAR: 'diffBaseYear',
+  DIFF_GOALS: 'diffGoals',
+  DIFF_INDUSTRY: 'diffIndustry',
+  DIFF_INITIATIVES: 'diffInitiatives',
+  DIFF_REPORTING_PERIODS: 'diffReportingPeriods',
+  DIFF_TAGS: 'diffTags',
+  EXTRACT_EMISSIONS: 'extractEmissions',
+  FOLLOW_UP: 'followUp',
+  GUESS_WIKIDATA: 'guessWikidata',
+  SAVE_TO_API: 'saveToAPI',
+  SEND_COMPANY_LINK: 'sendCompanyLink',
+  WIKIPEDIA_UPLOAD: 'wikipediaUpload',
+}
+
+// Create queue clients (NOT workers)
+export const queues = {
+  nlmParsePDF: new DiscordQueue(QUEUE_NAMES.NLM_PARSE_PDF),
+  indexMarkdown: new DiscordQueue(QUEUE_NAMES.INDEX_MARKDOWN),
+  nlmExtractTables: new DiscordQueue(QUEUE_NAMES.NLM_EXTRACT_TABLES),
+  precheck: new DiscordQueue(QUEUE_NAMES.PRECHECK),
+  checkDB: new DiscordQueue(QUEUE_NAMES.CHECK_DB),
+  diffBaseYear: new DiscordQueue(QUEUE_NAMES.DIFF_BASE_YEAR),
+  diffGoals: new DiscordQueue(QUEUE_NAMES.DIFF_GOALS),
+  diffIndustry: new DiscordQueue(QUEUE_NAMES.DIFF_INDUSTRY),
+  diffInitiatives: new DiscordQueue(QUEUE_NAMES.DIFF_INITIATIVES),
+  diffReportingPeriods: new DiscordQueue(QUEUE_NAMES.DIFF_REPORTING_PERIODS),
+  diffTags: new DiscordQueue(QUEUE_NAMES.DIFF_TAGS),
+  extractEmissions: new DiscordQueue(QUEUE_NAMES.EXTRACT_EMISSIONS),
+  followUp: new DiscordQueue(QUEUE_NAMES.FOLLOW_UP),
+  guessWikidata: new DiscordQueue(QUEUE_NAMES.GUESS_WIKIDATA),
+  saveToAPI: new DiscordQueue(QUEUE_NAMES.SAVE_TO_API),
+  sendCompanyLink: new DiscordQueue(QUEUE_NAMES.SEND_COMPANY_LINK),
+  wikipediaUpload: new DiscordQueue(QUEUE_NAMES.WIKIPEDIA_UPLOAD),
+}

--- a/src/workers/checkDB.ts
+++ b/src/workers/checkDB.ts
@@ -103,7 +103,7 @@ const checkDB = new DiscordWorker(
   
     await flow.add({
       ...base,
-      queueName: 'sendCompanyLink',
+      queueName: QUEUE_NAMES.SEND_COMPANY_LINK,
       data: {
         ...base.data,
       },
@@ -111,7 +111,7 @@ const checkDB = new DiscordWorker(
         scope12 || scope3 || biogenic || economy
           ? {
               ...base,
-              queueName: 'diffReportingPeriods',
+              queueName: QUEUE_NAMES.DIFF_REPORTING_PERIODS,
               data: {
                 ...base.data,
                 scope12,
@@ -124,7 +124,7 @@ const checkDB = new DiscordWorker(
         industry
           ? {
               ...base,
-              queueName: 'diffIndustry',
+              queueName: QUEUE_NAMES.DIFF_INDUSTRY,
               data: {
                 ...base.data,
                 industry,
@@ -134,7 +134,7 @@ const checkDB = new DiscordWorker(
         goals
           ? {
               ...base,
-              queueName: 'diffGoals',
+              queueName: QUEUE_NAMES.DIFF_GOALS,
               data: {
                 ...base.data,
                 goals,
@@ -144,7 +144,7 @@ const checkDB = new DiscordWorker(
         baseYear
           ? {
               ...base,
-              queueName: 'diffBaseYear',
+              queueName: QUEUE_NAMES.DIFF_BASE_YEAR,
               data: {
                 ...base.data,
                 baseYear,
@@ -154,7 +154,7 @@ const checkDB = new DiscordWorker(
         initiatives
           ? {
               ...base,
-              queueName: 'diffInitiatives',
+              queueName: QUEUE_NAMES.DIFF_INITIATIVES,
               data: {
                 ...base.data,
                 initiatives,

--- a/src/workers/diffBaseYear.ts
+++ b/src/workers/diffBaseYear.ts
@@ -1,5 +1,6 @@
 import { DiscordJob, DiscordWorker } from '../lib/DiscordWorker'
 import { defaultMetadata, diffChanges } from '../lib/saveUtils'
+import { QUEUE_NAMES } from '../queues'
 import saveToAPI from './saveToAPI'
 
 export class DiffBaseYearJob extends DiscordJob {
@@ -12,7 +13,7 @@ export class DiffBaseYearJob extends DiscordJob {
 }
 
 const diffBaseYear = new DiscordWorker<DiffBaseYearJob>(
-  'diffBaseYear',
+  QUEUE_NAMES.DIFF_BASE_YEAR,
   async (job) => {
     const { url, companyName, existingCompany, baseYear } = job.data
     const metadata = defaultMetadata(url)

--- a/src/workers/diffGoals.ts
+++ b/src/workers/diffGoals.ts
@@ -1,5 +1,6 @@
 import { DiscordJob, DiscordWorker } from '../lib/DiscordWorker'
 import { defaultMetadata, diffChanges } from '../lib/saveUtils'
+import { QUEUE_NAMES } from '../queues'
 import saveToAPI from './saveToAPI'
 
 export class DiffGoalsJob extends DiscordJob {
@@ -16,9 +17,11 @@ export class DiffGoalsJob extends DiscordJob {
   }
 }
 
-const diffGoals = new DiscordWorker<DiffGoalsJob>('diffGoals', async (job) => {
-  const { url, companyName, existingCompany, goals } = job.data
-  const metadata = defaultMetadata(url)
+const diffGoals = new DiscordWorker<DiffGoalsJob>(
+  QUEUE_NAMES.DIFF_GOALS,
+  async (job) => {
+    const { url, companyName, existingCompany, goals } = job.data
+    const metadata = defaultMetadata(url)
 
   const body = {
     goals,

--- a/src/workers/diffIndustry.ts
+++ b/src/workers/diffIndustry.ts
@@ -1,5 +1,6 @@
 import { DiscordJob, DiscordWorker } from '../lib/DiscordWorker'
 import { defaultMetadata, diffChanges } from '../lib/saveUtils'
+import { QUEUE_NAMES } from '../queues'
 import saveToAPI from './saveToAPI'
 
 export class DiffIndustryJob extends DiscordJob {
@@ -12,7 +13,7 @@ export class DiffIndustryJob extends DiscordJob {
 }
 
 const diffIndustry = new DiscordWorker<DiffIndustryJob>(
-  'diffIndustry',
+  QUEUE_NAMES.DIFF_INDUSTRY,
   async (job) => {
     const { url, companyName, existingCompany, industry } = job.data
     const metadata = defaultMetadata(url)

--- a/src/workers/diffInitiatives.ts
+++ b/src/workers/diffInitiatives.ts
@@ -1,5 +1,6 @@
 import { DiscordJob, DiscordWorker } from '../lib/DiscordWorker'
 import { defaultMetadata, diffChanges } from '../lib/saveUtils'
+import { QUEUE_NAMES } from '../queues'
 import saveToAPI from './saveToAPI'
 
 export class DiffInitiativesJob extends DiscordJob {
@@ -17,7 +18,7 @@ export class DiffInitiativesJob extends DiscordJob {
 }
 
 const diffInitiatives = new DiscordWorker<DiffInitiativesJob>(
-  'diffInitiatives',
+  QUEUE_NAMES.DIFF_INITIATIVES,
   async (job) => {
     const { url, companyName, existingCompany, initiatives } = job.data
     const metadata = defaultMetadata(url)

--- a/src/workers/diffReportingPeriods.ts
+++ b/src/workers/diffReportingPeriods.ts
@@ -2,6 +2,7 @@ import { DiscordJob, DiscordWorker } from '../lib/DiscordWorker'
 import { defaultMetadata, diffChanges } from '../lib/saveUtils'
 import { getReportingPeriodDates } from '../lib/reportingPeriodDates'
 import saveToAPI from './saveToAPI'
+import { QUEUE_NAMES } from '../queues'
 
 export class DiffReportingPeriodsJob extends DiscordJob {
   declare data: DiscordJob['data'] & {
@@ -17,7 +18,7 @@ export class DiffReportingPeriodsJob extends DiscordJob {
 }
 
 const diffReportingPeriods = new DiscordWorker<DiffReportingPeriodsJob>(
-  'diffReportingPeriods',
+QUEUE_NAMES.DIFF_REPORTING_PERIODS,
   async (job) => {
     const {
       url,

--- a/src/workers/diffTags.ts
+++ b/src/workers/diffTags.ts
@@ -1,5 +1,6 @@
 import { DiscordJob, DiscordWorker } from '../lib/DiscordWorker'
 import { defaultMetadata, diffChanges } from '../lib/saveUtils'
+import { QUEUE_NAMES } from '../queues'
 import saveToAPI from './saveToAPI'
 
 export class DiffTagsJob extends DiscordJob {
@@ -12,7 +13,7 @@ export class DiffTagsJob extends DiscordJob {
 }
 
 const diffTags = new DiscordWorker<DiffTagsJob>(
-  'diffTags',
+  QUEUE_NAMES.DIFF_TAGS,
   async (job) => {
     const { url, companyName, existingCompany, tags } = job.data
     const metadata = defaultMetadata(url)

--- a/src/workers/extractEmissions.ts
+++ b/src/workers/extractEmissions.ts
@@ -24,7 +24,7 @@ const extractEmissions = new DiscordWorker<ExtractEmissionsJob>(
     const base = {
       name: companyName,
       data: { ...job.data, ...childrenValues },
-      queueName: 'followUp',
+      queueName: QUEUE_NAMES.FOLLOW_UP,
       opts: {
         attempts: 3,
       },
@@ -32,7 +32,7 @@ const extractEmissions = new DiscordWorker<ExtractEmissionsJob>(
 
     await flow.add({
       name: companyName,
-      queueName: 'checkDB',
+      queueName: QUEUE_NAMES.CHECK_DB,
       data: {
         ...base.data,
       },

--- a/src/workers/extractEmissions.ts
+++ b/src/workers/extractEmissions.ts
@@ -2,6 +2,7 @@ import { FlowProducer } from 'bullmq'
 import redis from '../config/redis'
 import { DiscordJob, DiscordWorker } from '../lib/DiscordWorker'
 import { JobType } from '../types'
+import { QUEUE_NAMES } from '../queues'
 
 class ExtractEmissionsJob extends DiscordJob {
   declare data: DiscordJob['data'] & {
@@ -13,7 +14,7 @@ class ExtractEmissionsJob extends DiscordJob {
 const flow = new FlowProducer({ connection: redis })
 
 const extractEmissions = new DiscordWorker<ExtractEmissionsJob>(
-  'extractEmissions',
+  QUEUE_NAMES.EXTRACT_EMISSIONS,
   async (job) => {
     const { companyName } = job.data
     job.sendMessage(`🤖 Hämtar utsläppsdata...`)

--- a/src/workers/followUp.ts
+++ b/src/workers/followUp.ts
@@ -5,6 +5,7 @@ import { ChatCompletionAssistantMessageParam, ChatCompletionSystemMessageParam, 
 import { zodResponseFormat } from 'openai/helpers/zod'
 import { resolve } from 'path'
 import { vectorDB } from '../lib/vectordb'
+import { QUEUE_NAMES } from '../queues'
 
 class FollowUpJob extends DiscordJob {
   declare data: DiscordJob['data'] & {
@@ -15,7 +16,7 @@ class FollowUpJob extends DiscordJob {
 }
 
 const followUp = new DiscordWorker<FollowUpJob>(
-  'followUp',
+  QUEUE_NAMES.FOLLOW_UP,
   async (job: FollowUpJob) => {
     const { type, url, previousAnswer } = job.data
     const {

--- a/src/workers/guessWikidata.ts
+++ b/src/workers/guessWikidata.ts
@@ -8,6 +8,7 @@ import wikidata, { Wikidata } from '../prompts/wikidata'
 import discord from '../discord'
 import apiConfig from '../config/api'
 import { ChatCompletionMessageParam } from 'openai/resources'
+import { QUEUE_NAMES } from '../queues'
 
 export class GuessWikidataJob extends DiscordJob {
   declare data: DiscordJob['data'] & {
@@ -32,7 +33,7 @@ const insignificantWords = new Set([
 ])
 
 const guessWikidata = new DiscordWorker<GuessWikidataJob>(
-  'guessWikidata',
+  QUEUE_NAMES.GUESS_WIKIDATA,
   async (job: GuessWikidataJob) => {
     const {
       companyName,

--- a/src/workers/indexMarkdown.ts
+++ b/src/workers/indexMarkdown.ts
@@ -1,11 +1,12 @@
 import config from '../config/chromadb'
 import { DiscordWorker, DiscordJob } from '../lib/DiscordWorker'
 import { vectorDB } from '../lib/vectordb'
+import { QUEUE_NAMES } from '../queues'
 
 class IndexMarkdownJob extends DiscordJob {}
 
 const indexMarkdown = new DiscordWorker(
-  'indexMarkdown',
+  QUEUE_NAMES.INDEX_MARKDOWN,
   async (job: IndexMarkdownJob) => {
     const { url } = job.data
     const childrenValues = await job.getChildrenEntries()

--- a/src/workers/nlmExtractTables.ts
+++ b/src/workers/nlmExtractTables.ts
@@ -8,6 +8,7 @@ import { extractTablesFromJson, fetchPdf } from '../lib/pdfTools'
 import { jsonToMarkdown } from '../lib/jsonExtraction'
 import { openai } from '../lib/openai'
 import { ParsedDocument } from '../lib/nlm-ingestor-schema'
+import { QUEUE_NAMES } from '../queues'
 
 class NLMExtractTablesJob extends DiscordJob {
   declare data: DiscordJob['data'] & {
@@ -82,7 +83,7 @@ const searchTerms = [
   'koldioxid',
 ]
 const nlmExtractTables = new DiscordWorker(
-  'nlmExtractTables',
+  QUEUE_NAMES.NLM_EXTRACT_TABLES,
   async (job: NLMExtractTablesJob) => {
     const { json, url } = job.data
     

--- a/src/workers/nlmParsePDF.ts
+++ b/src/workers/nlmParsePDF.ts
@@ -6,6 +6,7 @@ import precheck from './precheck'
 import { jsonToMarkdown } from '../lib/jsonExtraction'
 import { vectorDB } from '../lib/vectordb'
 import { ParsedDocument } from '../lib/nlm-ingestor-schema'
+import { QUEUE_NAMES } from '../queues'
 
 const headers = {
   'User-Agent':
@@ -15,7 +16,7 @@ const headers = {
 const flow = new FlowProducer({ connection: redis })
 
 const nlmParsePDF = new DiscordWorker(
-  'nlmParsePDF',
+  QUEUE_NAMES.NLM_PARSE_PDF,
   async (job) => {
     const { url } = job.data
 

--- a/src/workers/nlmParsePDF.ts
+++ b/src/workers/nlmParsePDF.ts
@@ -88,12 +88,12 @@ const nlmParsePDF = new DiscordWorker(
         const precheck = await flow.add({
           ...base,
           name: 'precheck ' + name,
-          queueName: 'precheck',
+          queueName: QUEUE_NAMES.PRECHECK,
           children: [
             {
               ...base,
               name: 'indexMarkdown ' + name,
-              queueName: 'indexMarkdown',
+              queueName: QUEUE_NAMES.INDEX_MARKDOWN,
               children: [
                 {
                   ...base,
@@ -103,7 +103,7 @@ const nlmParsePDF = new DiscordWorker(
                     json,
                   },
                   name: 'extractTables ' + name,
-                  queueName: 'nlmExtractTables',
+                  queueName: QUEUE_NAMES.NLM_EXTRACT_TABLES,
                 },
               ],
             },

--- a/src/workers/precheck.ts
+++ b/src/workers/precheck.ts
@@ -6,6 +6,7 @@ import { zodResponseFormat } from 'openai/helpers/zod'
 import { DiscordJob, DiscordWorker } from '../lib/DiscordWorker'
 import { JobType } from '../types'
 import { z } from 'zod'
+import { QUEUE_NAMES } from '../queues'
 
 class PrecheckJob extends DiscordJob {
   declare data: DiscordJob['data'] & {
@@ -21,124 +22,127 @@ const companyNameSchema = z.object({
   companyName: z.string().nullable(),
 })
 
-const precheck = new DiscordWorker('precheck', async (job: PrecheckJob) => {
-  const { cachedMarkdown, type, ...baseData } = job.data
-  const { markdown = cachedMarkdown } = await job.getChildrenEntries()
-
-  async function extractCompanyName(
-    markdown: string,
-    retry = 3,
-    start = 0,
-    chunkSize = 5000
-  ): Promise<string | null> {
-    if (retry <= 0 || start >= markdown.length) return null
-    const chunk = markdown.substring(start, start + chunkSize)
-    const response = await askStream(
-      [
+const precheck = new DiscordWorker(
+  QUEUE_NAMES.PRECHECK, 
+  async (job: PrecheckJob) => {
+    const { cachedMarkdown, type, ...baseData } = job.data
+    const { markdown = cachedMarkdown } = await job.getChildrenEntries()
+  
+    async function extractCompanyName(
+      markdown: string,
+      retry = 3,
+      start = 0,
+      chunkSize = 5000
+    ): Promise<string | null> {
+      if (retry <= 0 || start >= markdown.length) return null
+      const chunk = markdown.substring(start, start + chunkSize)
+      const response = await askStream(
+        [
+          {
+            role: 'user',
+            content: `What is the name of the company? Respond only with the company name, leave null if you cannot find it. We will search Wikidata for this name. The following is an extract from a PDF:
+            
+            ${chunk}
+            `,
+          },
+        ],
         {
-          role: 'user',
-          content: `What is the name of the company? Respond only with the company name, leave null if you cannot find it. We will search Wikidata for this name. The following is an extract from a PDF:
-          
-          ${chunk}
-          `,
-        },
-      ],
-      {
-        response_format: zodResponseFormat(
-          companyNameSchema,
-          `companyName-${retry}`
-        ),
-      }
-    ).then(JSON.parse)
-
-    const { companyName: rawName } = companyNameSchema.parse(response)
-    const companyName = rawName ? rawName.trim() : null
-
-    return (
-      companyName ||
-      extractCompanyName(markdown, retry - 1, start + chunkSize, chunkSize)
+          response_format: zodResponseFormat(
+            companyNameSchema,
+            `companyName-${retry}`
+          ),
+        }
+      ).then(JSON.parse)
+  
+      const { companyName: rawName } = companyNameSchema.parse(response)
+      const companyName = rawName ? rawName.trim() : null
+  
+      return (
+        companyName ||
+        extractCompanyName(markdown, retry - 1, start + chunkSize, chunkSize)
+      )
+    }
+  
+    const companyName = await extractCompanyName(markdown)
+  
+    if (!companyName) throw new Error('Could not find company name')
+  
+    job.log('Company name: ' + companyName)
+    await job.setThreadName(companyName)
+  
+    const description = await askPrompt(
+      `Du är en torr revisor som ska skriva en kort, objektiv beskrivning av företagets verksamhet.
+  
+  ** Beskrivning **
+  Följ dessa riktlinjer:
+  
+  1. Längd: Beskrivningen får inte överstiga 300 tecken, inklusive mellanslag.
+  2. Syfte: Endast företagets verksamhet ska beskrivas. Använd ett extra sakligt och neutralt språk.
+  3. Förbjudet innehåll (marknadsföring): VIKTIGT! Undvik ord som "ledande", "i framkant", "marknadsledare", "innovativt", "värdefull", "framgångsrik" eller liknande. Texten får INTE innehålla formuleringar som uppfattas som marknadsföring eller säljande språk.
+  4. Förbjudet innehåll (hållbarhet): VIKTIGT! Undvik ord som "hållbarhet", "klimat" eller liknande. Texten får INTE innehålla bedömningar av företagets hållbarhetsarbete.
+  5. Språk: VIKTIGT! Beskrivningen ska ENDAST vara på svenska. Om originaltexten är på engelska, översätt till svenska.
+  
+  För att säkerställa att svaret följer riktlinjerna, tänk på att:
+  
+  - Använd ett sakligt och neutralt språk.
+  - Aldrig använda marknadsförande eller värderande språk.
+  - Tydligt beskriva företagets verksamhet.
+  
+  Svara endast med företagets beskrivning. Lägg inte till andra instruktioner eller kommentarer.
+  
+  Exempel på svar: "AAK är ett företag som specialiserar sig på växtbaserade oljelösningar. Företaget erbjuder ett brett utbud av produkter och tjänster inom livsmedelsindustrin, inklusive specialfetter för choklad och konfektyr, mejeriprodukter, bageri och andra livsmedelsapplikationer."
+  
+  Följande är ett utdrag ur en PDF:`,
+      markdown.substring(0, 5000)
     )
-  }
-
-  const companyName = await extractCompanyName(markdown)
-
-  if (!companyName) throw new Error('Could not find company name')
-
-  job.log('Company name: ' + companyName)
-  await job.setThreadName(companyName)
-
-  const description = await askPrompt(
-    `Du är en torr revisor som ska skriva en kort, objektiv beskrivning av företagets verksamhet.
-
-** Beskrivning **
-Följ dessa riktlinjer:
-
-1. Längd: Beskrivningen får inte överstiga 300 tecken, inklusive mellanslag.
-2. Syfte: Endast företagets verksamhet ska beskrivas. Använd ett extra sakligt och neutralt språk.
-3. Förbjudet innehåll (marknadsföring): VIKTIGT! Undvik ord som "ledande", "i framkant", "marknadsledare", "innovativt", "värdefull", "framgångsrik" eller liknande. Texten får INTE innehålla formuleringar som uppfattas som marknadsföring eller säljande språk.
-4. Förbjudet innehåll (hållbarhet): VIKTIGT! Undvik ord som "hållbarhet", "klimat" eller liknande. Texten får INTE innehålla bedömningar av företagets hållbarhetsarbete.
-5. Språk: VIKTIGT! Beskrivningen ska ENDAST vara på svenska. Om originaltexten är på engelska, översätt till svenska.
-
-För att säkerställa att svaret följer riktlinjerna, tänk på att:
-
-- Använd ett sakligt och neutralt språk.
-- Aldrig använda marknadsförande eller värderande språk.
-- Tydligt beskriva företagets verksamhet.
-
-Svara endast med företagets beskrivning. Lägg inte till andra instruktioner eller kommentarer.
-
-Exempel på svar: "AAK är ett företag som specialiserar sig på växtbaserade oljelösningar. Företaget erbjuder ett brett utbud av produkter och tjänster inom livsmedelsindustrin, inklusive specialfetter för choklad och konfektyr, mejeriprodukter, bageri och andra livsmedelsapplikationer."
-
-Följande är ett utdrag ur en PDF:`,
-    markdown.substring(0, 5000)
-  )
-
-  const base = {
-    data: { ...baseData, companyName, description },
-    opts: {
-      attempts: 3,
-    },
-  }
-
-  job.log('Company description:\n' + description)
-
-  job.sendMessage('🤖 Ställer frågor om basfakta...')
-
-  try {
-    const extractEmissions = await flow.add({
-      name: 'precheck done ' + companyName,
-      queueName: 'extractEmissions', // this is where the result from the children will be sent
-      data: { ...base.data },
-      children: [
-        {
-          ...base,
-          name: 'guessWikidata ' + companyName,
-          queueName: 'guessWikidata',
-          data: {
-            ...base.data,
-            schema: zodResponseFormat(wikidata.schema, type),
-          },
-        },
-        {
-          ...base,
-          queueName: 'followUp',
-          name: 'fiscalYear ' + companyName,
-          data: {
-            ...base.data,
-            type: JobType.FiscalYear,
-          },
-        },
-      ],
+  
+    const base = {
+      data: { ...baseData, companyName, description },
       opts: {
         attempts: 3,
       },
-    })
-    return extractEmissions.job?.id
-  } catch (error) {
-    job.log('Error: ' + error)
-    job.editMessage('❌ Error: ' + error)
-    throw error
+    }
+  
+    job.log('Company description:\n' + description)
+  
+    job.sendMessage('🤖 Ställer frågor om basfakta...')
+  
+    try {
+      const extractEmissions = await flow.add({
+        name: 'precheck done ' + companyName,
+        queueName: 'extractEmissions', // this is where the result from the children will be sent
+        data: { ...base.data },
+        children: [
+          {
+            ...base,
+            name: 'guessWikidata ' + companyName,
+            queueName: 'guessWikidata',
+            data: {
+              ...base.data,
+              schema: zodResponseFormat(wikidata.schema, type),
+            },
+          },
+          {
+            ...base,
+            queueName: 'followUp',
+            name: 'fiscalYear ' + companyName,
+            data: {
+              ...base.data,
+              type: JobType.FiscalYear,
+            },
+          },
+        ],
+        opts: {
+          attempts: 3,
+        },
+      })
+      return extractEmissions.job?.id
+    } catch (error) {
+      job.log('Error: ' + error)
+      job.editMessage('❌ Error: ' + error)
+      throw error
+    }
   }
-})
+)
 
 export default precheck

--- a/src/workers/precheck.ts
+++ b/src/workers/precheck.ts
@@ -110,13 +110,13 @@ const precheck = new DiscordWorker(
     try {
       const extractEmissions = await flow.add({
         name: 'precheck done ' + companyName,
-        queueName: 'extractEmissions', // this is where the result from the children will be sent
+        queueName: QUEUE_NAMES.EXTRACT_EMISSIONS,
         data: { ...base.data },
         children: [
           {
             ...base,
             name: 'guessWikidata ' + companyName,
-            queueName: 'guessWikidata',
+            queueName: QUEUE_NAMES.GUESS_WIKIDATA,
             data: {
               ...base.data,
               schema: zodResponseFormat(wikidata.schema, type),
@@ -124,7 +124,7 @@ const precheck = new DiscordWorker(
           },
           {
             ...base,
-            queueName: 'followUp',
+            queueName: QUEUE_NAMES.FOLLOW_UP,
             name: 'fiscalYear ' + companyName,
             data: {
               ...base.data,

--- a/src/workers/saveToAPI.ts
+++ b/src/workers/saveToAPI.ts
@@ -3,6 +3,7 @@ import discord from '../discord'
 import apiConfig from '../config/api'
 import { apiFetch } from '../lib/api'
 import wikipediaUpload from './wikipediaUpload'
+import { QUEUE_NAMES } from '../queues'
 
 export interface SaveToApiJob extends DiscordJob {
   data: DiscordJob['data'] & {
@@ -17,7 +18,7 @@ export interface SaveToApiJob extends DiscordJob {
 }
 
 export const saveToAPI = new DiscordWorker<SaveToApiJob>(
-  'saveToAPI',
+  QUEUE_NAMES.SAVE_TO_API,
   async (job: SaveToApiJob) => {
     try {
       const {

--- a/src/workers/sendCompanyLink.ts
+++ b/src/workers/sendCompanyLink.ts
@@ -1,6 +1,7 @@
 import { DiscordJob, DiscordWorker } from '../lib/DiscordWorker'
 import { getCompanyURL } from '../lib/saveUtils'
 import { Wikidata } from '../prompts/wikidata'
+import { QUEUE_NAMES } from '../queues'
 
 export class SendCompanyLinkJob extends DiscordJob {
   declare data: DiscordJob['data'] & {
@@ -11,7 +12,7 @@ export class SendCompanyLinkJob extends DiscordJob {
 }
 
 const sendCompanyLink = new DiscordWorker<SendCompanyLinkJob>(
-  'sendCompanyLink',
+  QUEUE_NAMES.SEND_COMPANY_LINK,
   async (job) => {
     const { companyName, wikidata, existingCompany } = job.data
     const wikidataId = wikidata.node

--- a/src/workers/wikipediaUpload.ts
+++ b/src/workers/wikipediaUpload.ts
@@ -3,6 +3,7 @@ import { getWikipediaTitle } from '../lib/wikidata'
 import { generateWikipediaArticleText, updateWikipediaContent } from '../lib/wikipedia'
 import { Emissions } from '@prisma/client'
 import wikipediaConfig from '../config/wikipedia'
+import { QUEUE_NAMES } from '../queues'
 
 export class WikipediaUploadJob extends DiscordJob {
   declare data: DiscordJob['data'] & {
@@ -22,7 +23,7 @@ const checkEmissionsExist = (emissions: Emissions): boolean => {
 }
 
 const wikipediaUpload = new DiscordWorker<WikipediaUploadJob>(
-  'wikipediaUpload',
+  QUEUE_NAMES.WIKIPEDIA_UPLOAD,
   async (job) => {
     const {
       wikidata,


### PR DESCRIPTION
This completely splits the garbo part from the workers:
- introducing separate queues for garbo to use
- Introducing queue names used across queues and workers for type safety and limiting spelling errors