### PR TITLE
Fix editor scope 1 total

### DIFF
--- a/src/api/schemas/request.ts
+++ b/src/api/schemas/request.ts
@@ -81,7 +81,7 @@ export const emissionsSchema = z
   .object({
     scope1: z
       .object({
-        total: z.number(),
+        total: z.number().optional(),
         unit: emissionUnitSchemaWithDefault,
         verified: z.boolean().optional(),
       })


### PR DESCRIPTION
### Background

To allow validation of existing values without changing them, we need to make the request for scope 1 total be optional so the FE can just pass the verify to the BE.