### PR TITLE
removing the json object default since we always send in the schema

### DIFF
--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -9,6 +9,7 @@ const openai = new OpenAI({
   apiKey: openaiConfig.apiKey,
 })
 
+
 const ask = async (messages: ChatCompletionMessageParam[], options?: RequestOptions & {response_format?: ResponseFormatJSONSchema}) => {
   const response = await openai.chat.completions.create({
     messages: messages.filter((m) => m.content),
@@ -42,17 +43,19 @@ const askStream = async (
   options: RequestOptions  & {onParagraph?: (response: string, paragraph: string) => void} & {response_format?: ResponseFormatJSONSchema}
 ) => {
   const { stream: _, ...safeOpenAIOptions } = options
-  const stream:  Stream<ChatCompletionChunk> = await openai.chat.completions.create({
+
+  const config = {
     messages: messages.filter((m) => m.content),
     model: 'gpt-4o-2024-08-06',
     temperature: 0.1,
     stream: true,
     max_tokens: 4096,
-    response_format: {
-      type: 'json_object',
-    },
+    response_format: options.response_format,
     ...safeOpenAIOptions,
-  }  satisfies ChatCompletionCreateParamsStreaming);
+  } satisfies ChatCompletionCreateParamsStreaming;
+
+  const stream:  Stream<ChatCompletionChunk> = await openai.chat.completions.create(config);
+
 
   let response = ''
   let paragraph = ''


### PR DESCRIPTION
i dont really see the point of supporting json_object as return value from openai, we always send a real schema instead