### PR TITLE
fix: do not hallucinate tables that arent there

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ prisma/generated
 *.db-journal
 *.pdf
 *.code-workspace
+
+# ignore secrets
+*secret*

--- a/src/prompts/followUp/scope12.ts
+++ b/src/prompts/followUp/scope12.ts
@@ -82,6 +82,21 @@ const queryTexts = [
   'Market-based and location-based emissions',
   'GHG protocol Scope 1 and 2 data',
   'carbon emissions CO2',
+  'CO2-eq',
+  'CO2 emissions',
+  'Scope 1 and 2',
+  'Scope 1',
+  'Scope 2',
+  'CO2e',
+  'tCO2e',
+  'GHG Protocol',
+  'emissions',
+  'carbon footprint',
+  'carbon accounting',
+  'carbon emissions',
+  'carbon emissions data',
+  'carbon emissions report',
+  'carbon emissions calculation',
 ]
 
 export default { prompt, schema, queryTexts }

--- a/src/workers/followUp.ts
+++ b/src/workers/followUp.ts
@@ -1,7 +1,11 @@
 import { askStream } from '../lib/openai'
 import { DiscordJob, DiscordWorker } from '../lib/DiscordWorker'
 import { JobType } from '../types'
-import { ChatCompletionAssistantMessageParam, ChatCompletionSystemMessageParam, ChatCompletionUserMessageParam } from 'openai/resources'
+import {
+  ChatCompletionAssistantMessageParam,
+  ChatCompletionSystemMessageParam,
+  ChatCompletionUserMessageParam,
+} from 'openai/resources'
 import { zodResponseFormat } from 'openai/helpers/zod'
 import { resolve } from 'path'
 import { vectorDB } from '../lib/vectordb'
@@ -22,7 +26,7 @@ const followUp = new DiscordWorker<FollowUpJob>(
       default: { schema, prompt, queryTexts },
     } = await import(resolve(import.meta.dirname, `../prompts/${type}`))
 
-    const markdown = await vectorDB.getRelevantMarkdown(url, queryTexts, 5)
+    const markdown = await vectorDB.getRelevantMarkdown(url, queryTexts, 15)
 
     job.log(`Reflecting on: ${prompt}
     
@@ -48,8 +52,14 @@ const followUp = new DiscordWorker<FollowUpJob>(
         } as ChatCompletionUserMessageParam,
         Array.isArray(job.stacktrace)
           ? [
-              { role: 'assistant' , content: previousAnswer } as ChatCompletionAssistantMessageParam,
-              { role: 'user', content: job.stacktrace.join('') } as ChatCompletionUserMessageParam,
+              {
+                role: 'assistant',
+                content: previousAnswer,
+              } as ChatCompletionAssistantMessageParam,
+              {
+                role: 'user',
+                content: job.stacktrace.join(''),
+              } as ChatCompletionUserMessageParam,
             ]
           : undefined,
       ]

--- a/src/workers/nlmExtractTables.ts
+++ b/src/workers/nlmExtractTables.ts
@@ -43,7 +43,7 @@ const extractTextViaVisionAPI = async (
       {
         role: 'assistant',
         content:
-          'Sure. Sounds good. Send the screenhot and I will extract the table(s) if there are any and return in markdown format as accurately as possible without any other comment.',
+          'Sure. Sounds good. Send the screenshot and I will extract the table(s) if there are any and return in markdown format as accurately as possible without any other comment.',
       },
       {
         role: 'user',

--- a/src/workers/nlmExtractTables.ts
+++ b/src/workers/nlmExtractTables.ts
@@ -38,17 +38,21 @@ const extractTextViaVisionAPI = async (
       },
       {
         role: 'user',
-        content: `I have a PDF with couple of tables related to a company's CO2 emissions. Can you extract the text from screenshot. I will send you the screenshot extract the header and table contents and ignore the surrounding text if they are not related to the tables/graphs (such as header, description, footnotes or disclaimers). For missing values or skipped cells, always use a placeholder like "n.a.". Use Markdown format for the table(s), only reply with markdown. OK?`,
+        content: `I have a PDF where I think there might be a couple of tables related to a company's CO2 emissions. Can you extract the text from screenshot if there are any? I will send you the screenshot extract the header and table contents and ignore the surrounding text if they are not related to the tables/graphs (such as header, illustrations, description, footnotes or disclaimers). For missing values or skipped cells, use a placeholder like "n.a.". Use Markdown format for the table(s), only reply with markdown. If there are no tables, just answer with an empty response. OK?`,
       },
       {
         role: 'assistant',
         content:
-          'Sure. Sounds good. Send the screenhot and I will extract the table(s) and return in markdown format as accurately as possible without any other comment.',
+          'Sure. Sounds good. Send the screenhot and I will extract the table(s) if there are any and return in markdown format as accurately as possible without any other comment.',
       },
       {
-        role: 'assistant',
+        role: 'user',
         content:
           'This is previous table extracted from previous pages:' + context,
+      },
+      {
+        role: 'assistant',
+        content: 'Thanks, noted. Lets look at the screenshot.',
       },
       {
         role: 'user',
@@ -66,6 +70,8 @@ const extractTextViaVisionAPI = async (
 
 const searchTerms = [
   'co2',
+  'co2e',
+  'co2 eq',
   'GHG',
   'turnover',
   'revenue',
@@ -85,7 +91,7 @@ const nlmExtractTables = new DiscordWorker(
   'nlmExtractTables',
   async (job: NLMExtractTablesJob) => {
     const { json, url } = job.data
-    
+
     job.sendMessage('🔍 Söker efter relevanta tabeller...')
 
     try {
@@ -93,7 +99,7 @@ const nlmExtractTables = new DiscordWorker(
       const outputDir = path.resolve('/tmp', 'garbo-screenshots')
       await mkdir(outputDir, { recursive: true })
       job.editMessage(`✅ PDF nedladdad!`)
-      
+
       job.log('Extracting pages...')
       const { pages } = await extractTablesFromJson(
         pdf,
@@ -107,7 +113,7 @@ const nlmExtractTables = new DiscordWorker(
       )
 
       job.log(`Extracted ${pages.length} pages. Extracting tables...`)
-      
+
       const tables: { page_idx: number; markdown: string }[] =
         await pages.reduce(async (resultsPromise, { pageNumber, filename }) => {
           const results = await resultsPromise


### PR DESCRIPTION
We had problems sometimes when we try to extract tables from a PDF where there might be a big picture on the page:

<img width="1331" alt="image" src="https://github.com/user-attachments/assets/66cc87a4-9da7-400b-bdae-00303a19a5bc" />

Which lead to this result- because the prompt told very specifically to always return a table with n.a. if there was no relevant data. This confuses Garbo later on in the process.
<img width="1124" alt="image" src="https://github.com/user-attachments/assets/cac28a30-e138-4737-93d2-d4434cb1e960" />
