### PR TITLE
Fixed bug caused by creating token with existing exp in body

### DIFF
--- a/src/api/plugins/auth.ts
+++ b/src/api/plugins/auth.ts
@@ -33,8 +33,9 @@ async function authPlugin(app: FastifyInstance) {
       if (newToken !== undefined) {
         reply.headers['x-auth-token'] = newToken
       }
-      request.user = user
+      request.user = user;
     } catch (err) {
+      console.log(err);
       request.log.error('Authentication failed:', err)
       return reply.status(401).send(unauthorizedError)
     }

--- a/src/api/services/authService.ts
+++ b/src/api/services/authService.ts
@@ -3,21 +3,13 @@ import apiConfig from "../../config/api"
 import { prisma } from "../../lib/prisma";
 import jwt from "jsonwebtoken";
 import { serviceAuthenticationBody } from "../types";
+import { User } from "@prisma/client";
 
 interface GithubUserinfo {
     login: string,
     avatar_url: string,
     name: string,
     email: string
-}
-
-interface User {
-    id: string,
-    name: string ,
-    email: string | null,
-    githubId: string | null,
-    githubImageUrl: string | null
-    bot: boolean
 }
 
 class AuthService {
@@ -112,15 +104,16 @@ class AuthService {
     private static readonly SECONDS_IN_A_MINUTE = 60;
 
     verifyToken(token: string) {
-        const user = jwt.verify(token, apiConfig.jwtSecret) as User & {exp: number};
-        if (!user.email && !user.githubId) {
+        const userPayload = jwt.verify(token, apiConfig.jwtSecret) as User & {exp: number};
+        if (!userPayload.email && !userPayload.githubId) {
             throw new Error("Invalid token: No email or GitHub ID present");
         }
         const currentTimeInSeconds = Date.now() / 1000;
         const renewalThreshold = AuthService.TOKEN_EXPIRY_BUFFER_MINUTES * AuthService.SECONDS_IN_A_MINUTE;
 
-        const shouldRenew = currentTimeInSeconds > user.exp - renewalThreshold;
+        const shouldRenew = currentTimeInSeconds > userPayload.exp - renewalThreshold;
 
+        const {exp, ...user} = userPayload;
         return {
             user, 
             newToken: shouldRenew ? this.createToken(user) : undefined


### PR DESCRIPTION
The bug was caused due to the token refresh mechanism creating a new token if the token is valid for less than 15min.
In the creation the payload contained the old expire time and the jwt token creation tried adding a new expire time which caused an error.

Solution: Removing the exp property from the token payload before passing it to the creation function.

Closes #808 