### PR TITLE
Revert "[feat] update municipality consumption emissions with 2023 entry"

### DIFF
--- a/src/data/climate-data.json
+++ b/src/data/climate-data.json
@@ -102,7 +102,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Klimatstrategi 2030",
     "bicycleMetrePerCapita": 2.83,
-    "totalConsumptionEmission": 5.81,
+    "totalConsumptionEmission": 5.58,
     "electricVehiclePerChargePoints": 73.0,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1x27RSR7W9aNADMMXb5BQyeVPViE00CpT/view?usp=drive_link"
@@ -210,7 +210,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Klimatstrategi 2022–2030",
     "bicycleMetrePerCapita": 2.89,
-    "totalConsumptionEmission": 5.76,
+    "totalConsumptionEmission": 5.53,
     "electricVehiclePerChargePoints": 54.43,
     "procurementScore": "0",
     "procurementLink": ""
@@ -318,7 +318,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Energi– och klimatplan planerad hösten 2023.",
     "bicycleMetrePerCapita": 3.36,
-    "totalConsumptionEmission": 5.39,
+    "totalConsumptionEmission": 5.16,
     "electricVehiclePerChargePoints": 15.27,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1uLhQvzq-4bEGVlrMmmoymzKxTx_4FaLw/view?usp=drive_link"
@@ -426,7 +426,7 @@
     "climatePlanYear": 2011,
     "climatePlanComment": "Miljömål 2011–2025",
     "bicycleMetrePerCapita": 2.67,
-    "totalConsumptionEmission": 5.48,
+    "totalConsumptionEmission": 5.25,
     "electricVehiclePerChargePoints": 3.22,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1TvoNPoKFN-r1wsEhMRKoeHXgxILwZb2U/view?usp=drive_link"
@@ -534,7 +534,7 @@
     "climatePlanYear": 2009,
     "climatePlanComment": "Energi- och klimatstrategi antagen år 2009, vilken beskriver energiläget och befintliga utsläpp av växthusgaser, den innehåller också övergripande mål och strategier.",
     "bicycleMetrePerCapita": 3.31,
-    "totalConsumptionEmission": 5.67,
+    "totalConsumptionEmission": 5.48,
     "electricVehiclePerChargePoints": 9.67,
     "procurementScore": "2",
     "procurementLink": "https://docs.google.com/document/d/1iEXfZZiEl5LSZsNl-A5gCSyRqNU36C2V/edit?usp=drive_link&ouid=104089955738391943844&rtpof=true&sd=true"
@@ -642,7 +642,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 2.42,
-    "totalConsumptionEmission": 5.69,
+    "totalConsumptionEmission": 5.42,
     "electricVehiclePerChargePoints": 2.56,
     "procurementScore": "0",
     "procurementLink": ""
@@ -750,7 +750,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Arbetet väntas slutföras under 2024.",
     "bicycleMetrePerCapita": 3.59,
-    "totalConsumptionEmission": 5.23,
+    "totalConsumptionEmission": 5.16,
     "electricVehiclePerChargePoints": 4.7,
     "procurementScore": "1",
     "procurementLink": ""
@@ -858,7 +858,7 @@
     "climatePlanYear": 2024,
     "climatePlanComment": "Strategisk plan 2024-2028",
     "bicycleMetrePerCapita": 2.07,
-    "totalConsumptionEmission": 5.47,
+    "totalConsumptionEmission": 5.28,
     "electricVehiclePerChargePoints": 21.89,
     "procurementScore": "0",
     "procurementLink": ""
@@ -966,7 +966,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Ekologiskt hållbarhetsprogram 2022–2025.",
     "bicycleMetrePerCapita": 2.96,
-    "totalConsumptionEmission": 5.59,
+    "totalConsumptionEmission": 5.43,
     "electricVehiclePerChargePoints": 5.62,
     "procurementScore": "0",
     "procurementLink": ""
@@ -1074,7 +1074,7 @@
     "climatePlanYear": 2020,
     "climatePlanComment": "Hållbarhetsprogram 2020–2030.",
     "bicycleMetrePerCapita": 2.98,
-    "totalConsumptionEmission": 5.84,
+    "totalConsumptionEmission": 5.7,
     "electricVehiclePerChargePoints": 23.53,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1jTFL_NGHLfw6GEv8l2OV7i8VJfnmi5Y_/view?usp=drive_link"
@@ -1182,7 +1182,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 3.4,
-    "totalConsumptionEmission": 5.3,
+    "totalConsumptionEmission": 5.09,
     "electricVehiclePerChargePoints": 14.06,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/12cQAQ6TVcfe_rCZEkuDO0uXLCtBwJDex/view?usp=drive_link"
@@ -1290,7 +1290,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Miljöprogram 2040",
     "bicycleMetrePerCapita": 2.64,
-    "totalConsumptionEmission": 5.44,
+    "totalConsumptionEmission": 5.27,
     "electricVehiclePerChargePoints": 1.34,
     "procurementScore": "0",
     "procurementLink": ""
@@ -1398,7 +1398,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Handlingsplan för fossilfria transporter",
     "bicycleMetrePerCapita": 1.77,
-    "totalConsumptionEmission": 5.44,
+    "totalConsumptionEmission": 5.31,
     "electricVehiclePerChargePoints": null,
     "procurementScore": "0",
     "procurementLink": ""
@@ -1506,7 +1506,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 3.32,
-    "totalConsumptionEmission": 5.48,
+    "totalConsumptionEmission": 5.29,
     "electricVehiclePerChargePoints": 55.12,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1w-XpLcjZch_a49jJyc65AJSYXjl6kOfM/view?usp=sharing"
@@ -1614,7 +1614,7 @@
     "climatePlanYear": 2018,
     "climatePlanComment": "Borgmästaravtalet. Kommunen jobbar med uppdatering av planen.",
     "bicycleMetrePerCapita": 4.29,
-    "totalConsumptionEmission": 6.72,
+    "totalConsumptionEmission": 6.57,
     "electricVehiclePerChargePoints": 7.24,
     "procurementScore": "0",
     "procurementLink": ""
@@ -1722,7 +1722,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 2.13,
-    "totalConsumptionEmission": 5.82,
+    "totalConsumptionEmission": 5.61,
     "electricVehiclePerChargePoints": 257.0,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/drive/u/0/folders/1W0ikrmofAruq9lzl1j562VHonpwsK4rB"
@@ -1830,7 +1830,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Program för ekologisk hållbarhet 2021–2026",
     "bicycleMetrePerCapita": 2.73,
-    "totalConsumptionEmission": 5.75,
+    "totalConsumptionEmission": 5.58,
     "electricVehiclePerChargePoints": 12.74,
     "procurementScore": "0",
     "procurementLink": ""
@@ -1938,7 +1938,7 @@
     "climatePlanYear": 2019,
     "climatePlanComment": "Energi– och klimatstrategi, ska följas upp årligen.",
     "bicycleMetrePerCapita": 2.55,
-    "totalConsumptionEmission": 5.56,
+    "totalConsumptionEmission": 5.35,
     "electricVehiclePerChargePoints": 2.86,
     "procurementScore": "1",
     "procurementLink": ""
@@ -2046,7 +2046,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Finns både Miljöstrategi 2021–2030 och Handlingsplan för miljöstrategin 2022.",
     "bicycleMetrePerCapita": 3.61,
-    "totalConsumptionEmission": 5.77,
+    "totalConsumptionEmission": 5.59,
     "electricVehiclePerChargePoints": 10.67,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1Ase30RwyvTk6aU2BJ2zp6jTJmWGrn-WZ/view?usp=drive_link"
@@ -2154,7 +2154,7 @@
     "climatePlanYear": 2020,
     "climatePlanComment": "Energi– och klimatstrategi 2020–2024 kopplad till Borås koldioxidbudget.",
     "bicycleMetrePerCapita": 1.86,
-    "totalConsumptionEmission": 5.63,
+    "totalConsumptionEmission": 5.41,
     "electricVehiclePerChargePoints": 20.91,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1qw6EEOaJbPcGIFmXXKMP1hVRfc6V_mqm/view?usp=drive_link"
@@ -2262,7 +2262,7 @@
     "climatePlanYear": 2018,
     "climatePlanComment": "Klimatstrategi 2018–2023",
     "bicycleMetrePerCapita": 2.59,
-    "totalConsumptionEmission": 5.74,
+    "totalConsumptionEmission": 5.35,
     "electricVehiclePerChargePoints": 52.95,
     "procurementScore": "1",
     "procurementLink": ""
@@ -2370,7 +2370,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 1.16,
-    "totalConsumptionEmission": 5.5,
+    "totalConsumptionEmission": 5.3,
     "electricVehiclePerChargePoints": 22.88,
     "procurementScore": "0",
     "procurementLink": ""
@@ -2478,7 +2478,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 6.47,
-    "totalConsumptionEmission": 5.53,
+    "totalConsumptionEmission": 5.28,
     "electricVehiclePerChargePoints": 11.18,
     "procurementScore": "0",
     "procurementLink": ""
@@ -2586,7 +2586,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 0.95,
-    "totalConsumptionEmission": 5.47,
+    "totalConsumptionEmission": 5.27,
     "electricVehiclePerChargePoints": 2.57,
     "procurementScore": "1",
     "procurementLink": ""
@@ -2694,7 +2694,7 @@
     "climatePlanYear": 2020,
     "climatePlanComment": "Miljöprogram 2030",
     "bicycleMetrePerCapita": 3.37,
-    "totalConsumptionEmission": 6.01,
+    "totalConsumptionEmission": 5.67,
     "electricVehiclePerChargePoints": 9.46,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1AVb6qkh7b2xX05KYsEwHKjTT8zR55-JK/view?usp=drive_link"
@@ -2802,7 +2802,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Nytt miljö– och energiprogram är under utveckling, klar under 2024.",
     "bicycleMetrePerCapita": 4.86,
-    "totalConsumptionEmission": 6.28,
+    "totalConsumptionEmission": 6.01,
     "electricVehiclePerChargePoints": 8.27,
     "procurementScore": "0",
     "procurementLink": ""
@@ -2910,7 +2910,7 @@
     "climatePlanYear": 2020,
     "climatePlanComment": "Utvecklingsplan 2020–2023. Planerar att ta fram fler strategier.",
     "bicycleMetrePerCapita": 3.08,
-    "totalConsumptionEmission": 5.52,
+    "totalConsumptionEmission": 5.29,
     "electricVehiclePerChargePoints": 10.5,
     "procurementScore": "1",
     "procurementLink": ""
@@ -3018,7 +3018,7 @@
     "climatePlanYear": 2020,
     "climatePlanComment": "Miljö– och klimatprogram 2021–2030",
     "bicycleMetrePerCapita": 1.88,
-    "totalConsumptionEmission": 7.61,
+    "totalConsumptionEmission": 7.14,
     "electricVehiclePerChargePoints": 43.7,
     "procurementScore": "0",
     "procurementLink": ""
@@ -3126,7 +3126,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Energi– och klimatprogram 2021–2030. Status oklart, vattenstämplat \"Samrådsunderlag\".",
     "bicycleMetrePerCapita": 4.7,
-    "totalConsumptionEmission": 5.51,
+    "totalConsumptionEmission": 5.3,
     "electricVehiclePerChargePoints": 27.55,
     "procurementScore": "0",
     "procurementLink": ""
@@ -3234,7 +3234,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 2.26,
-    "totalConsumptionEmission": 5.38,
+    "totalConsumptionEmission": 5.36,
     "electricVehiclePerChargePoints": 1.56,
     "procurementScore": "0",
     "procurementLink": ""
@@ -3342,7 +3342,7 @@
     "climatePlanYear": 2020,
     "climatePlanComment": "Hållbarhetsstrategi.",
     "bicycleMetrePerCapita": 2.08,
-    "totalConsumptionEmission": 5.93,
+    "totalConsumptionEmission": 5.62,
     "electricVehiclePerChargePoints": 3.26,
     "procurementScore": "0",
     "procurementLink": ""
@@ -3450,7 +3450,7 @@
     "climatePlanYear": 2020,
     "climatePlanComment": "Energistrategi 2020–2030. Särskild klimatplan saknas.",
     "bicycleMetrePerCapita": 2.74,
-    "totalConsumptionEmission": 6.23,
+    "totalConsumptionEmission": 5.81,
     "electricVehiclePerChargePoints": 19.55,
     "procurementScore": "1",
     "procurementLink": ""
@@ -3558,7 +3558,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Ny plan antas under 2023.",
     "bicycleMetrePerCapita": 4.22,
-    "totalConsumptionEmission": 6.05,
+    "totalConsumptionEmission": 6.0,
     "electricVehiclePerChargePoints": 12.42,
     "procurementScore": "2",
     "procurementLink": "https://eksjo.se/download/18.1620518918d79e0cd832678/1707475042339/H%C3%A5llbarhetsbokslut%20Eksj%C3%B6%20kommun%202022.pdf"
@@ -3666,7 +3666,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 1.66,
-    "totalConsumptionEmission": 5.51,
+    "totalConsumptionEmission": 5.26,
     "electricVehiclePerChargePoints": 2.35,
     "procurementScore": "1",
     "procurementLink": ""
@@ -3774,7 +3774,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Klimatkontrakt 2030 via Viable Cities.",
     "bicycleMetrePerCapita": 2.78,
-    "totalConsumptionEmission": 5.55,
+    "totalConsumptionEmission": 5.34,
     "electricVehiclePerChargePoints": 13.79,
     "procurementScore": "0",
     "procurementLink": ""
@@ -3882,7 +3882,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Klimatprogram. Gäller tills vidare.",
     "bicycleMetrePerCapita": 2.21,
-    "totalConsumptionEmission": 5.38,
+    "totalConsumptionEmission": 5.1,
     "electricVehiclePerChargePoints": 16.77,
     "procurementScore": "1",
     "procurementLink": ""
@@ -3990,7 +3990,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 2.49,
-    "totalConsumptionEmission": 5.56,
+    "totalConsumptionEmission": 5.32,
     "electricVehiclePerChargePoints": 64.15,
     "procurementScore": "2",
     "procurementLink": "https://lund.se/kommun-och-politik/sa-styrs-lunds-kommun/forfattningssamling"
@@ -4098,7 +4098,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 3.27,
-    "totalConsumptionEmission": 5.63,
+    "totalConsumptionEmission": 5.41,
     "electricVehiclePerChargePoints": 9.64,
     "procurementScore": "0",
     "procurementLink": ""
@@ -4206,7 +4206,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 3.32,
-    "totalConsumptionEmission": 5.4,
+    "totalConsumptionEmission": 5.18,
     "electricVehiclePerChargePoints": 26.84,
     "procurementScore": "0",
     "procurementLink": ""
@@ -4314,7 +4314,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plans saknas. Har klimatinitiativ och koldioxidbudget. ",
     "bicycleMetrePerCapita": 3.37,
-    "totalConsumptionEmission": 5.44,
+    "totalConsumptionEmission": 5.21,
     "electricVehiclePerChargePoints": 5.35,
     "procurementScore": "0",
     "procurementLink": ""
@@ -4422,7 +4422,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Klimatstrategi 2021–2030. Kommunen står även bakom Västra Götalandsregionens kraftsamling för klimatet, Klimat 2030",
     "bicycleMetrePerCapita": 3.87,
-    "totalConsumptionEmission": 5.48,
+    "totalConsumptionEmission": 5.25,
     "electricVehiclePerChargePoints": 18.57,
     "procurementScore": "2",
     "procurementLink": "https://www.falkoping.se/download/18.1adde54a17861a73b1e11aae/1626330208751/Klimatstrategi%202021-2030.pdf"
@@ -4530,7 +4530,7 @@
     "climatePlanYear": 2012,
     "climatePlanComment": "Energi– och klimatprogram, vision 2050",
     "bicycleMetrePerCapita": 3.2,
-    "totalConsumptionEmission": 5.64,
+    "totalConsumptionEmission": 5.42,
     "electricVehiclePerChargePoints": 20.9,
     "procurementScore": "0",
     "procurementLink": ""
@@ -4638,7 +4638,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.  ",
     "bicycleMetrePerCapita": 1.83,
-    "totalConsumptionEmission": 5.46,
+    "totalConsumptionEmission": 5.26,
     "electricVehiclePerChargePoints": 9.89,
     "procurementScore": "0",
     "procurementLink": ""
@@ -4746,7 +4746,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Arbetet med att ta fram en ny energi– och klimatstrategi påbörjas under början av 2024.",
     "bicycleMetrePerCapita": 3.4,
-    "totalConsumptionEmission": 5.64,
+    "totalConsumptionEmission": 5.4,
     "electricVehiclePerChargePoints": 44.33,
     "procurementScore": "0",
     "procurementLink": ""
@@ -4854,7 +4854,7 @@
     "climatePlanYear": 2019,
     "climatePlanComment": "Energi– och klimatplan 2019–2023",
     "bicycleMetrePerCapita": 3.05,
-    "totalConsumptionEmission": 5.55,
+    "totalConsumptionEmission": 5.32,
     "electricVehiclePerChargePoints": 37.0,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1hhIx6EKV79wTPibNR4KA--taYA-_vuff/view?usp=drive_link"
@@ -4962,7 +4962,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Miljö– och klimatplan 2021–2030",
     "bicycleMetrePerCapita": 6.53,
-    "totalConsumptionEmission": 5.54,
+    "totalConsumptionEmission": 5.35,
     "electricVehiclePerChargePoints": 14.14,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1ho5nKkvRMkY4_upel84VnHwFSDesAw03/view?usp=drive_link"
@@ -5070,7 +5070,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 3.53,
-    "totalConsumptionEmission": 5.47,
+    "totalConsumptionEmission": 5.23,
     "electricVehiclePerChargePoints": 22.33,
     "procurementScore": "1",
     "procurementLink": ""
@@ -5178,7 +5178,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Arbete med plan pågår och väntas vara klart i början av 2024. ",
     "bicycleMetrePerCapita": 0.97,
-    "totalConsumptionEmission": 5.66,
+    "totalConsumptionEmission": 5.4,
     "electricVehiclePerChargePoints": 46.0,
     "procurementScore": "0",
     "procurementLink": ""
@@ -5286,7 +5286,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Strategi för hållbar utveckling",
     "bicycleMetrePerCapita": 4.3,
-    "totalConsumptionEmission": 5.48,
+    "totalConsumptionEmission": 5.21,
     "electricVehiclePerChargePoints": 12.84,
     "procurementScore": "0",
     "procurementLink": ""
@@ -5394,7 +5394,7 @@
     "climatePlanYear": 2013,
     "climatePlanComment": "Miljö– och hållbarhetsplan, gäller tills vidare",
     "bicycleMetrePerCapita": 1.72,
-    "totalConsumptionEmission": 5.74,
+    "totalConsumptionEmission": 5.45,
     "electricVehiclePerChargePoints": 13.97,
     "procurementScore": "0",
     "procurementLink": ""
@@ -5502,7 +5502,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 4.42,
-    "totalConsumptionEmission": 5.58,
+    "totalConsumptionEmission": 5.28,
     "electricVehiclePerChargePoints": 22.43,
     "procurementScore": "0",
     "procurementLink": ""
@@ -5610,7 +5610,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Genomförandeprogram för klimat, miljö och energi",
     "bicycleMetrePerCapita": 3.1,
-    "totalConsumptionEmission": 5.46,
+    "totalConsumptionEmission": 5.24,
     "electricVehiclePerChargePoints": 5.04,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1XJ1UVRwbdwDQ8OxsECSV9_xrk9IzKZYr/view?usp=drive_link"
@@ -5718,7 +5718,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 2.31,
-    "totalConsumptionEmission": 5.54,
+    "totalConsumptionEmission": 5.4,
     "electricVehiclePerChargePoints": 12.33,
     "procurementScore": "0",
     "procurementLink": ""
@@ -5826,7 +5826,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 3.13,
-    "totalConsumptionEmission": 5.69,
+    "totalConsumptionEmission": 5.41,
     "electricVehiclePerChargePoints": 58.75,
     "procurementScore": "2",
     "procurementLink": "https://www.grastorp.se/bygga-bo-och-miljo/klimat-och-hallbarhet.html"
@@ -5934,7 +5934,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 5.08,
-    "totalConsumptionEmission": 5.67,
+    "totalConsumptionEmission": 5.46,
     "electricVehiclePerChargePoints": 7.14,
     "procurementScore": "2",
     "procurementLink": "https://klimat2030.se/undertecknare/gullspang-kommun/"
@@ -6042,7 +6042,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 3.61,
-    "totalConsumptionEmission": 5.68,
+    "totalConsumptionEmission": 5.64,
     "electricVehiclePerChargePoints": 6.65,
     "procurementScore": "0",
     "procurementLink": ""
@@ -6150,7 +6150,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Klimatplan 2035",
     "bicycleMetrePerCapita": 2.88,
-    "totalConsumptionEmission": 5.42,
+    "totalConsumptionEmission": 5.19,
     "electricVehiclePerChargePoints": 11.58,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1jLax0svJUbW27r9Cyolt06suLnk_t6mL/view?usp=drive_link"
@@ -6258,7 +6258,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Miljö– och klimatprogram 2021–2030",
     "bicycleMetrePerCapita": 1.28,
-    "totalConsumptionEmission": 6.18,
+    "totalConsumptionEmission": 5.81,
     "electricVehiclePerChargePoints": 6.71,
     "procurementScore": "2",
     "procurementLink": "https://goteborg.se/wps/portal/start/foretag-och-organisationer/upphandling-och-inkop/hallbar-upphandling/ekologisk-hallbarhet-i-upphandling"
@@ -6366,7 +6366,7 @@
     "climatePlanYear": 2019,
     "climatePlanComment": "Klimat– och miljöpolitiskt program 2019–2024",
     "bicycleMetrePerCapita": 4.21,
-    "totalConsumptionEmission": 5.69,
+    "totalConsumptionEmission": 5.48,
     "electricVehiclePerChargePoints": 37.5,
     "procurementScore": "0",
     "procurementLink": ""
@@ -6474,7 +6474,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Klimatprogram 2021–2025",
     "bicycleMetrePerCapita": 1.85,
-    "totalConsumptionEmission": 5.78,
+    "totalConsumptionEmission": 5.51,
     "electricVehiclePerChargePoints": 47.44,
     "procurementScore": "1",
     "procurementLink": ""
@@ -6582,7 +6582,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas",
     "bicycleMetrePerCapita": 5.52,
-    "totalConsumptionEmission": 5.66,
+    "totalConsumptionEmission": 5.47,
     "electricVehiclePerChargePoints": 15.0,
     "procurementScore": "0",
     "procurementLink": ""
@@ -6690,7 +6690,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 3.41,
-    "totalConsumptionEmission": 5.59,
+    "totalConsumptionEmission": 5.38,
     "electricVehiclePerChargePoints": 35.92,
     "procurementScore": "2",
     "procurementLink": "https://www.orebro.se/fordjupning/fordjupning/sa-arbetar-vi-med/maltider-i-kommunens-kok-och-serveringar.html"
@@ -6798,7 +6798,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 3.67,
-    "totalConsumptionEmission": 5.81,
+    "totalConsumptionEmission": 5.59,
     "electricVehiclePerChargePoints": 15.65,
     "procurementScore": "0",
     "procurementLink": ""
@@ -6906,7 +6906,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Plan för energi och klimat. Gäller tills vidare.",
     "bicycleMetrePerCapita": 4.82,
-    "totalConsumptionEmission": 6.06,
+    "totalConsumptionEmission": 5.84,
     "electricVehiclePerChargePoints": 11.16,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1N2X0IxEXtbzKbUT3oTSQDL3KqpgSTx0v/view?usp=drive_link"
@@ -7014,7 +7014,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 3.29,
-    "totalConsumptionEmission": 5.85,
+    "totalConsumptionEmission": 5.58,
     "electricVehiclePerChargePoints": 59.61,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1hniLkbvsciBRv7cP5rklYnwggrPZpDTC/view?usp=drive_link"
@@ -7122,7 +7122,7 @@
     "climatePlanYear": 2017,
     "climatePlanComment": "Klimat– och miljöpolitisk program. ",
     "bicycleMetrePerCapita": 2.01,
-    "totalConsumptionEmission": 5.5,
+    "totalConsumptionEmission": 5.21,
     "electricVehiclePerChargePoints": 45.33,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1K3YjGk-sbfjZ8quF6OQ_3QcW1yy9Fyb8/view?usp=drive_link"
@@ -7230,7 +7230,7 @@
     "climatePlanYear": 2012,
     "climatePlanComment": "Klimatstrategi 2020–2050",
     "bicycleMetrePerCapita": 3.2,
-    "totalConsumptionEmission": 5.47,
+    "totalConsumptionEmission": 5.71,
     "electricVehiclePerChargePoints": 2.6,
     "procurementScore": "0",
     "procurementLink": ""
@@ -7338,7 +7338,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Arbete med handlingsplan pågår och är klart som tidigast under andra kvartalet 2024.",
     "bicycleMetrePerCapita": 2.3,
-    "totalConsumptionEmission": 5.44,
+    "totalConsumptionEmission": 5.2,
     "electricVehiclePerChargePoints": 10.85,
     "procurementScore": "0",
     "procurementLink": ""
@@ -7446,7 +7446,7 @@
     "climatePlanYear": 2020,
     "climatePlanComment": "Energi– och klimatstrategi 2020–2025 ",
     "bicycleMetrePerCapita": 1.83,
-    "totalConsumptionEmission": 5.72,
+    "totalConsumptionEmission": 5.52,
     "electricVehiclePerChargePoints": 17.96,
     "procurementScore": "0",
     "procurementLink": ""
@@ -7554,7 +7554,7 @@
     "climatePlanYear": 2018,
     "climatePlanComment": "Klimat– och energiplan 2018–2024 ",
     "bicycleMetrePerCapita": 3.13,
-    "totalConsumptionEmission": 5.92,
+    "totalConsumptionEmission": 5.52,
     "electricVehiclePerChargePoints": 13.28,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1gjtYP7sEOFc76vDxpxdCi8Qoow--iDmS/view?usp=drive_link"
@@ -7662,7 +7662,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Står bakom klimatlöften inom Västra Götalands klimat 2030. Har miljömål från 2014 (med målår 2020).",
     "bicycleMetrePerCapita": 3.28,
-    "totalConsumptionEmission": 5.5,
+    "totalConsumptionEmission": 5.27,
     "electricVehiclePerChargePoints": 21.29,
     "procurementScore": "2",
     "procurementLink": "https://docs.google.com/document/d/1Hp5em_ksdYvvOUrcVLzaqOY2p7Ak0xaF/edit"
@@ -7770,7 +7770,7 @@
     "climatePlanYear": 2018,
     "climatePlanComment": "Hållbarhetsstrategi",
     "bicycleMetrePerCapita": 2.51,
-    "totalConsumptionEmission": 5.64,
+    "totalConsumptionEmission": 5.46,
     "electricVehiclePerChargePoints": 35.17,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1I_ntkS2087DySPdOKSaj0XiOlneNkryg/view?usp=drive_link"
@@ -7878,7 +7878,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Hänvisar till  Sandvikens kommun Energi- och klimatstrategi från 2007.",
     "bicycleMetrePerCapita": 3.44,
-    "totalConsumptionEmission": 5.54,
+    "totalConsumptionEmission": 5.37,
     "electricVehiclePerChargePoints": 12.5,
     "procurementScore": "0",
     "procurementLink": ""
@@ -7986,7 +7986,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Miljöprogram 2022–2025",
     "bicycleMetrePerCapita": 2.03,
-    "totalConsumptionEmission": 5.84,
+    "totalConsumptionEmission": 5.48,
     "electricVehiclePerChargePoints": 18.07,
     "procurementScore": "2",
     "procurementLink": "https://www.huddinge.se/organisation-och-styrning/sa-arbetar-vi-med/miljo-och-klimat/miljoprogram-2022-2025/"
@@ -8094,7 +8094,7 @@
     "climatePlanYear": 2017,
     "climatePlanComment": "Energi– och klimatstrategi 2017–2050",
     "bicycleMetrePerCapita": 2.11,
-    "totalConsumptionEmission": 5.6,
+    "totalConsumptionEmission": 5.4,
     "electricVehiclePerChargePoints": 19.12,
     "procurementScore": "0",
     "procurementLink": ""
@@ -8202,7 +8202,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 3.35,
-    "totalConsumptionEmission": 5.44,
+    "totalConsumptionEmission": 5.24,
     "electricVehiclePerChargePoints": 3.73,
     "procurementScore": "0",
     "procurementLink": ""
@@ -8310,7 +8310,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 4.0,
-    "totalConsumptionEmission": 6.23,
+    "totalConsumptionEmission": 5.98,
     "electricVehiclePerChargePoints": 11.13,
     "procurementScore": "0",
     "procurementLink": ""
@@ -8418,7 +8418,7 @@
     "climatePlanYear": null,
     "climatePlanComment": null,
     "bicycleMetrePerCapita": 2.67,
-    "totalConsumptionEmission": 5.36,
+    "totalConsumptionEmission": 5.13,
     "electricVehiclePerChargePoints": 21.67,
     "procurementScore": "2",
     "procurementLink": "https://www.orebro.se/fordjupning/fordjupning/sa-arbetar-vi-med/maltider-i-kommunens-kok-och-serveringar.html"
@@ -8526,7 +8526,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 2.53,
-    "totalConsumptionEmission": 5.6,
+    "totalConsumptionEmission": 5.38,
     "electricVehiclePerChargePoints": 2.05,
     "procurementScore": "1",
     "procurementLink": ""
@@ -8634,7 +8634,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Har eget klimatlöfte. ",
     "bicycleMetrePerCapita": 2.4,
-    "totalConsumptionEmission": 5.6,
+    "totalConsumptionEmission": 5.46,
     "electricVehiclePerChargePoints": 12.78,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1Uo30oDKp9v3A74kk-J-d1FKjRukx6Hit/view?usp=drive_link"
@@ -8742,7 +8742,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Energi– och klimatplan.",
     "bicycleMetrePerCapita": 3.66,
-    "totalConsumptionEmission": 5.98,
+    "totalConsumptionEmission": 5.62,
     "electricVehiclePerChargePoints": 5.55,
     "procurementScore": "2",
     "procurementLink": "https://goteborg.se/wps/portal/start/foretag-och-organisationer/upphandling-och-inkop/hallbar-upphandling/ekologisk-hallbarhet-i-upphandling"
@@ -8850,7 +8850,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Ny energi– och klimatplan i början av 2024.",
     "bicycleMetrePerCapita": 3.62,
-    "totalConsumptionEmission": 5.51,
+    "totalConsumptionEmission": 5.42,
     "electricVehiclePerChargePoints": 15.4,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1tXmK9utLkEmJ-DLafEMVVuZRr_L8idBL/view?usp=drive_link"
@@ -8958,7 +8958,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Hållbarhetsstrategi 2021. Uppdateras senast 2026.",
     "bicycleMetrePerCapita": 3.92,
-    "totalConsumptionEmission": 5.78,
+    "totalConsumptionEmission": 5.52,
     "electricVehiclePerChargePoints": 45.28,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/12ilXQYvNJP-uJfo6HZEdGpzmcIXzxbrv/view?usp=drive_link"
@@ -9066,7 +9066,7 @@
     "climatePlanYear": 2015,
     "climatePlanComment": "Miljöprogram 2015–2025",
     "bicycleMetrePerCapita": 3.83,
-    "totalConsumptionEmission": 5.93,
+    "totalConsumptionEmission": 5.65,
     "electricVehiclePerChargePoints": 12.47,
     "procurementScore": "1",
     "procurementLink": ""
@@ -9174,7 +9174,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Hade en energi- och klimatstrategi fram till 2010. ",
     "bicycleMetrePerCapita": 3.07,
-    "totalConsumptionEmission": 5.34,
+    "totalConsumptionEmission": 5.14,
     "electricVehiclePerChargePoints": 6.54,
     "procurementScore": "0",
     "procurementLink": ""
@@ -9282,7 +9282,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 3.1,
-    "totalConsumptionEmission": 5.59,
+    "totalConsumptionEmission": 5.37,
     "electricVehiclePerChargePoints": 21.07,
     "procurementScore": "0",
     "procurementLink": ""
@@ -9390,7 +9390,7 @@
     "climatePlanYear": 2023,
     "climatePlanComment": "Miljö- och klimatstrategi för Höörs kommun",
     "bicycleMetrePerCapita": 3.57,
-    "totalConsumptionEmission": 5.66,
+    "totalConsumptionEmission": 5.43,
     "electricVehiclePerChargePoints": 85.62,
     "procurementScore": "0",
     "procurementLink": ""
@@ -9498,7 +9498,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.  ",
     "bicycleMetrePerCapita": 2.13,
-    "totalConsumptionEmission": 5.46,
+    "totalConsumptionEmission": 5.25,
     "electricVehiclePerChargePoints": 2.42,
     "procurementScore": "0",
     "procurementLink": ""
@@ -9606,7 +9606,7 @@
     "climatePlanYear": 2024,
     "climatePlanComment": "Klimat och Energiplan 2024-2030",
     "bicycleMetrePerCapita": 2.33,
-    "totalConsumptionEmission": 5.95,
+    "totalConsumptionEmission": 5.66,
     "electricVehiclePerChargePoints": 47.78,
     "procurementScore": "2",
     "procurementLink": "https://www.jarfalla.se/download/18.5e2d810118697502d1121381/1677764821650/Miljoplan-2023-2030-Jarfalla-kommun-med-bolag.pdf"
@@ -9714,7 +9714,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Hållbarhetsprogram 2022–2030",
     "bicycleMetrePerCapita": 2.78,
-    "totalConsumptionEmission": 5.7,
+    "totalConsumptionEmission": 5.46,
     "electricVehiclePerChargePoints": 23.59,
     "procurementScore": "2",
     "procurementLink": "https://www.jonkoping.se/download/18.6751acba183a2e89e794ecfe/1666359577980/Program%20f%C3%B6r%20h%C3%A5llbarhet%20i%20J%C3%B6nk%C3%B6pings%20kommun%202022-2030.pdf"
@@ -9822,7 +9822,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Hade en miljöplan 2017–2019.",
     "bicycleMetrePerCapita": 2.54,
-    "totalConsumptionEmission": 5.42,
+    "totalConsumptionEmission": 5.25,
     "electricVehiclePerChargePoints": 5.99,
     "procurementScore": "1",
     "procurementLink": ""
@@ -9930,7 +9930,7 @@
     "climatePlanYear": 2019,
     "climatePlanComment": "Handlingsplan Fossilbränslefri kommun 2030",
     "bicycleMetrePerCapita": 3.09,
-    "totalConsumptionEmission": 5.41,
+    "totalConsumptionEmission": 5.19,
     "electricVehiclePerChargePoints": 10.75,
     "procurementScore": "1",
     "procurementLink": ""
@@ -10038,7 +10038,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 3.61,
-    "totalConsumptionEmission": 5.71,
+    "totalConsumptionEmission": 5.5,
     "electricVehiclePerChargePoints": 10.25,
     "procurementScore": "0",
     "procurementLink": ""
@@ -10146,7 +10146,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas men har ett miljöråd. ",
     "bicycleMetrePerCapita": 3.81,
-    "totalConsumptionEmission": 5.38,
+    "totalConsumptionEmission": 5.14,
     "electricVehiclePerChargePoints": 7.68,
     "procurementScore": "1",
     "procurementLink": ""
@@ -10254,7 +10254,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Miljöprogram 2021–2030. ",
     "bicycleMetrePerCapita": 3.7,
-    "totalConsumptionEmission": 5.57,
+    "totalConsumptionEmission": 5.43,
     "electricVehiclePerChargePoints": 46.78,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1ZK_q1FOAh3CuX-goDQHXk3gZzXvhaa-J/view?usp=drive_link"
@@ -10362,7 +10362,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Hållbarhetsprogram 2021–2025",
     "bicycleMetrePerCapita": 1.63,
-    "totalConsumptionEmission": 5.62,
+    "totalConsumptionEmission": 5.38,
     "electricVehiclePerChargePoints": 16.76,
     "procurementScore": "2",
     "procurementLink": "https://www.karlskrona.se/kommun-och-politik/sa-fungerar-kommunen/forfattningssamling/styrande-dokument/"
@@ -10470,7 +10470,7 @@
     "climatePlanYear": 2023,
     "climatePlanComment": "Klimatkontrakt 2030 inom Viable Cities. Ny Energi– och klimatplan samt handlingsplan beslutas maj 2023.",
     "bicycleMetrePerCapita": 2.99,
-    "totalConsumptionEmission": 5.64,
+    "totalConsumptionEmission": 5.46,
     "electricVehiclePerChargePoints": 14.04,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/drive/u/0/folders/1W0ikrmofAruq9lzl1j562VHonpwsK4rB"
@@ -10578,7 +10578,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Klimatstrategi ska vara klar 2024.",
     "bicycleMetrePerCapita": 3.02,
-    "totalConsumptionEmission": 5.33,
+    "totalConsumptionEmission": 5.1,
     "electricVehiclePerChargePoints": 12.09,
     "procurementScore": "0",
     "procurementLink": ""
@@ -10686,7 +10686,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 3.6,
-    "totalConsumptionEmission": 5.58,
+    "totalConsumptionEmission": 5.33,
     "electricVehiclePerChargePoints": 25.73,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1ho5nKkvRMkY4_upel84VnHwFSDesAw03/view?usp=drive_link"
@@ -10794,7 +10794,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 1.71,
-    "totalConsumptionEmission": 5.6,
+    "totalConsumptionEmission": 5.37,
     "electricVehiclePerChargePoints": 74.17,
     "procurementScore": "0",
     "procurementLink": ""
@@ -10902,7 +10902,7 @@
     "climatePlanYear": 2015,
     "climatePlanComment": "Åtgärdsplan för hållbar energi för kommunkoncernen",
     "bicycleMetrePerCapita": 1.36,
-    "totalConsumptionEmission": 6.74,
+    "totalConsumptionEmission": 6.9,
     "electricVehiclePerChargePoints": 10.15,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1QuHFKI5cCG4xYCO5vSCGQjTPb9cuenNR/view?usp=drive_link"
@@ -11010,7 +11010,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Hållbarhetsstrategi 2021–2023",
     "bicycleMetrePerCapita": 3.13,
-    "totalConsumptionEmission": 5.51,
+    "totalConsumptionEmission": 5.33,
     "electricVehiclePerChargePoints": 14.83,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1w-XpLcjZch_a49jJyc65AJSYXjl6kOfM/view?usp=sharing"
@@ -11118,7 +11118,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 2.09,
-    "totalConsumptionEmission": 6.06,
+    "totalConsumptionEmission": 5.67,
     "electricVehiclePerChargePoints": 34.16,
     "procurementScore": "0",
     "procurementLink": ""
@@ -11226,7 +11226,7 @@
     "climatePlanYear": 2019,
     "climatePlanComment": "Program för Ekologisk hållbarhet 2020–2031",
     "bicycleMetrePerCapita": 2.63,
-    "totalConsumptionEmission": 5.5,
+    "totalConsumptionEmission": 5.26,
     "electricVehiclePerChargePoints": 7.6,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1ammChocFfoS_N_xgvfsW7mMw3Ir34bKB/view?usp=drive_link"
@@ -11334,7 +11334,7 @@
     "climatePlanYear": 2023,
     "climatePlanComment": "Remissversion, kommer klubbas 2023",
     "bicycleMetrePerCapita": 4.41,
-    "totalConsumptionEmission": 5.43,
+    "totalConsumptionEmission": 5.19,
     "electricVehiclePerChargePoints": 15.75,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1mYF167j4UjKJXvjtAQRG-yUgdcWAIVoC/view?usp=sharing"
@@ -11442,7 +11442,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 2.5,
-    "totalConsumptionEmission": 5.42,
+    "totalConsumptionEmission": 5.2,
     "electricVehiclePerChargePoints": 18.69,
     "procurementScore": "0",
     "procurementLink": ""
@@ -11550,7 +11550,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 1.56,
-    "totalConsumptionEmission": 5.55,
+    "totalConsumptionEmission": 5.33,
     "electricVehiclePerChargePoints": 8.03,
     "procurementScore": "0",
     "procurementLink": ""
@@ -11658,7 +11658,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Nya handlingsplanen för ökad ekologisk hållbarhet förväntas april 2024.",
     "bicycleMetrePerCapita": 4.13,
-    "totalConsumptionEmission": 5.71,
+    "totalConsumptionEmission": 5.46,
     "electricVehiclePerChargePoints": 22.45,
     "procurementScore": "2",
     "procurementLink": "https://www.orebro.se/fordjupning/fordjupning/sa-arbetar-vi-med/maltider-i-kommunens-kok-och-serveringar.html"
@@ -11766,7 +11766,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Klimatstrategi",
     "bicycleMetrePerCapita": 2.48,
-    "totalConsumptionEmission": 6.16,
+    "totalConsumptionEmission": 5.8,
     "electricVehiclePerChargePoints": 28.64,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1y2nkO3_NWSuN-oewU29nLqG2deq3_YtE/view?usp=drive_link"
@@ -11874,7 +11874,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plans saknas. ",
     "bicycleMetrePerCapita": 0.79,
-    "totalConsumptionEmission": 5.5,
+    "totalConsumptionEmission": 5.32,
     "electricVehiclePerChargePoints": 9.19,
     "procurementScore": "0",
     "procurementLink": ""
@@ -11982,7 +11982,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 2.48,
-    "totalConsumptionEmission": 5.91,
+    "totalConsumptionEmission": 5.61,
     "electricVehiclePerChargePoints": 9.75,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1262bO-n943JUJbipwSl9rDqo1LwEgnri/view?usp=drive_link"
@@ -12090,7 +12090,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Ska tas fram 2024.",
     "bicycleMetrePerCapita": 5.06,
-    "totalConsumptionEmission": 6.12,
+    "totalConsumptionEmission": 5.8,
     "electricVehiclePerChargePoints": 17.22,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1rqYkHoIoH9ZcZ13i1508K3Wq1QlaNueC/view?usp=drive_link"
@@ -12198,7 +12198,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 3.03,
-    "totalConsumptionEmission": 5.55,
+    "totalConsumptionEmission": 5.33,
     "electricVehiclePerChargePoints": 15.45,
     "procurementScore": "2",
     "procurementLink": "https://docs.google.com/presentation/d/1efwagf4pX8ZGtM1_17gsX19APKvybYaf/edit?usp=drive_link&ouid=104089955738391943844&rtpof=true&sd=true"
@@ -12306,7 +12306,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 4.6,
-    "totalConsumptionEmission": 5.52,
+    "totalConsumptionEmission": 5.23,
     "electricVehiclePerChargePoints": 20.51,
     "procurementScore": "2",
     "procurementLink": "https://docs.google.com/document/d/1GtY6dau8CLIUyg3zal3EM3ZK4eeniAHU/edit?usp=drive_link&ouid=104089955738391943844&rtpof=true&sd=true"
@@ -12414,7 +12414,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 3.16,
-    "totalConsumptionEmission": 5.85,
+    "totalConsumptionEmission": 5.49,
     "electricVehiclePerChargePoints": 15.05,
     "procurementScore": "1",
     "procurementLink": ""
@@ -12522,7 +12522,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 4.26,
-    "totalConsumptionEmission": 5.55,
+    "totalConsumptionEmission": 5.36,
     "electricVehiclePerChargePoints": 12.38,
     "procurementScore": "0",
     "procurementLink": ""
@@ -12630,7 +12630,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Hållbarhetsprogram 2022–2030",
     "bicycleMetrePerCapita": 1.38,
-    "totalConsumptionEmission": 5.71,
+    "totalConsumptionEmission": 5.45,
     "electricVehiclePerChargePoints": 11.24,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1VKCOeuXYByZoSmBUxg8Iva68xH8iKEgW/view?usp=drive_link"
@@ -12738,7 +12738,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Pågår ett arbete att ta fram ny plan.",
     "bicycleMetrePerCapita": 2.98,
-    "totalConsumptionEmission": 5.65,
+    "totalConsumptionEmission": 5.37,
     "electricVehiclePerChargePoints": 4.87,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1gmk-2GlIoOEVx-YTJiii6uIqUkuzSjX8/view?usp=drive_link"
@@ -12846,7 +12846,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Arbete med ny energiplan pågår, beslut hösten 2023.",
     "bicycleMetrePerCapita": 2.68,
-    "totalConsumptionEmission": 5.92,
+    "totalConsumptionEmission": 5.61,
     "electricVehiclePerChargePoints": 24.81,
     "procurementScore": "2",
     "procurementLink": "https://klimat2030.se/undertecknare/lerum-kommun/"
@@ -12954,7 +12954,7 @@
     "climatePlanYear": 2019,
     "climatePlanComment": "Energi, miljö– och klimatstrategiskt program för Lessebo kommun 2019 –2030",
     "bicycleMetrePerCapita": 3.21,
-    "totalConsumptionEmission": 5.52,
+    "totalConsumptionEmission": 5.33,
     "electricVehiclePerChargePoints": 6.09,
     "procurementScore": "2",
     "procurementLink": "https://www.lessebo.se/download/18.718021f218bf6061c471d424/1700838950724/M%C3%A5ltidspolicy%20antagen%2023-02-27.pdf"
@@ -13062,7 +13062,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Miljöprogram 2021–2030. ",
     "bicycleMetrePerCapita": 2.63,
-    "totalConsumptionEmission": 6.96,
+    "totalConsumptionEmission": 6.56,
     "electricVehiclePerChargePoints": 73.04,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1q_kHO1VxjxsEheFfUgoG4fEPxJwOUaOd/view?usp=drive_link"
@@ -13170,7 +13170,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 3.26,
-    "totalConsumptionEmission": 6.32,
+    "totalConsumptionEmission": 6.2,
     "electricVehiclePerChargePoints": 28.26,
     "procurementScore": "1",
     "procurementLink": ""
@@ -13278,7 +13278,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 2.65,
-    "totalConsumptionEmission": 5.67,
+    "totalConsumptionEmission": 5.5,
     "electricVehiclePerChargePoints": 49.2,
     "procurementScore": "2",
     "procurementLink": "https://lillaedet.se/download/18.521396a21877977188d6244/1682000731913/%C3%85rsredovisning%202022.pdf"
@@ -13386,7 +13386,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Arbetar utifrån Örebro läns klimat– och energiprogram.",
     "bicycleMetrePerCapita": 2.29,
-    "totalConsumptionEmission": 5.41,
+    "totalConsumptionEmission": 5.21,
     "electricVehiclePerChargePoints": 38.9,
     "procurementScore": "1",
     "procurementLink": ""
@@ -13494,7 +13494,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Klimatkontrakt 2030 inom Viable Cities. ",
     "bicycleMetrePerCapita": 3.41,
-    "totalConsumptionEmission": 6.02,
+    "totalConsumptionEmission": 5.76,
     "electricVehiclePerChargePoints": 13.32,
     "procurementScore": "2",
     "procurementLink": "https://www.linkoping.se/klimatsmart-linkoping/"
@@ -13602,7 +13602,7 @@
     "climatePlanYear": 2020,
     "climatePlanComment": "Klimat- och energiplan ",
     "bicycleMetrePerCapita": 5.12,
-    "totalConsumptionEmission": 6.03,
+    "totalConsumptionEmission": 5.77,
     "electricVehiclePerChargePoints": 12.32,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1wC6YUXj-ahqnEQ_WUzir5ao8OW0CwWW1/view?usp=drive_link"
@@ -13710,7 +13710,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 2.66,
-    "totalConsumptionEmission": 5.46,
+    "totalConsumptionEmission": 5.26,
     "electricVehiclePerChargePoints": 6.76,
     "procurementScore": "0",
     "procurementLink": ""
@@ -13818,7 +13818,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 2.36,
-    "totalConsumptionEmission": 5.57,
+    "totalConsumptionEmission": 5.47,
     "electricVehiclePerChargePoints": 15.0,
     "procurementScore": "2",
     "procurementLink": "https://www.orebro.se/fordjupning/fordjupning/sa-arbetar-vi-med/maltider-i-kommunens-kok-och-serveringar.html"
@@ -13926,7 +13926,7 @@
     "climatePlanYear": 2020,
     "climatePlanComment": "Energi– och klimatplan 2021–2025",
     "bicycleMetrePerCapita": 4.07,
-    "totalConsumptionEmission": 6.5,
+    "totalConsumptionEmission": 6.02,
     "electricVehiclePerChargePoints": 21.35,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1bUudOfnRmbs697U8jFs7SbSCn1al8yzm/view?usp=drive_link"
@@ -14034,7 +14034,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 4.15,
-    "totalConsumptionEmission": 5.4,
+    "totalConsumptionEmission": 5.21,
     "electricVehiclePerChargePoints": 14.45,
     "procurementScore": "2",
     "procurementLink": "https://upphandlingscenterfbr.se/download/18.232f037e18721ea54a579cb/1679982679008/N%C3%A4mndplan%202023-2025%20-%20daterad%202022-12-05%20fastst%C3%A4lld%20av%20GNU.pdf"
@@ -14142,7 +14142,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 3.03,
-    "totalConsumptionEmission": 5.62,
+    "totalConsumptionEmission": 5.46,
     "electricVehiclePerChargePoints": 41.68,
     "procurementScore": "2",
     "procurementLink": "https://docs.google.com/document/d/1JN8kGEnfzI1aLNyewmAewY7vLJPI2MOR/edit?usp=drive_link&ouid=104089955738391943844&rtpof=true&sd=true"
@@ -14250,7 +14250,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Program för ekologisk hållbar utveckling 2021–2030",
     "bicycleMetrePerCapita": 3.28,
-    "totalConsumptionEmission": 5.75,
+    "totalConsumptionEmission": 5.46,
     "electricVehiclePerChargePoints": 21.52,
     "procurementScore": "2",
     "procurementLink": "https://lund.se/kommun-och-politik/sa-styrs-lunds-kommun/forfattningssamling"
@@ -14358,7 +14358,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Pågående arbete med att ta fram klimatstrategi och koldioxidbudget. Nuvarande klimatarbete ingår i översiktsplanen.",
     "bicycleMetrePerCapita": 3.72,
-    "totalConsumptionEmission": 5.26,
+    "totalConsumptionEmission": 5.03,
     "electricVehiclePerChargePoints": 5.79,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1MPw4jWzpLCk3e-l72xPuqVv0pYYayNRM/view?usp=drive_link"
@@ -14466,7 +14466,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 2.7,
-    "totalConsumptionEmission": 5.54,
+    "totalConsumptionEmission": 5.38,
     "electricVehiclePerChargePoints": 13.86,
     "procurementScore": "0",
     "procurementLink": ""
@@ -14574,7 +14574,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Klimatkontrakt 2030 inom Viable Cities. ",
     "bicycleMetrePerCapita": 1.54,
-    "totalConsumptionEmission": 6.18,
+    "totalConsumptionEmission": 5.74,
     "electricVehiclePerChargePoints": 18.5,
     "procurementScore": "2",
     "procurementLink": "https://malmo.se/Miljo-och-klimat/Sa-jobbar-vi-med-vara-miljo--och-klimatmal/Sex-mal-for-minsta-mojliga-klimatpaverkan.html"
@@ -14682,7 +14682,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 2.16,
-    "totalConsumptionEmission": 5.8,
+    "totalConsumptionEmission": 5.58,
     "electricVehiclePerChargePoints": 1.68,
     "procurementScore": "0",
     "procurementLink": ""
@@ -14790,7 +14790,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 4.22,
-    "totalConsumptionEmission": 5.24,
+    "totalConsumptionEmission": 5.06,
     "electricVehiclePerChargePoints": 3.36,
     "procurementScore": "0",
     "procurementLink": ""
@@ -14898,7 +14898,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Klimatkontrakt 2030 inom Viable Cities. ",
     "bicycleMetrePerCapita": 4.32,
-    "totalConsumptionEmission": 5.48,
+    "totalConsumptionEmission": 5.24,
     "electricVehiclePerChargePoints": 11.31,
     "procurementScore": "2",
     "procurementLink": "https://mariestad.se/download/18.216f23a018c6320f584a16/1702479676636/Klimatkontrakt_Mariestad_2023.pdf"
@@ -15006,7 +15006,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 2.19,
-    "totalConsumptionEmission": 5.5,
+    "totalConsumptionEmission": 5.27,
     "electricVehiclePerChargePoints": 109.75,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1si4gGgN7FLAyciNftvdcJvfuArOBfskg/view?usp=drive_link"
@@ -15114,7 +15114,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 4.15,
-    "totalConsumptionEmission": 5.51,
+    "totalConsumptionEmission": 5.3,
     "electricVehiclePerChargePoints": 5.79,
     "procurementScore": "2",
     "procurementLink": "https://foretag.vaxjo.se/download/18.3d04795317955c86cd918e16/1622707803967/Klimatkontrakt%202030.pdf"
@@ -15222,7 +15222,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Arbete pågår med Energi– och Klimatstrategi som bör vara klart under 2023.",
     "bicycleMetrePerCapita": 2.85,
-    "totalConsumptionEmission": 5.43,
+    "totalConsumptionEmission": 5.23,
     "electricVehiclePerChargePoints": 5.28,
     "procurementScore": "0",
     "procurementLink": ""
@@ -15330,7 +15330,7 @@
     "climatePlanYear": 2020,
     "climatePlanComment": "Energi och klimatstrategi. 2020–2023.",
     "bicycleMetrePerCapita": 3.71,
-    "totalConsumptionEmission": 5.57,
+    "totalConsumptionEmission": 5.39,
     "electricVehiclePerChargePoints": 17.52,
     "procurementScore": "1",
     "procurementLink": ""
@@ -15438,7 +15438,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas, men planeras att tas fram. Klimatarbetet har hittills ingått i Strategi Hållbara Mora, som genomgår revidering just nu.",
     "bicycleMetrePerCapita": 3.15,
-    "totalConsumptionEmission": 5.84,
+    "totalConsumptionEmission": 5.59,
     "electricVehiclePerChargePoints": 8.44,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1vCpggLOKZSYCiQlpCyVoj5nh3K4MTKX9/view?usp=drive_link"
@@ -15546,7 +15546,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 3.71,
-    "totalConsumptionEmission": 5.34,
+    "totalConsumptionEmission": 5.09,
     "electricVehiclePerChargePoints": 39.57,
     "procurementScore": "1",
     "procurementLink": ""
@@ -15654,7 +15654,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Miljöprogram. 2021–2030.",
     "bicycleMetrePerCapita": 4.66,
-    "totalConsumptionEmission": 5.49,
+    "totalConsumptionEmission": 5.31,
     "electricVehiclePerChargePoints": 12.62,
     "procurementScore": "0",
     "procurementLink": ""
@@ -15762,7 +15762,7 @@
     "climatePlanYear": null,
     "climatePlanComment": null,
     "bicycleMetrePerCapita": 4.18,
-    "totalConsumptionEmission": 5.62,
+    "totalConsumptionEmission": 5.44,
     "electricVehiclePerChargePoints": 7.24,
     "procurementScore": "2",
     "procurementLink": "https://www.munkedal.se/download/18.65b854c9188d75f3a1f7bf3a/1688714563570/M%C3%A5l%20och%20Resursplan%20(MRP)%20budget%202024%20plan%202025-2026.pdf"
@@ -15870,7 +15870,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 5.68,
-    "totalConsumptionEmission": 5.56,
+    "totalConsumptionEmission": 5.36,
     "electricVehiclePerChargePoints": 11.71,
     "procurementScore": "0",
     "procurementLink": ""
@@ -15978,7 +15978,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Energiplan för minimerad klimatpåverkan.",
     "bicycleMetrePerCapita": 2.42,
-    "totalConsumptionEmission": 5.92,
+    "totalConsumptionEmission": 5.62,
     "electricVehiclePerChargePoints": 12.87,
     "procurementScore": "0",
     "procurementLink": ""
@@ -16086,7 +16086,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 5.55,
-    "totalConsumptionEmission": 5.52,
+    "totalConsumptionEmission": 5.32,
     "electricVehiclePerChargePoints": 28.08,
     "procurementScore": "0",
     "procurementLink": ""
@@ -16194,7 +16194,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Ny Miljö– och klimatstrategi 2023–2030 på väg.",
     "bicycleMetrePerCapita": 1.9,
-    "totalConsumptionEmission": 5.57,
+    "totalConsumptionEmission": 5.33,
     "electricVehiclePerChargePoints": 8.96,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1mYOB0AiXphXqiUq5N9xPipB1dq_baJDy/view?usp=drive_link"
@@ -16302,7 +16302,7 @@
     "climatePlanYear": 2025,
     "climatePlanComment": "Klimat- och miljöprogram 2025-2040",
     "bicycleMetrePerCapita": 1.59,
-    "totalConsumptionEmission": 6.3,
+    "totalConsumptionEmission": 5.89,
     "electricVehiclePerChargePoints": 34.01,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1tfxAMrHDvtlItM7yGBMxdsf0K34-Mau0/view?usp=drive_link"
@@ -16410,7 +16410,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 3.34,
-    "totalConsumptionEmission": 5.52,
+    "totalConsumptionEmission": 5.23,
     "electricVehiclePerChargePoints": 15.15,
     "procurementScore": "0",
     "procurementLink": ""
@@ -16518,7 +16518,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Energi– och Klimatstrategi. 2020–2030.",
     "bicycleMetrePerCapita": 4.08,
-    "totalConsumptionEmission": 5.46,
+    "totalConsumptionEmission": 5.3,
     "electricVehiclePerChargePoints": 95.5,
     "procurementScore": "0",
     "procurementLink": ""
@@ -16626,7 +16626,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Inom projektet One Planet City Challenge kommer en strategi tas fram, dock oklart när.",
     "bicycleMetrePerCapita": 1.22,
-    "totalConsumptionEmission": 5.77,
+    "totalConsumptionEmission": 5.56,
     "electricVehiclePerChargePoints": 24.64,
     "procurementScore": "0",
     "procurementLink": ""
@@ -16734,7 +16734,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 2.09,
-    "totalConsumptionEmission": 5.54,
+    "totalConsumptionEmission": 5.4,
     "electricVehiclePerChargePoints": 44.2,
     "procurementScore": "0",
     "procurementLink": ""
@@ -16842,7 +16842,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Arbete pågår med Färdplan för ett fossilfritt Norrköping 2030",
     "bicycleMetrePerCapita": 2.38,
-    "totalConsumptionEmission": 5.95,
+    "totalConsumptionEmission": 5.7,
     "electricVehiclePerChargePoints": 21.12,
     "procurementScore": "1",
     "procurementLink": ""
@@ -16950,7 +16950,7 @@
     "climatePlanYear": 2020,
     "climatePlanComment": "Miljö– och klimatstrategi.",
     "bicycleMetrePerCapita": 1.83,
-    "totalConsumptionEmission": 5.53,
+    "totalConsumptionEmission": 5.3,
     "electricVehiclePerChargePoints": 19.84,
     "procurementScore": "0",
     "procurementLink": ""
@@ -17058,7 +17058,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 2.04,
-    "totalConsumptionEmission": 5.28,
+    "totalConsumptionEmission": 5.06,
     "electricVehiclePerChargePoints": 14.62,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/197JctRJdPSChyHhWKPk8PviGzZ6RL1mC/view?usp=drive_link"
@@ -17166,7 +17166,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Senaste gällde fram till 2022.",
     "bicycleMetrePerCapita": 4.33,
-    "totalConsumptionEmission": 5.9,
+    "totalConsumptionEmission": 5.72,
     "electricVehiclePerChargePoints": 23.17,
     "procurementScore": "0",
     "procurementLink": ""
@@ -17274,7 +17274,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 3.53,
-    "totalConsumptionEmission": 5.85,
+    "totalConsumptionEmission": 5.56,
     "electricVehiclePerChargePoints": 9.35,
     "procurementScore": "0",
     "procurementLink": ""
@@ -17382,7 +17382,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Program för ekologisk hållbarhet.",
     "bicycleMetrePerCapita": 3.06,
-    "totalConsumptionEmission": 5.57,
+    "totalConsumptionEmission": 5.3,
     "electricVehiclePerChargePoints": 24.08,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/16zXIRb-G87K_XAdAJMj28s_YY5fhHRpC/view?usp=drive_link"
@@ -17490,7 +17490,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Hållbarhetsprogram 2023–2030",
     "bicycleMetrePerCapita": 3.25,
-    "totalConsumptionEmission": 5.6,
+    "totalConsumptionEmission": 5.33,
     "electricVehiclePerChargePoints": 52.71,
     "procurementScore": "0",
     "procurementLink": ""
@@ -17598,7 +17598,7 @@
     "climatePlanYear": 2016,
     "climatePlanComment": "Energi– och Klimatstrategi.",
     "bicycleMetrePerCapita": 2.71,
-    "totalConsumptionEmission": 5.3,
+    "totalConsumptionEmission": 5.04,
     "electricVehiclePerChargePoints": 22.85,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1R8oO0VhRS0wXPFlYKaNkecRML92FkWWq/view?usp=drive_link"
@@ -17706,7 +17706,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Miljöstrategiskt program 2022–2026",
     "bicycleMetrePerCapita": 2.99,
-    "totalConsumptionEmission": 5.47,
+    "totalConsumptionEmission": 5.32,
     "electricVehiclePerChargePoints": 1.09,
     "procurementScore": "0",
     "procurementLink": ""
@@ -17814,7 +17814,7 @@
     "climatePlanYear": 2023,
     "climatePlanComment": "Ny Handlingsplan för klimat och energi beslutad men ej publicerad",
     "bicycleMetrePerCapita": 3.55,
-    "totalConsumptionEmission": 5.44,
+    "totalConsumptionEmission": 5.28,
     "electricVehiclePerChargePoints": 2.07,
     "procurementScore": "0",
     "procurementLink": ""
@@ -17922,7 +17922,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 2.01,
-    "totalConsumptionEmission": 5.45,
+    "totalConsumptionEmission": 5.22,
     "electricVehiclePerChargePoints": 9.42,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1hESt5-M_HD0dtK51ACwswZJIkQlIEMJA/view?usp=drive_link"
@@ -18030,7 +18030,7 @@
     "climatePlanYear": 2018,
     "climatePlanComment": "Klimatstrategi till 2030",
     "bicycleMetrePerCapita": 1.28,
-    "totalConsumptionEmission": 5.94,
+    "totalConsumptionEmission": 5.65,
     "electricVehiclePerChargePoints": 13.09,
     "procurementScore": "0",
     "procurementLink": ""
@@ -18138,7 +18138,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Klimat– och energiplan. Gäller till 2030.",
     "bicycleMetrePerCapita": 2.23,
-    "totalConsumptionEmission": 5.57,
+    "totalConsumptionEmission": 5.33,
     "electricVehiclePerChargePoints": 22.33,
     "procurementScore": "0",
     "procurementLink": ""
@@ -18246,7 +18246,7 @@
     "climatePlanYear": 2023,
     "climatePlanComment": "Energi- och klimatplan 2023–2028",
     "bicycleMetrePerCapita": 3.61,
-    "totalConsumptionEmission": 5.36,
+    "totalConsumptionEmission": 5.2,
     "electricVehiclePerChargePoints": 17.46,
     "procurementScore": "2",
     "procurementLink": "https://www.oskarshamn.se/bygga-bo-miljo/bygglov-boende-miljo/mat-maltider-och-menyer/"
@@ -18354,7 +18354,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 3.84,
-    "totalConsumptionEmission": 5.41,
+    "totalConsumptionEmission": 5.28,
     "electricVehiclePerChargePoints": 95.33,
     "procurementScore": "0",
     "procurementLink": ""
@@ -18462,7 +18462,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 5.41,
-    "totalConsumptionEmission": 5.31,
+    "totalConsumptionEmission": 5.11,
     "electricVehiclePerChargePoints": 6.94,
     "procurementScore": "0",
     "procurementLink": ""
@@ -18570,7 +18570,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 4.43,
-    "totalConsumptionEmission": 5.45,
+    "totalConsumptionEmission": 5.22,
     "electricVehiclePerChargePoints": 4.0,
     "procurementScore": "0",
     "procurementLink": ""
@@ -18678,7 +18678,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Arbete pågår med ny Klimat– och energiplan.",
     "bicycleMetrePerCapita": 2.19,
-    "totalConsumptionEmission": 6.06,
+    "totalConsumptionEmission": 5.69,
     "electricVehiclePerChargePoints": 35.39,
     "procurementScore": "0",
     "procurementLink": ""
@@ -18786,7 +18786,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Energi– och klimatprogram. Gäller till 2030. ",
     "bicycleMetrePerCapita": 3.51,
-    "totalConsumptionEmission": 5.41,
+    "totalConsumptionEmission": 5.15,
     "electricVehiclePerChargePoints": 5.77,
     "procurementScore": "0",
     "procurementLink": ""
@@ -18894,7 +18894,7 @@
     "climatePlanYear": 2019,
     "climatePlanComment": "Handlingsplan klimat och energi, gäller tillsvidare.",
     "bicycleMetrePerCapita": 3.12,
-    "totalConsumptionEmission": 5.54,
+    "totalConsumptionEmission": 5.4,
     "electricVehiclePerChargePoints": 29.86,
     "procurementScore": "2",
     "procurementLink": "https://www.pitea.se/contentassets/ce699811aafa4dd7a941622e5800b9ae/klimat--och-energiplan.pdf"
@@ -19002,7 +19002,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 1.5,
-    "totalConsumptionEmission": 5.54,
+    "totalConsumptionEmission": 5.32,
     "electricVehiclePerChargePoints": 5.86,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1mCQmKMHi1-lOTKEpsodUI3q1kCJUnJR_/view?usp=drive_link"
@@ -19110,7 +19110,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 1.51,
-    "totalConsumptionEmission": 5.43,
+    "totalConsumptionEmission": 5.21,
     "electricVehiclePerChargePoints": 23.9,
     "procurementScore": "0",
     "procurementLink": ""
@@ -19218,7 +19218,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Program för klimat och energi 2021–2025",
     "bicycleMetrePerCapita": 4.05,
-    "totalConsumptionEmission": 5.54,
+    "totalConsumptionEmission": 5.32,
     "electricVehiclePerChargePoints": 12.62,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1rmnLBQdqN0EK8oGFEoVD5vTY2T7n2oR0/view?usp=drive_link"
@@ -19326,7 +19326,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 1.78,
-    "totalConsumptionEmission": 5.73,
+    "totalConsumptionEmission": 5.56,
     "electricVehiclePerChargePoints": 8.33,
     "procurementScore": "0",
     "procurementLink": ""
@@ -19434,7 +19434,7 @@
     "climatePlanYear": 2019,
     "climatePlanComment": "Energi– och klimatstrategi. 2020–2030 med utblick mot 2045.",
     "bicycleMetrePerCapita": 1.22,
-    "totalConsumptionEmission": 5.54,
+    "totalConsumptionEmission": 5.33,
     "electricVehiclePerChargePoints": 12.75,
     "procurementScore": "0",
     "procurementLink": ""
@@ -19542,7 +19542,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 2.88,
-    "totalConsumptionEmission": 5.84,
+    "totalConsumptionEmission": 5.47,
     "electricVehiclePerChargePoints": 50.6,
     "procurementScore": "2",
     "procurementLink": "https://www.salem.se/bygga-bo--miljo/energi-och-klimat/samordnad-varudistribution/"
@@ -19650,7 +19650,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Arbete pågår med att ta fram en hållbarhetsplan. ",
     "bicycleMetrePerCapita": 3.32,
-    "totalConsumptionEmission": 5.59,
+    "totalConsumptionEmission": 5.36,
     "electricVehiclePerChargePoints": 5.96,
     "procurementScore": "0",
     "procurementLink": ""
@@ -19758,7 +19758,7 @@
     "climatePlanYear": 2018,
     "climatePlanComment": "Plan för klimatsmart Sigtuna",
     "bicycleMetrePerCapita": 2.52,
-    "totalConsumptionEmission": 5.65,
+    "totalConsumptionEmission": 5.28,
     "electricVehiclePerChargePoints": 4.02,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1s8VP3YFBH92yQeCuHFqXf29iWWFINlUa/view?usp=drive_link"
@@ -19866,7 +19866,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Reviderad policy ska presenteras i början av 2024.",
     "bicycleMetrePerCapita": 4.15,
-    "totalConsumptionEmission": 5.71,
+    "totalConsumptionEmission": 5.5,
     "electricVehiclePerChargePoints": 14.25,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1ovZ3qqKSWsWP86RLrS8v6a7lXm-IoLhT/view?usp=drive_link"
@@ -19974,7 +19974,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Hållbara Sjöbo 2034 – Kommunalt miljömålsprogram. ",
     "bicycleMetrePerCapita": 2.76,
-    "totalConsumptionEmission": 5.54,
+    "totalConsumptionEmission": 5.3,
     "electricVehiclePerChargePoints": 28.72,
     "procurementScore": "0",
     "procurementLink": ""
@@ -20082,7 +20082,7 @@
     "climatePlanYear": 2017,
     "climatePlanComment": "Miljöstrategi. ",
     "bicycleMetrePerCapita": 3.8,
-    "totalConsumptionEmission": 5.62,
+    "totalConsumptionEmission": 5.39,
     "electricVehiclePerChargePoints": 12.69,
     "procurementScore": "0",
     "procurementLink": ""
@@ -20190,7 +20190,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Klimatkontrakt 2030 inom Viable Cities.",
     "bicycleMetrePerCapita": 3.35,
-    "totalConsumptionEmission": 5.54,
+    "totalConsumptionEmission": 5.39,
     "electricVehiclePerChargePoints": 22.19,
     "procurementScore": "2",
     "procurementLink": "https://skelleftea.se/invanare/startsida/jobb-och-foretagande/upphandling-och-inkop/policy-for-inkop-och-upphandling"
@@ -20298,7 +20298,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 3.33,
-    "totalConsumptionEmission": 5.73,
+    "totalConsumptionEmission": 5.47,
     "electricVehiclePerChargePoints": 5.74,
     "procurementScore": "0",
     "procurementLink": ""
@@ -20406,7 +20406,7 @@
     "climatePlanYear": 2017,
     "climatePlanComment": "Klimatstrategi och energiplan, gäller till 2030",
     "bicycleMetrePerCapita": 4.53,
-    "totalConsumptionEmission": 5.6,
+    "totalConsumptionEmission": 5.36,
     "electricVehiclePerChargePoints": 20.69,
     "procurementScore": "0",
     "procurementLink": ""
@@ -20514,7 +20514,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Energi– och klimatplan 2021–2030",
     "bicycleMetrePerCapita": 3.16,
-    "totalConsumptionEmission": 5.78,
+    "totalConsumptionEmission": 5.62,
     "electricVehiclePerChargePoints": 11.13,
     "procurementScore": "2",
     "procurementLink": "https://docs.google.com/presentation/d/1UhGuEOewdkD4-C4WKgel_IngCRST9XLi/edit#slide=id.p2"
@@ -20622,7 +20622,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 2.93,
-    "totalConsumptionEmission": 5.8,
+    "totalConsumptionEmission": 5.52,
     "electricVehiclePerChargePoints": 4.48,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1vh9_Pz3sY-ayXP2HYXuymnvxr7-g-JhA/view?usp=drive_link"
@@ -20730,7 +20730,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 1.58,
-    "totalConsumptionEmission": 5.42,
+    "totalConsumptionEmission": 5.22,
     "electricVehiclePerChargePoints": 11.4,
     "procurementScore": "0",
     "procurementLink": ""
@@ -20838,7 +20838,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Plan för miljö– och klimatarbetet 2021–2030",
     "bicycleMetrePerCapita": 1.54,
-    "totalConsumptionEmission": 6.4,
+    "totalConsumptionEmission": 6.02,
     "electricVehiclePerChargePoints": 50.7,
     "procurementScore": "2",
     "procurementLink": "https://docs.google.com/document/d/1lqp_KRVXeN4AnuRHFj3tuIUnA5yjGrke/edit?usp=drive_link&ouid=104089955738391943844&rtpof=true&sd=true"
@@ -20946,7 +20946,7 @@
     "climatePlanYear": 2019,
     "climatePlanComment": "Klimatstrategi",
     "bicycleMetrePerCapita": 1.31,
-    "totalConsumptionEmission": 6.06,
+    "totalConsumptionEmission": 5.72,
     "electricVehiclePerChargePoints": 46.31,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1e7xk7cX43q9lQh-RVgv2iXNVYpy-bTcu/view?usp=drive_link"
@@ -21054,7 +21054,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 2.06,
-    "totalConsumptionEmission": 5.28,
+    "totalConsumptionEmission": 5.05,
     "electricVehiclePerChargePoints": 1.29,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1fBenhGplUcQVmAaD-1OG1dxAdjd_Kpma/view?usp=drive_link"
@@ -21162,7 +21162,7 @@
     "climatePlanYear": 2018,
     "climatePlanComment": "Hållbarhetsstrategi 2030. ",
     "bicycleMetrePerCapita": 1.44,
-    "totalConsumptionEmission": 5.78,
+    "totalConsumptionEmission": 5.52,
     "electricVehiclePerChargePoints": 9.94,
     "procurementScore": "1",
     "procurementLink": ""
@@ -21270,7 +21270,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Miljöplan",
     "bicycleMetrePerCapita": 4.51,
-    "totalConsumptionEmission": 6.21,
+    "totalConsumptionEmission": 5.82,
     "electricVehiclePerChargePoints": 26.6,
     "procurementScore": "0",
     "procurementLink": ""
@@ -21378,7 +21378,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 3.46,
-    "totalConsumptionEmission": 5.88,
+    "totalConsumptionEmission": 5.58,
     "electricVehiclePerChargePoints": 28.4,
     "procurementScore": "2",
     "procurementLink": "https://goteborg.se/wps/portal/start/foretag-och-organisationer/upphandling-och-inkop/hallbar-upphandling/ekologisk-hallbarhet-i-upphandling"
@@ -21486,7 +21486,7 @@
     "climatePlanYear": 2020,
     "climatePlanComment": "Klimathandlingsplan 2020–2023",
     "bicycleMetrePerCapita": 1.21,
-    "totalConsumptionEmission": 6.24,
+    "totalConsumptionEmission": 5.99,
     "electricVehiclePerChargePoints": 14.78,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1lWsJ0ha6OjIKLcy0oKrYebDU7o1TC6ta/view?usp=drive_link"
@@ -21594,7 +21594,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 2.0,
-    "totalConsumptionEmission": 5.95,
+    "totalConsumptionEmission": 5.73,
     "electricVehiclePerChargePoints": 5.09,
     "procurementScore": "0",
     "procurementLink": ""
@@ -21702,7 +21702,7 @@
     "climatePlanYear": 2020,
     "climatePlanComment": "Strategi för koldioxideffektiva resor i Storumans kommun",
     "bicycleMetrePerCapita": 3.4,
-    "totalConsumptionEmission": 5.42,
+    "totalConsumptionEmission": 5.23,
     "electricVehiclePerChargePoints": 2.09,
     "procurementScore": "0",
     "procurementLink": ""
@@ -21810,7 +21810,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Klimat– och energiplan 2021–2040",
     "bicycleMetrePerCapita": 2.51,
-    "totalConsumptionEmission": 5.84,
+    "totalConsumptionEmission": 5.56,
     "electricVehiclePerChargePoints": 27.78,
     "procurementScore": "2",
     "procurementLink": "https://www.strangnas.se/download/18.447c02bc16a7743570ae41bd/1557487982068/Ink%C3%B6ps-%20och%20upphandlingspolicy%20f%C3%B6r%20Str%C3%A4ngn%C3%A4s%20kommun.pdf"
@@ -21918,7 +21918,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Strategi Agenda 2030. Gäller 2021–2025. ",
     "bicycleMetrePerCapita": 4.17,
-    "totalConsumptionEmission": 5.64,
+    "totalConsumptionEmission": 5.43,
     "electricVehiclePerChargePoints": 2.44,
     "procurementScore": "0",
     "procurementLink": ""
@@ -22026,7 +22026,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 1.55,
-    "totalConsumptionEmission": 5.55,
+    "totalConsumptionEmission": 5.29,
     "electricVehiclePerChargePoints": 2.88,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1gQac0zLfRQMl4h2AzgxjVgYx5VxuT8Wj/view?usp=drive_link"
@@ -22134,7 +22134,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 0.7,
-    "totalConsumptionEmission": 6.01,
+    "totalConsumptionEmission": 5.61,
     "electricVehiclePerChargePoints": 58.0,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1u8cO9XWLg7ND9Hu_aZq3K_X91Jywc7jT/view?usp=drive_link"
@@ -22242,7 +22242,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Klimatplan 2022–2024.",
     "bicycleMetrePerCapita": 2.89,
-    "totalConsumptionEmission": 5.88,
+    "totalConsumptionEmission": 5.76,
     "electricVehiclePerChargePoints": 12.74,
     "procurementScore": "1",
     "procurementLink": ""
@@ -22350,7 +22350,7 @@
     "climatePlanYear": 2018,
     "climatePlanComment": "Miljöstrategi. ",
     "bicycleMetrePerCapita": 3.24,
-    "totalConsumptionEmission": 5.56,
+    "totalConsumptionEmission": 5.32,
     "electricVehiclePerChargePoints": 9.26,
     "procurementScore": "0",
     "procurementLink": ""
@@ -22458,7 +22458,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 3.38,
-    "totalConsumptionEmission": 5.64,
+    "totalConsumptionEmission": 5.41,
     "electricVehiclePerChargePoints": 10.74,
     "procurementScore": "0",
     "procurementLink": ""
@@ -22566,7 +22566,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Klimatplan 2022–2030",
     "bicycleMetrePerCapita": 2.97,
-    "totalConsumptionEmission": 5.55,
+    "totalConsumptionEmission": 5.43,
     "electricVehiclePerChargePoints": 24.25,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1JEHzpx_KGTW0UpukUBd6aXjUWRmZuIc0/view?usp=drive_link"
@@ -22674,7 +22674,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Hållbarhetsstrategi.",
     "bicycleMetrePerCapita": 3.5,
-    "totalConsumptionEmission": 5.94,
+    "totalConsumptionEmission": 5.68,
     "electricVehiclePerChargePoints": 37.71,
     "procurementScore": "0",
     "procurementLink": ""
@@ -22782,7 +22782,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 4.79,
-    "totalConsumptionEmission": 5.39,
+    "totalConsumptionEmission": 5.16,
     "electricVehiclePerChargePoints": null,
     "procurementScore": "1",
     "procurementLink": ""
@@ -22890,7 +22890,7 @@
     "climatePlanYear": 2018,
     "climatePlanComment": "Energi- och klimatplan till 2030. ",
     "bicycleMetrePerCapita": 3.5,
-    "totalConsumptionEmission": 5.59,
+    "totalConsumptionEmission": 5.44,
     "electricVehiclePerChargePoints": 23.0,
     "procurementScore": "0",
     "procurementLink": ""
@@ -22998,7 +22998,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Kretsloppsplan och Plan för klimatneutralitet kommer under 2023.",
     "bicycleMetrePerCapita": 2.36,
-    "totalConsumptionEmission": 5.56,
+    "totalConsumptionEmission": 5.36,
     "electricVehiclePerChargePoints": 48.5,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1jO9A8oBwRQKxaLjumj1OOQ2Ct38qjd1n/view?usp=drive_link"
@@ -23106,7 +23106,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 4.42,
-    "totalConsumptionEmission": 5.42,
+    "totalConsumptionEmission": 5.19,
     "electricVehiclePerChargePoints": 32.42,
     "procurementScore": "1",
     "procurementLink": ""
@@ -23214,7 +23214,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Arbete med ny energi– och klimatplan slutförs första kvartalet 2024.",
     "bicycleMetrePerCapita": 2.89,
-    "totalConsumptionEmission": 5.45,
+    "totalConsumptionEmission": 5.28,
     "electricVehiclePerChargePoints": 15.21,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1m5bLwwYggrtNNlKg16vsYWon6MGm8Par/view?usp=drive_link"
@@ -23322,7 +23322,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Mål och strategier för miljö och klimat 2022–2025",
     "bicycleMetrePerCapita": 3.01,
-    "totalConsumptionEmission": 5.66,
+    "totalConsumptionEmission": 5.54,
     "electricVehiclePerChargePoints": 11.37,
     "procurementScore": "0",
     "procurementLink": ""
@@ -23430,7 +23430,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Miljö– och klimatstrategi, gäller till 2030",
     "bicycleMetrePerCapita": 2.87,
-    "totalConsumptionEmission": 5.56,
+    "totalConsumptionEmission": 5.2,
     "electricVehiclePerChargePoints": 67.24,
     "procurementScore": "0",
     "procurementLink": ""
@@ -23538,7 +23538,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 4.88,
-    "totalConsumptionEmission": 5.47,
+    "totalConsumptionEmission": 5.28,
     "electricVehiclePerChargePoints": 12.23,
     "procurementScore": "0",
     "procurementLink": ""
@@ -23646,7 +23646,7 @@
     "climatePlanYear": 2020,
     "climatePlanComment": "Klimat– och miljöstrategi 2020–2024.",
     "bicycleMetrePerCapita": 1.01,
-    "totalConsumptionEmission": 5.85,
+    "totalConsumptionEmission": 5.58,
     "electricVehiclePerChargePoints": 5.89,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1ZlmjJYH8vdPOJRWxToWlBBE_DST1ZAVC/view?usp=drive_link"
@@ -23754,7 +23754,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Med i Klimat 2023 (VGR)",
     "bicycleMetrePerCapita": 4.27,
-    "totalConsumptionEmission": 5.54,
+    "totalConsumptionEmission": 5.32,
     "electricVehiclePerChargePoints": 6.24,
     "procurementScore": "2",
     "procurementLink": "https://docs.google.com/document/d/1klDMfERm6bk0pA9qD8a6xJD3GTqD0RrG/edit?usp=drive_link&ouid=104089955738391943844&rtpof=true&sd=true"
@@ -23862,7 +23862,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Med i Klimat 2023 (VGR). Har koldioxidbudget. ",
     "bicycleMetrePerCapita": 2.07,
-    "totalConsumptionEmission": 5.48,
+    "totalConsumptionEmission": 5.27,
     "electricVehiclePerChargePoints": 38.0,
     "procurementScore": "2",
     "procurementLink": "https://docs.google.com/presentation/d/1UhGuEOewdkD4-C4WKgel_IngCRST9XLi/edit#slide=id.p2"
@@ -23970,7 +23970,7 @@
     "climatePlanYear": 2020,
     "climatePlanComment": "Klimat– och energiplan från år 2020. \"Klimat och energiprogram för Tierps kommun\" kommer att antas 12 december 2023.",
     "bicycleMetrePerCapita": 2.73,
-    "totalConsumptionEmission": 5.35,
+    "totalConsumptionEmission": 5.16,
     "electricVehiclePerChargePoints": 22.52,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1I-qkygApHkxPCh4bd0JJda2BrVTMBZkr/view?usp=drive_link"
@@ -24078,7 +24078,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 2.35,
-    "totalConsumptionEmission": 5.55,
+    "totalConsumptionEmission": 5.3,
     "electricVehiclePerChargePoints": 18.19,
     "procurementScore": "0",
     "procurementLink": ""
@@ -24186,7 +24186,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Miljöprogram 2022–2027",
     "bicycleMetrePerCapita": 8.1,
-    "totalConsumptionEmission": 5.57,
+    "totalConsumptionEmission": 5.31,
     "electricVehiclePerChargePoints": 6.31,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1GPESfcGXvYvQhoZW8TayLG0Fl9C-C5LY/view?usp=drive_link"
@@ -24294,7 +24294,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 1.33,
-    "totalConsumptionEmission": 5.96,
+    "totalConsumptionEmission": 5.62,
     "electricVehiclePerChargePoints": 34.08,
     "procurementScore": "0",
     "procurementLink": ""
@@ -24402,7 +24402,7 @@
     "climatePlanYear": 2023,
     "climatePlanComment": "Klimatplan 2024-2045",
     "bicycleMetrePerCapita": 2.2,
-    "totalConsumptionEmission": 5.39,
+    "totalConsumptionEmission": 5.23,
     "electricVehiclePerChargePoints": 59.2,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1WEriX_kLliQ7-_DEX5Bc05VgrBFeIQSC/view?usp=drive_link"
@@ -24510,7 +24510,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 1.44,
-    "totalConsumptionEmission": 5.6,
+    "totalConsumptionEmission": 5.4,
     "electricVehiclePerChargePoints": 2.62,
     "procurementScore": "1",
     "procurementLink": ""
@@ -24618,7 +24618,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Arbete med klimatplan väntas vara klart under andra kvartalet 2024.",
     "bicycleMetrePerCapita": 4.27,
-    "totalConsumptionEmission": 5.6,
+    "totalConsumptionEmission": 5.35,
     "electricVehiclePerChargePoints": 19.9,
     "procurementScore": "0",
     "procurementLink": ""
@@ -24726,7 +24726,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Med i Klimat 2023 (VGR)",
     "bicycleMetrePerCapita": 6.09,
-    "totalConsumptionEmission": 5.41,
+    "totalConsumptionEmission": 5.19,
     "electricVehiclePerChargePoints": 48.18,
     "procurementScore": "0",
     "procurementLink": ""
@@ -24834,7 +24834,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Ekologisk hållbarhetsstrategi 2022–2035. Arbete pågår med klimatplan, vilken ska släppas under 2024.",
     "bicycleMetrePerCapita": 4.07,
-    "totalConsumptionEmission": 5.21,
+    "totalConsumptionEmission": 5.04,
     "electricVehiclePerChargePoints": 36.17,
     "procurementScore": "0",
     "procurementLink": ""
@@ -24942,7 +24942,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 3.04,
-    "totalConsumptionEmission": 5.82,
+    "totalConsumptionEmission": 5.58,
     "electricVehiclePerChargePoints": 26.94,
     "procurementScore": "0",
     "procurementLink": ""
@@ -25050,7 +25050,7 @@
     "climatePlanYear": 2024,
     "climatePlanComment": "Gäller 2024-2027",
     "bicycleMetrePerCapita": 2.99,
-    "totalConsumptionEmission": 5.47,
+    "totalConsumptionEmission": 5.21,
     "electricVehiclePerChargePoints": 10.4,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1AHepDbh2-DMpocV6KArinKglkgM1GFn1/view?usp=drive_link"
@@ -25158,7 +25158,7 @@
     "climatePlanYear": 2023,
     "climatePlanComment": "Energi- och klimatplan",
     "bicycleMetrePerCapita": 3.63,
-    "totalConsumptionEmission": 5.74,
+    "totalConsumptionEmission": 5.4,
     "electricVehiclePerChargePoints": 15.48,
     "procurementScore": "0",
     "procurementLink": ""
@@ -25266,7 +25266,7 @@
     "climatePlanYear": 2019,
     "climatePlanComment": "Klimatplan 2030",
     "bicycleMetrePerCapita": 2.19,
-    "totalConsumptionEmission": 5.78,
+    "totalConsumptionEmission": 5.44,
     "electricVehiclePerChargePoints": 67.08,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1d87b8ZKab9jzAX6vpuptgTUv6F0EDH4v/view?usp=drive_link"
@@ -25374,7 +25374,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 2.35,
-    "totalConsumptionEmission": 6.4,
+    "totalConsumptionEmission": 5.97,
     "electricVehiclePerChargePoints": 55.47,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1F5TxQo7GHWYFPgsG9dzJZplkScHfppfR/view?usp=sharing"
@@ -25482,7 +25482,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Strategi för Agenda 2030",
     "bicycleMetrePerCapita": 5.55,
-    "totalConsumptionEmission": 5.5,
+    "totalConsumptionEmission": 5.28,
     "electricVehiclePerChargePoints": 10.38,
     "procurementScore": "2",
     "procurementLink": "https://toreboda.se/Toreboda-kommun/Hallbarhet--miljo/Strategiskt-hallbarhetsarbete/Kommunens-klimatloften"
@@ -25590,7 +25590,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Energi– och klimatplan 2022–2030. Finns även separat åtgärdsplan.",
     "bicycleMetrePerCapita": 2.37,
-    "totalConsumptionEmission": 5.78,
+    "totalConsumptionEmission": 5.48,
     "electricVehiclePerChargePoints": 16.48,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1LCvp1LfjM4Q0wnCbEqL1F6zJ8fJiZKmq/view?usp=drive_link"
@@ -25698,7 +25698,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Står bakom klimatlöften inom Västra Götalands klimat 2030",
     "bicycleMetrePerCapita": 6.22,
-    "totalConsumptionEmission": 5.36,
+    "totalConsumptionEmission": 5.15,
     "electricVehiclePerChargePoints": 11.0,
     "procurementScore": "0",
     "procurementLink": ""
@@ -25806,7 +25806,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Program och planer för att nå Umeå kommuns miljömål",
     "bicycleMetrePerCapita": 2.66,
-    "totalConsumptionEmission": 5.7,
+    "totalConsumptionEmission": 5.54,
     "electricVehiclePerChargePoints": 20.25,
     "procurementScore": "2",
     "procurementLink": "https://docs.google.com/document/d/13xhFpEzYLYzbCAhrQGnl-ZycaY8DR9pD/edit?usp=drive_link&ouid=104089955738391943844&rtpof=true&sd=true"
@@ -25914,7 +25914,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Klimat– och energistrategi för Upplands Väsby 2022–2025",
     "bicycleMetrePerCapita": 3.86,
-    "totalConsumptionEmission": 5.76,
+    "totalConsumptionEmission": 5.46,
     "electricVehiclePerChargePoints": 38.33,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1gOAObk2x8iu_AOGdUeRIntx3umiFfEAx/view?usp=drive_link"
@@ -25995,7 +25995,7 @@
     "climatePlanYear": 2023,
     "climatePlanComment": "Miljö– och klimatstrategi 2023–2045",
     "bicycleMetrePerCapita": 2.66,
-    "totalConsumptionEmission": 6.03,
+    "totalConsumptionEmission": 5.75,
     "electricVehiclePerChargePoints": 16.52,
     "procurementScore": "2",
     "procurementLink": "https://www.upplands-bro.se/download/18.7f3cb58e1825cf9e8316f0/1659459494101/Upphandlingspolicy"
@@ -26103,7 +26103,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Miljö– och klimatprogram. Se även tillhörande handlingsplan.",
     "bicycleMetrePerCapita": 2.15,
-    "totalConsumptionEmission": 6.08,
+    "totalConsumptionEmission": 5.96,
     "electricVehiclePerChargePoints": 20.75,
     "procurementScore": "2",
     "procurementLink": "https://www.uppsala.se/kommun-och-politik/publikationer/2021/mal-och-budget-2022-med-plan-for-2023-2024/"
@@ -26211,7 +26211,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Förslag på remiss för klimat– och energistrategi 2022–2030 ",
     "bicycleMetrePerCapita": 0.3,
-    "totalConsumptionEmission": 5.3,
+    "totalConsumptionEmission": 5.06,
     "electricVehiclePerChargePoints": 36.8,
     "procurementScore": "2",
     "procurementLink": "https://foretag.vaxjo.se/download/18.3d04795317955c86cd918e16/1622707803967/Klimatkontrakt%202030.pdf"
@@ -26319,7 +26319,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 3.4,
-    "totalConsumptionEmission": 5.54,
+    "totalConsumptionEmission": 5.33,
     "electricVehiclePerChargePoints": 23.57,
     "procurementScore": "0",
     "procurementLink": ""
@@ -26427,7 +26427,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Miljöprogram 2022–2025",
     "bicycleMetrePerCapita": 5.25,
-    "totalConsumptionEmission": 5.56,
+    "totalConsumptionEmission": 5.35,
     "electricVehiclePerChargePoints": 12.85,
     "procurementScore": "0",
     "procurementLink": ""
@@ -26535,7 +26535,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 2.51,
-    "totalConsumptionEmission": 5.37,
+    "totalConsumptionEmission": 5.22,
     "electricVehiclePerChargePoints": 6.18,
     "procurementScore": "0",
     "procurementLink": ""
@@ -26643,7 +26643,7 @@
     "climatePlanYear": 2019,
     "climatePlanComment": "Miljö– och klimatstrategi",
     "bicycleMetrePerCapita": 2.23,
-    "totalConsumptionEmission": 6.04,
+    "totalConsumptionEmission": 5.68,
     "electricVehiclePerChargePoints": 37.68,
     "procurementScore": "2",
     "procurementLink": "https://dok.vallentuna.se/file/f%C3%B6rfattningssamling/1.%20kommungemensam/1.2%20ekonomi/1.2.6%20policys/1.2.6.3%20Policy%20f%C3%B6r%20ink%C3%B6p%20och%20upphandling.pdf"
@@ -26751,7 +26751,7 @@
     "climatePlanYear": 2013,
     "climatePlanComment": "Energi– och klimatplan 2010–2020 (gäller fortfarande)",
     "bicycleMetrePerCapita": 1.33,
-    "totalConsumptionEmission": 5.5,
+    "totalConsumptionEmission": 5.28,
     "electricVehiclePerChargePoints": 5.74,
     "procurementScore": "0",
     "procurementLink": ""
@@ -26859,7 +26859,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Miljöstrategi 2021–2030",
     "bicycleMetrePerCapita": 3.81,
-    "totalConsumptionEmission": 5.53,
+    "totalConsumptionEmission": 5.31,
     "electricVehiclePerChargePoints": 9.74,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1hP2o4QdT7KM2v9EQTACLtq04yYq5VTqP/view?usp=drive_link"
@@ -26967,7 +26967,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Pågår arbete med att ta fram en energi– och klimatstrategi.",
     "bicycleMetrePerCapita": 2.88,
-    "totalConsumptionEmission": 5.61,
+    "totalConsumptionEmission": 5.32,
     "electricVehiclePerChargePoints": 14.47,
     "procurementScore": "1",
     "procurementLink": ""
@@ -27075,7 +27075,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Hållbara Vaxholm 2021–2030. Vaxholms stads hållbarhetsstrategi 2021–2030",
     "bicycleMetrePerCapita": 1.19,
-    "totalConsumptionEmission": 6.54,
+    "totalConsumptionEmission": 6.14,
     "electricVehiclePerChargePoints": 110.25,
     "procurementScore": "2",
     "procurementLink": "https://www.vaxholm.se/download/18.6719b35d171ac1e3c542cbff/1589542471525/Upphandlings-%20och%20ink%C3%B6pspolicy.pdf"
@@ -27183,7 +27183,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Program för hållbar utveckling. 2020–2030.",
     "bicycleMetrePerCapita": 3.91,
-    "totalConsumptionEmission": 6.51,
+    "totalConsumptionEmission": 6.09,
     "electricVehiclePerChargePoints": 27.05,
     "procurementScore": "0",
     "procurementLink": ""
@@ -27291,7 +27291,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Har ett miljöbokslut 2021 där Jönköpings mål finns.",
     "bicycleMetrePerCapita": 3.85,
-    "totalConsumptionEmission": 5.37,
+    "totalConsumptionEmission": 5.17,
     "electricVehiclePerChargePoints": 27.84,
     "procurementScore": "0",
     "procurementLink": ""
@@ -27399,7 +27399,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 1.03,
-    "totalConsumptionEmission": 5.51,
+    "totalConsumptionEmission": 5.33,
     "electricVehiclePerChargePoints": 7.33,
     "procurementScore": "0",
     "procurementLink": ""
@@ -27507,7 +27507,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 3.19,
-    "totalConsumptionEmission": 5.34,
+    "totalConsumptionEmission": 5.1,
     "electricVehiclePerChargePoints": 7.25,
     "procurementScore": "0",
     "procurementLink": ""
@@ -27615,7 +27615,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 3.34,
-    "totalConsumptionEmission": 5.22,
+    "totalConsumptionEmission": 5.03,
     "electricVehiclePerChargePoints": 12.17,
     "procurementScore": "0",
     "procurementLink": ""
@@ -27723,7 +27723,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Med i Glokala Sverige 2021",
     "bicycleMetrePerCapita": 1.84,
-    "totalConsumptionEmission": 5.47,
+    "totalConsumptionEmission": 5.29,
     "electricVehiclePerChargePoints": 31.3,
     "procurementScore": "0",
     "procurementLink": ""
@@ -27831,7 +27831,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Miljöaktivitetsplan 2022",
     "bicycleMetrePerCapita": 4.06,
-    "totalConsumptionEmission": 5.47,
+    "totalConsumptionEmission": 5.23,
     "electricVehiclePerChargePoints": 14.19,
     "procurementScore": "2",
     "procurementLink": "https://vanersborg.se/kommun-och-politik/hallbar-utveckling/klimatloften-2024-2026"
@@ -27939,7 +27939,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 2.61,
-    "totalConsumptionEmission": 5.53,
+    "totalConsumptionEmission": 5.32,
     "electricVehiclePerChargePoints": 10.37,
     "procurementScore": "0",
     "procurementLink": ""
@@ -28047,7 +28047,7 @@
     "climatePlanYear": 2024,
     "climatePlanComment": "Miljö– och klimatplan 2020–2030, reviderad 2024",
     "bicycleMetrePerCapita": 1.5,
-    "totalConsumptionEmission": 5.98,
+    "totalConsumptionEmission": 5.64,
     "electricVehiclePerChargePoints": 21.08,
     "procurementScore": "2",
     "procurementLink": "https://opengov.360online.com/Meetings/varmdo/File/Details/806917.PDF?fileName=M%C3%A5l%20och%20budget%202024%20med%20ramar%202025-2027%20version%202%20efter%20KS%20beredning&fileSize=9104281"
@@ -28155,7 +28155,7 @@
     "climatePlanYear": 2023,
     "climatePlanComment": "Plan för Värnamo kommuns miljöarbete 2023–2035. Planen har en tillhörande åtgärdsplan med konkreta åtgärder",
     "bicycleMetrePerCapita": 4.56,
-    "totalConsumptionEmission": 5.58,
+    "totalConsumptionEmission": 5.27,
     "electricVehiclePerChargePoints": 15.58,
     "procurementScore": "0",
     "procurementLink": ""
@@ -28263,7 +28263,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Energi– och klimatstrategi 2021–2030",
     "bicycleMetrePerCapita": 3.23,
-    "totalConsumptionEmission": 5.63,
+    "totalConsumptionEmission": 5.51,
     "electricVehiclePerChargePoints": 9.72,
     "procurementScore": "2",
     "procurementLink": "https://www.vastervik.se/Bygga-bo-och-miljo/Energi-och-uppvarmning/kommunens-energi-och-klimatstrategi/"
@@ -28371,7 +28371,7 @@
     "climatePlanYear": 2017,
     "climatePlanComment": "Klimatprogram med handlingsplan 2017–2020. ",
     "bicycleMetrePerCapita": 2.91,
-    "totalConsumptionEmission": 5.9,
+    "totalConsumptionEmission": 5.59,
     "electricVehiclePerChargePoints": 11.13,
     "procurementScore": "1",
     "procurementLink": ""
@@ -28479,7 +28479,7 @@
     "climatePlanYear": 2019,
     "climatePlanComment": "Hållbarhetsprogram Hållbara Växjö 2030",
     "bicycleMetrePerCapita": 2.86,
-    "totalConsumptionEmission": 5.49,
+    "totalConsumptionEmission": 5.19,
     "electricVehiclePerChargePoints": 20.19,
     "procurementScore": "2",
     "procurementLink": "https://foretag.vaxjo.se/download/18.3d04795317955c86cd918e16/1622707803967/Klimatkontrakt%202030.pdf"
@@ -28587,7 +28587,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Förberedande arbete pågår.",
     "bicycleMetrePerCapita": 2.45,
-    "totalConsumptionEmission": 5.48,
+    "totalConsumptionEmission": 5.25,
     "electricVehiclePerChargePoints": 15.52,
     "procurementScore": "1",
     "procurementLink": ""
@@ -28695,7 +28695,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 1.81,
-    "totalConsumptionEmission": 5.67,
+    "totalConsumptionEmission": 5.38,
     "electricVehiclePerChargePoints": 72.5,
     "procurementScore": "0",
     "procurementLink": ""
@@ -28803,7 +28803,7 @@
     "climatePlanYear": 2020,
     "climatePlanComment": "Miljöprogram 2021–2025",
     "bicycleMetrePerCapita": 4.32,
-    "totalConsumptionEmission": 5.57,
+    "totalConsumptionEmission": 5.31,
     "electricVehiclePerChargePoints": 10.28,
     "procurementScore": "0",
     "procurementLink": ""
@@ -28911,7 +28911,7 @@
     "climatePlanYear": 2020,
     "climatePlanComment": "Miljöplan 2030",
     "bicycleMetrePerCapita": 3.48,
-    "totalConsumptionEmission": 5.63,
+    "totalConsumptionEmission": 5.37,
     "electricVehiclePerChargePoints": 8.37,
     "procurementScore": "0",
     "procurementLink": ""
@@ -29019,7 +29019,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Beslut om utveckling av klimatplan väntas före sommaren 2023",
     "bicycleMetrePerCapita": 0.77,
-    "totalConsumptionEmission": 5.67,
+    "totalConsumptionEmission": 5.37,
     "electricVehiclePerChargePoints": 1.94,
     "procurementScore": "0",
     "procurementLink": ""
@@ -29127,7 +29127,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 1.62,
-    "totalConsumptionEmission": 5.47,
+    "totalConsumptionEmission": 5.32,
     "electricVehiclePerChargePoints": 3.97,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1sI2sMvR9jRMyIvnH2Z4U7BE3kuW8LiQU/view?usp=drive_link"
@@ -29235,7 +29235,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Energi– och klimatstrategi",
     "bicycleMetrePerCapita": 2.26,
-    "totalConsumptionEmission": 5.75,
+    "totalConsumptionEmission": 5.58,
     "electricVehiclePerChargePoints": 9.32,
     "procurementScore": "2",
     "procurementLink": "https://www.pitea.se/contentassets/ce699811aafa4dd7a941622e5800b9ae/klimat--och-energiplan.pdf"
@@ -29343,7 +29343,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. Ny hållbarhetsplan under utveckling.",
     "bicycleMetrePerCapita": 3.69,
-    "totalConsumptionEmission": 5.68,
+    "totalConsumptionEmission": 5.37,
     "electricVehiclePerChargePoints": 23.49,
     "procurementScore": "1",
     "procurementLink": ""
@@ -29451,7 +29451,7 @@
     "climatePlanYear": 2017,
     "climatePlanComment": "Energi– och klimatstrategi",
     "bicycleMetrePerCapita": 3.03,
-    "totalConsumptionEmission": 5.35,
+    "totalConsumptionEmission": 5.14,
     "electricVehiclePerChargePoints": 3.82,
     "procurementScore": "0",
     "procurementLink": ""
@@ -29559,7 +29559,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 1.97,
-    "totalConsumptionEmission": 5.53,
+    "totalConsumptionEmission": 5.33,
     "electricVehiclePerChargePoints": 6.56,
     "procurementScore": "0",
     "procurementLink": ""
@@ -29667,7 +29667,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 1.31,
-    "totalConsumptionEmission": 5.67,
+    "totalConsumptionEmission": 5.49,
     "electricVehiclePerChargePoints": 2.72,
     "procurementScore": "2",
     "procurementLink": "https://docs.google.com/document/d/1s_u6HwkOhsOd_of59VGruJbXWOfdcqT8/edit?usp=drive_link&ouid=104089955738391943844&rtpof=true&sd=true"
@@ -29775,7 +29775,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 2.43,
-    "totalConsumptionEmission": 5.61,
+    "totalConsumptionEmission": 4.97,
     "electricVehiclePerChargePoints": 3.02,
     "procurementScore": "0",
     "procurementLink": ""
@@ -29883,7 +29883,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas.",
     "bicycleMetrePerCapita": 0.82,
-    "totalConsumptionEmission": 5.3,
+    "totalConsumptionEmission": 5.01,
     "electricVehiclePerChargePoints": 14.0,
     "procurementScore": "0",
     "procurementLink": ""
@@ -29991,7 +29991,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Verksamhetsplan för miljöstrategiskt arbete 2022.",
     "bicycleMetrePerCapita": 3.05,
-    "totalConsumptionEmission": 5.65,
+    "totalConsumptionEmission": 5.33,
     "electricVehiclePerChargePoints": 11.69,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1w-XpLcjZch_a49jJyc65AJSYXjl6kOfM/view?usp=drive_link"
@@ -30099,7 +30099,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Hållbarhetsprogram. Gäller tillsvidare.",
     "bicycleMetrePerCapita": 3.14,
-    "totalConsumptionEmission": 5.41,
+    "totalConsumptionEmission": 5.2,
     "electricVehiclePerChargePoints": null,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1GImZzAP8XtBTbmc3aaOyERVvPTJ9CyMY/view?usp=drive_link"
@@ -30207,7 +30207,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 1.59,
-    "totalConsumptionEmission": 5.68,
+    "totalConsumptionEmission": 5.37,
     "electricVehiclePerChargePoints": 51.08,
     "procurementScore": "0",
     "procurementLink": ""
@@ -30315,7 +30315,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 2.3,
-    "totalConsumptionEmission": 5.42,
+    "totalConsumptionEmission": 5.23,
     "electricVehiclePerChargePoints": 3.22,
     "procurementScore": "0",
     "procurementLink": ""
@@ -30423,7 +30423,7 @@
     "climatePlanYear": 2016,
     "climatePlanComment": "Miljöstrategi med mål och delmål 2020 och 2030",
     "bicycleMetrePerCapita": 3.53,
-    "totalConsumptionEmission": 5.66,
+    "totalConsumptionEmission": 5.38,
     "electricVehiclePerChargePoints": 13.57,
     "procurementScore": "2",
     "procurementLink": "https://www.orebro.se/fordjupning/fordjupning/sa-arbetar-vi-med/maltider-i-kommunens-kok-och-serveringar.html"
@@ -30531,7 +30531,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 5.19,
-    "totalConsumptionEmission": 5.44,
+    "totalConsumptionEmission": 5.21,
     "electricVehiclePerChargePoints": 6.83,
     "procurementScore": "2",
     "procurementLink": "https://drive.google.com/file/d/1w-XpLcjZch_a49jJyc65AJSYXjl6kOfM/view?usp=drive_link"
@@ -30639,7 +30639,7 @@
     "climatePlanYear": 2021,
     "climatePlanComment": "Klimatstrategi, gäller till 2026.",
     "bicycleMetrePerCapita": 2.12,
-    "totalConsumptionEmission": 5.68,
+    "totalConsumptionEmission": 5.48,
     "electricVehiclePerChargePoints": 15.4,
     "procurementScore": "2",
     "procurementLink": "https://docs.google.com/document/d/1Hjjp7bZbrpEoJ_rQuWgm48KzYZAvCtdw/edit"
@@ -30747,7 +30747,7 @@
     "climatePlanYear": 2019,
     "climatePlanComment": "Klimatprogram Färden mot ett fossilbränslefritt och energieffektivt Östersund 2030",
     "bicycleMetrePerCapita": 3.01,
-    "totalConsumptionEmission": 5.38,
+    "totalConsumptionEmission": 5.21,
     "electricVehiclePerChargePoints": 10.9,
     "procurementScore": "2",
     "procurementLink": "https://www.ostersund.se/bygga-bo-och-miljo/klimat-och-miljo/sa-arbetar-kommunen-med-klimat-och-miljo/klimatstrategi.html"
@@ -30855,7 +30855,7 @@
     "climatePlanYear": 2022,
     "climatePlanComment": "Miljö– och klimatprogram 2030.",
     "bicycleMetrePerCapita": 2.24,
-    "totalConsumptionEmission": 5.98,
+    "totalConsumptionEmission": 5.65,
     "electricVehiclePerChargePoints": 37.07,
     "procurementScore": "0",
     "procurementLink": ""
@@ -30963,7 +30963,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 2.24,
-    "totalConsumptionEmission": 5.39,
+    "totalConsumptionEmission": 5.19,
     "electricVehiclePerChargePoints": 16.17,
     "procurementScore": "0",
     "procurementLink": ""
@@ -31071,7 +31071,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 3.79,
-    "totalConsumptionEmission": 5.38,
+    "totalConsumptionEmission": 5.15,
     "electricVehiclePerChargePoints": 57.5,
     "procurementScore": "1",
     "procurementLink": ""
@@ -31179,7 +31179,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 1.78,
-    "totalConsumptionEmission": 5.72,
+    "totalConsumptionEmission": 5.62,
     "electricVehiclePerChargePoints": 3.47,
     "procurementScore": "0",
     "procurementLink": ""
@@ -31287,7 +31287,7 @@
     "climatePlanYear": null,
     "climatePlanComment": "Plan saknas. ",
     "bicycleMetrePerCapita": 3.13,
-    "totalConsumptionEmission": 5.84,
+    "totalConsumptionEmission": 5.66,
     "electricVehiclePerChargePoints": 28.0,
     "procurementScore": "0",
     "procurementLink": ""


### PR DESCRIPTION
Reverts Klimatbyran/garbo#827 to go back to 2022 data from 2023 after receiving feedback that we should not display the 2023 data even when commenting that it is approximated data. 2022 data is the latest reviewed and verified data. 

A followup PR on the FE side is required to adjust the copy. As well as a followup PR to revert the changes on the pipeline for municipality pipeline.