### PR TITLE
new return structure where we return metadata alongside the value

### DIFF
--- a/src/workers/checkDB.ts
+++ b/src/workers/checkDB.ts
@@ -33,9 +33,14 @@ const checkDB = new DiscordWorker(
       
     } = job.data
   
+    const childrenEntries = await job.getChildrenEntries()
+    
+    // Extract values from the new format where the returned value is wrapped in 'value' so we can also return metadata next to it (for validation tool),
+    //  or fallback to the old format where the returned value is not wrapped in 'value'
+    const extractValue = (entry: any) => entry?.value || entry
     const {
       scope12,
-      scope3,
+      scope3, 
       biogenic,
       industry,
       economy,
@@ -44,7 +49,9 @@ const checkDB = new DiscordWorker(
       initiatives,
       descriptions,
       lei,
-    } = await job.getChildrenEntries()
+    } = Object.fromEntries(
+      Object.entries(childrenEntries).map(([key, value]) => [key, extractValue(value)])
+    )
   
     job.sendMessage(`🤖 Checking if ${companyName} already exists in API...`)
     const wikidataId = wikidata.node


### PR DESCRIPTION
This change makes garbo output some metadata that we want to display in the validation tool after each step. New data returned is:

- prompt for garbo
- context (markdown pdf snippets garbo received)
- the schema for the data structure we want returnened form the AI

since we change the return values of the workers it also updates another function that uses that return value (the original value is now wrapped in `value` alongside the metadata attribute