### PR TITLE
fix: retry creation of threads if they fail the first time. Continue …

### DIFF
--- a/src/discord/commands/pdfs.ts
+++ b/src/discord/commands/pdfs.ts
@@ -18,7 +18,7 @@ export default {
         .setDescription('URLs to PDF files. Separate with comma or new lines.')
         .setRequired(true)
     )
-    .addBooleanOption((option) => 
+    .addBooleanOption((option) =>
       option
         .setName('auto-approve')
         .setDescription('Automatically approve the extracted data.')
@@ -28,15 +28,16 @@ export default {
   async execute(interaction: ChatInputCommandInteraction) {
     try {
       await interaction.deferReply({ ephemeral: true })
-      
+
       const urls = interaction.options
         .getString('urls')
         ?.split(/\s*,\s*|\s+/)
         .map((url) => url.trim()) // Remove whitespace
         .filter(Boolean) // Remove empty strings
         .filter((url) => url.startsWith('http')) // Only allow URLs
-      
-      const autoApprove = interaction.options.getBoolean('auto-approve') || false
+
+      const autoApprove =
+        interaction.options.getBoolean('auto-approve') || false
 
       if (!urls || !urls.length) {
         await interaction.followUp({
@@ -52,15 +53,16 @@ export default {
         })
       }
 
-      urls.forEach(async (url) => {
-        const thread = await (
-          interaction.channel as TextChannel
-        ).threads.create({
-          name: url.slice(-20),
-          autoArchiveDuration: 1440,
-          //startMessage: message.id,
-        })
+      const processUrl = async (url: string): Promise<void> => {
+        try {
+          const thread = await (
+            interaction.channel as TextChannel
+          ).threads.create({
+            name: url.slice(-20),
+            autoArchiveDuration: 1440,
+          })
 
+<<<<<<< Updated upstream
         thread.send(`PDF i kö: ${url}`)
         thread.send(`Be användaren att verifiera data: ${autoApprove ? 'Nej' : 'Ja'}`)
         queues.nlmParsePDF.add(
@@ -79,6 +81,42 @@ export default {
           }
         )
       })
+=======
+          await thread.send(`PDF i kö: ${url}`)
+          await thread.send(
+            `Be användaren att verifiera data: ${autoApprove ? 'Nej' : 'Ja'}`
+          )
+          await nlmParsePDF.queue.add(
+            'download ' + url.slice(-20),
+            {
+              url: url.trim(),
+              threadId: thread.id,
+              autoApprove,
+            } as DiscordJob['data'],
+            {
+              backoff: {
+                type: 'fixed',
+                delay: 60_000,
+              },
+              attempts: 10,
+            }
+          )
+        } catch (error) {
+          console.error(`Error processing URL ${url}:`, error)
+          // Retry after a delay
+          await new Promise((resolve) => setTimeout(resolve, 5000))
+          return processUrl(url)
+        }
+      }
+
+      const processAllUrls = async (): Promise<void> => {
+        for (const url of urls) {
+          await processUrl(url)
+        }
+      }
+
+      await processAllUrls()
+>>>>>>> Stashed changes
     } catch (error) {
       console.error('Pdfs: error', error)
       try {

--- a/src/discord/commands/pdfs.ts
+++ b/src/discord/commands/pdfs.ts
@@ -3,7 +3,7 @@ import {
   SlashCommandBuilder,
   TextChannel,
 } from 'discord.js'
-import { queues } from '../../queues';
+import { queues } from '../../queues'
 import { DiscordJob } from '../../lib/DiscordWorker'
 
 export default {
@@ -62,31 +62,11 @@ export default {
             autoArchiveDuration: 1440,
           })
 
-<<<<<<< Updated upstream
-        thread.send(`PDF i kö: ${url}`)
-        thread.send(`Be användaren att verifiera data: ${autoApprove ? 'Nej' : 'Ja'}`)
-        queues.nlmParsePDF.add(
-          'download ' + url.slice(-20),
-          {
-            url: url.trim(),
-            threadId: thread.id,
-            autoApprove,
-          } as DiscordJob['data'],
-          {
-            backoff: {
-              type: 'fixed',
-              delay: 60_000,
-            },
-            attempts: 10,
-          }
-        )
-      })
-=======
           await thread.send(`PDF i kö: ${url}`)
           await thread.send(
             `Be användaren att verifiera data: ${autoApprove ? 'Nej' : 'Ja'}`
           )
-          await nlmParsePDF.queue.add(
+          await queues.nlmParsePDF.queue.add(
             'download ' + url.slice(-20),
             {
               url: url.trim(),
@@ -116,7 +96,6 @@ export default {
       }
 
       await processAllUrls()
->>>>>>> Stashed changes
     } catch (error) {
       console.error('Pdfs: error', error)
       try {


### PR DESCRIPTION
This pull request includes changes to the `src/discord/commands/pdfs.ts` file to improve error handling and processing of URLs. The most important changes include refactoring the URL processing logic into a separate function, adding error handling with retries, and ensuring all URLs are processed sequentially.

Improvements to URL processing:

* Refactored the URL processing logic into a separate function `processUrl` to improve code readability and maintainability.
* Added error handling within the `processUrl` function to catch and log errors, and implemented a retry mechanism with a delay.
* Introduced a new function `processAllUrls` to ensure all URLs are processed sequentially using the `processUrl` function.

Code formatting:

* Adjusted the formatting of the `autoApprove` variable assignment for better readability.…until all jobs are finished