### PR TITLE
Create better defaults in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ API_PORT=3000
 API_BASE_URL=http://localhost:3000/api
 OPENAPI_PREFIX=api
 # Secret used for signing user data (i.e. creating tokens)
-JWT_SECRET=
+JWT_SECRET=11111111111111111111
 JWT_EXPIRES_IN=3600
 # Secret used to verify the client requesting a token (You can set this to anything when running locally)
 API_SECRET=
@@ -23,7 +23,7 @@ CACHE_MAX_AGE=3000
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 GITHUB_ORG=Klimatbyran
-GITHUB_REDIRECT_URI=http://localhost:5137/auth/callback
+GITHUB_REDIRECT_URI=http://localhost:5173/auth/callback
 
 
 


### PR DESCRIPTION
The JWT_SECRET can not be empty or Garbo will through an error trying to login the user for local development.

The GITHUB_REDIRECT_URI was pointing to the wrong port which was really hard to tell since it was just two numbers swapped with each other.