### PR TITLE
[836] Route for Industry codes

### DIFF
--- a/src/api/routes/industryGics.read.ts
+++ b/src/api/routes/industryGics.read.ts
@@ -3,11 +3,11 @@ import fs from 'fs/promises'
 import path from 'path'
 
 export async function industryGicsRoute(app: FastifyInstance) {
-  app.get('/industry-gics', async (_request, reply) => {
+  app.get('/', async (_request, reply) => {
     const filePath = path.join(__dirname, '../../output/en/industry-gics.json')
     try {
       const data = await fs.readFile(filePath, 'utf-8')
-      reply.header('Content-Type', 'application/json').send(JSON.parse(data))
+      reply.send(JSON.parse(data))
     } catch (err) {
       reply.status(500).send({ error: 'Could not load industry GICS data' })
     }

--- a/src/app.ts
+++ b/src/app.ts
@@ -129,7 +129,6 @@ async function publicContext(app: FastifyInstance) {
     prefix: 'api/reporting-period',
   })
   app.register(mailingListDownloadsRoute, { prefix: 'api' })
-
 }
 
 /**
@@ -149,8 +148,10 @@ async function authenticatedContext(app: FastifyInstance) {
   app.register(validationsReadRoutes, { prefix: 'api/validation' })
   app.register(validationsUpdateRoutes, { prefix: 'api/validation' })
 
-  app.register(emissionsAssessmentRoutes, { prefix: 'api/emissions-assessment' })
-  app.register(industryGicsRoute, { prefix: 'api' })
+  app.register(emissionsAssessmentRoutes, {
+    prefix: 'api/emissions-assessment',
+  })
+  app.register(industryGicsRoute, { prefix: 'api/industry-gics' })
 }
 
 export default startApp

--- a/src/config/mailchimp.ts
+++ b/src/config/mailchimp.ts
@@ -2,9 +2,9 @@ import 'dotenv/config'
 import { z } from 'zod'
 
 const envSchema = z.object({
-  MAILCHIMP_API_KEY: z.string(),
-  MAILCHIMP_SERVER_PREFIX: z.string(),
-  MAILCHIMP_LIST_ID: z.string(),
+  MAILCHIMP_API_KEY: z.string().optional(),
+  MAILCHIMP_SERVER_PREFIX: z.string().optional(),
+  MAILCHIMP_LIST_ID: z.string().optional(),
 })
 
 const env = envSchema.parse(process.env)


### PR DESCRIPTION
### Background
We're adding support to change the industry in the editor on the FE, to make it easier for the user I want to get a list of possible industry gics from the BE for a drop down list rather than have a static list on the FE. 

### What changed
Add new read only route that fetches the generated json list of english industry gic codes for the editor. Atm have it only for authenticated users as this is for an internal tool. 