### PR TITLE
Fix allow scope3 category value to be optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo",
-  "version": "3.18.4-rc.0",
+  "version": "3.18.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo",
-      "version": "3.18.4-rc.0",
+      "version": "3.18.4",
       "license": "MIT License",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garbo",
-  "version": "3.18.4-rc.0",
+  "version": "3.18.4",
   "description": "",
   "type": "module",
   "exports": {

--- a/src/api/schemas/request.ts
+++ b/src/api/schemas/request.ts
@@ -115,7 +115,7 @@ export const emissionsSchema = z
           .array(
             z.object({
               category: z.number().int().min(1).max(16),
-              total: z.number(),
+              total: z.number().optional(),
               unit: emissionUnitSchemaWithDefault,
               verified: z.boolean().optional(),
             })


### PR DESCRIPTION
That's currently preventing verifying scope 3 emissions without changing numbers