### PR TITLE
[Fix] Changed verified metadata to use user id instead of the email

### DIFF
--- a/src/api/services/metadataService.ts
+++ b/src/api/services/metadataService.ts
@@ -23,7 +23,7 @@ class MetadataService {
         verifiedBy: verified
           ? {
               connect: {
-                email: user.email,
+                id: user.id,
               },
             }
           : undefined,


### PR DESCRIPTION
Fixes an issue in the updating/creating of reporting periods

As the email is not a unique identifier anymore, the creation of verified metadata failed, blocking the whole reporting period upsert.

Fix: Switched the use of email in the creation of verified metadata with the user id.