### PR TITLE
[FIX] Remove api terms link until the page is built

### DIFF
--- a/src/config/openapi.ts
+++ b/src/config/openapi.ts
@@ -112,7 +112,6 @@ All endpoints require authentication using a Bearer token. Include your API key 
 ## Resources
 
 * [Klimatkollen Website](https://klimatkollen.se)
-* [API Terms of Service](https://klimatkollen.se/terms)
 * [Contact Support](mailto:support@klimatkollen.se)
 
 ## Examples


### PR DESCRIPTION
### Background
The openAPI docs included a link to a page that we don't have yet, so we're temporarily removing the reference it until we build that page. 

### What Changed
Removed link to API Terms doc