### PR TITLE
Fix/remove vision api

### DIFF
--- a/src/jobs/extractScreenshots/extractScreenshots.ts
+++ b/src/jobs/extractScreenshots/extractScreenshots.ts
@@ -4,7 +4,6 @@ import { extractTableScreenshotsFromJson, fetchPdf } from '../../lib/pdfTools'
 import { ParsedDocument } from '../../lib/nlm-ingestor-schema'
 import { Logger } from '../../types'
 
-
 const searchTerms = [
   // Carbon-related terms
   'co2',
@@ -31,22 +30,30 @@ const searchTerms = [
   'växthusgaser',
   'klimatavtryck',
   'klimatpåverkan',
-  'klimatneutral'
+  'klimatneutral',
 ]
 
+export async function createScreenshots(
+  json: ParsedDocument,
+  url: string,
+  logger: Logger,
+): Promise<void> {
+  logger.info('🔍 Searching for relevant tables...')
+  const pdf = await fetchPdf(url)
+  const outputDir = path.resolve('/tmp', 'garbo-screenshots')
+  await mkdir(outputDir, { recursive: true })
+  logger.info('✅ PDF downloaded')
+  logger.info('🔍 Creating screenshots of tables...')
+  const pageCount = await extractTableScreenshotsFromJson(
+    pdf,
+    json,
+    outputDir,
+    searchTerms,
+    url,
+  )
+  logger.info(
+    `🤖 Found relevant tables at ${pageCount} unique pages and made screenshots of them.`,
+  )
 
-export async function createScreenshots(json: ParsedDocument, url: string, logger: Logger): Promise<void> {
-    logger.info('🔍 Searching for relevant tables...')
-    const pdf = await fetchPdf(url)
-    const outputDir = path.resolve('/tmp', 'garbo-screenshots')
-    await mkdir(outputDir, { recursive: true })
-    logger.info('✅ PDF downloaded')
-    logger.info('🔍 Creating screenshots of tables...')
-    const pageCount = await extractTableScreenshotsFromJson(pdf, json, outputDir, searchTerms, url)
-    logger.info(
-        `🤖 Found relevant tables at ${pageCount} unique pages and made screenshots of them.`
-      )
-  
-    logger.info(`Extracted ${pageCount} pages`)
-  
+  logger.info(`Extracted ${pageCount} pages`)
 }

--- a/src/jobs/extractScreenshots/extractScreenshots.ts
+++ b/src/jobs/extractScreenshots/extractScreenshots.ts
@@ -1,0 +1,52 @@
+import path from 'path'
+import { mkdir } from 'fs/promises'
+import { extractTableScreenshotsFromJson, fetchPdf } from '../../lib/pdfTools'
+import { ParsedDocument } from '../../lib/nlm-ingestor-schema'
+import { Logger } from '../../types'
+
+
+const searchTerms = [
+  // Carbon-related terms
+  'co2',
+  'co2e',
+  'co2 eq',
+  'carbon dioxide',
+  'carbon footprint',
+  'carbon emissions',
+  'carbon neutral',
+  'carbon intensity',
+  'GHG',
+  'greenhouse gas',
+  'emissions',
+  'scope 1',
+  'scope 2',
+  'scope 3',
+  'climate impact',
+  'carbon offset',
+
+  // Swedish terms
+  'utsläpp',
+  'koldioxid',
+  'koldioxidekvivalenter',
+  'växthusgaser',
+  'klimatavtryck',
+  'klimatpåverkan',
+  'klimatneutral'
+]
+
+
+export async function createScreenshots(json: ParsedDocument, url: string, logger: Logger): Promise<void> {
+    logger.info('🔍 Searching for relevant tables...')
+    const pdf = await fetchPdf(url)
+    const outputDir = path.resolve('/tmp', 'garbo-screenshots')
+    await mkdir(outputDir, { recursive: true })
+    logger.info('✅ PDF downloaded')
+    logger.info('🔍 Creating screenshots of tables...')
+    const pageCount = await extractTableScreenshotsFromJson(pdf, json, outputDir, searchTerms, url)
+    logger.info(
+        `🤖 Found relevant tables at ${pageCount} unique pages and made screenshots of them.`
+      )
+  
+    logger.info(`Extracted ${pageCount} pages`)
+  
+}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,12 +1,12 @@
-import { DiscordJob } from "./DiscordWorker"
+import { DiscordJob } from './DiscordWorker'
 
 export const createDiscordLogger = (job?: DiscordJob) => {
-    if(!job){
-        return {
-            info: (message: string) => console.log(`${message}`),
-            error: (message: string) => console.error(`❌ ${message}`),
-        }
+  if (!job) {
+    return {
+      info: (message: string) => console.log(`${message}`),
+      error: (message: string) => console.error(`❌ ${message}`),
     }
+  }
   return {
     info: async (message: string) => {
       await job.log(message)

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,28 @@
+import { DiscordJob } from "./DiscordWorker"
+
+export const createDiscordLogger = (job?: DiscordJob) => {
+    if(!job){
+        return {
+            info: (message: string) => console.log(`${message}`),
+            error: (message: string) => console.error(`❌ ${message}`),
+        }
+    }
+  return {
+    info: async (message: string) => {
+      await job.log(message)
+      try {
+        await job.sendMessage(`${message}`)
+      } catch (err) {
+        await job.log(`WARN: failed to send Discord message: ${message}`)
+      }
+    },
+    error: async (message: string) => {
+      await job.log(`ERROR: ${message}`)
+      try {
+        await job.editMessage(`❌ ${message}`)
+      } catch (err) {
+        await job.log(`WARN: failed to edit Discord message: ${message}`)
+      }
+    },
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,3 +87,9 @@ export interface Initiative {
   year?: string;
   scope?: string;
 }
+
+
+export interface Logger {
+  info(message: string, meta?: any): void;
+  error(message: string, meta?: any): void;
+}

--- a/src/workers/indexMarkdown.ts
+++ b/src/workers/indexMarkdown.ts
@@ -3,14 +3,16 @@ import { DiscordWorker, DiscordJob } from '../lib/DiscordWorker'
 import { vectorDB } from '../lib/vectordb'
 import { QUEUE_NAMES } from '../queues'
 
-class IndexMarkdownJob extends DiscordJob {}
+class IndexMarkdownJob extends DiscordJob {
+  declare data: DiscordJob['data'] & {
+    markdown: string
+  }
+}
 
 const indexMarkdown = new DiscordWorker(
   QUEUE_NAMES.INDEX_MARKDOWN,
   async (job: IndexMarkdownJob) => {
-    const { url } = job.data
-    const childrenValues = await job.getChildrenEntries()
-    const { markdown }: { markdown: string } = childrenValues
+    const { url, markdown } = job.data
 
     await job.sendMessage(`🤖 Saving to vector database...`)
     job.log(

--- a/src/workers/nlmExtractTables.ts
+++ b/src/workers/nlmExtractTables.ts
@@ -15,17 +15,17 @@ const nlmExtractTables = new DiscordWorker(
   QUEUE_NAMES.NLM_EXTRACT_TABLES,
   async (job: NLMExtractTablesJob, logger: Logger) => {
     const { json, url } = job.data
-    try {  
+    try {
       await createScreenshots(json, url, logger)
     } catch (error) {
-      logger.error(`Error in ${QUEUE_NAMES.NLM_EXTRACT_TABLES}: ${error.message}`)
-      throw new UnrecoverableError(`Error in ${QUEUE_NAMES.NLM_EXTRACT_TABLES}: ${error.message}`)
+      logger.error(
+        `Error in ${QUEUE_NAMES.NLM_EXTRACT_TABLES}: ${error.message}`,
+      )
+      throw new UnrecoverableError(
+        `Error in ${QUEUE_NAMES.NLM_EXTRACT_TABLES}: ${error.message}`,
+      )
     }
-
   },
 )
 
 export default nlmExtractTables
-
-
-

--- a/src/workers/nlmExtractTables.ts
+++ b/src/workers/nlmExtractTables.ts
@@ -1,14 +1,9 @@
-import { readFileSync, statSync } from 'fs'
 import { UnrecoverableError } from 'bullmq'
-import path from 'path'
-import { mkdir } from 'fs/promises'
-
 import { DiscordJob, DiscordWorker } from '../lib/DiscordWorker'
-import { extractTablesFromJson, fetchPdf } from '../lib/pdfTools'
-import { jsonToMarkdown } from '../lib/jsonExtraction'
-import { openai } from '../lib/openai'
 import { ParsedDocument } from '../lib/nlm-ingestor-schema'
 import { QUEUE_NAMES } from '../queues'
+import { createScreenshots } from '@/jobs/extractScreenshots/extractScreenshots'
+import { Logger } from '@/types'
 
 class NLMExtractTablesJob extends DiscordJob {
   declare data: DiscordJob['data'] & {
@@ -16,158 +11,21 @@ class NLMExtractTablesJob extends DiscordJob {
   }
 }
 
-const searchTerms = [
-  // Carbon-related terms
-  'co2',
-  'co2e',
-  'co2 eq',
-  'carbon dioxide',
-  'carbon footprint',
-  'carbon emissions',
-  'carbon neutral',
-  'carbon intensity',
-  'GHG',
-  'greenhouse gas',
-  'emissions',
-  'scope 1',
-  'scope 2',
-  'scope 3',
-  'climate impact',
-  'carbon offset',
-
-  // Swedish terms
-  'utsläpp',
-  'koldioxid',
-  'koldioxidekvivalenter',
-  'växthusgaser',
-  'klimatavtryck',
-  'klimatpåverkan',
-  'klimatneutral'
-]
-
 const nlmExtractTables = new DiscordWorker(
   QUEUE_NAMES.NLM_EXTRACT_TABLES,
-  process
+  async (job: NLMExtractTablesJob, logger: Logger) => {
+    const { json, url } = job.data
+    try {  
+      await createScreenshots(json, url, logger)
+    } catch (error) {
+      logger.error(`Error in ${QUEUE_NAMES.NLM_EXTRACT_TABLES}: ${error.message}`)
+      throw new UnrecoverableError(`Error in ${QUEUE_NAMES.NLM_EXTRACT_TABLES}: ${error.message}`)
+    }
+
+  },
 )
 
-async function process(job: NLMExtractTablesJob) {
-  const { json, url } = job.data
-
-  job.sendMessage('🔍 Searching for relevant tables...')
-
-  try {
-    const pdf = await fetchPdf(url)
-    const outputDir = path.resolve('/tmp', 'garbo-screenshots')
-    await mkdir(outputDir, { recursive: true })
-    job.editMessage(`✅ PDF downloaded!`)
-
-    job.log('Extracting pages...')
-    const { pages } = await extractTablesFromJson(
-      pdf,
-      json,
-      outputDir,
-      searchTerms,
-      url
-    )
-
-    job.sendMessage(
-      `🤖 Found relevant tables at ${pages.length} unique pages.`
-    )
-
-    job.log(`Extracted ${pages.length} pages. Extracting tables...`)
-
-    // Filter out empty files first
-    const validPages = pages.filter(({ filename }) => {
-      const isValid = statSync(filename).size > 0
-      if (!isValid) {
-        job.log(`⚠️ Skipping empty image: ${filename}`)
-      }
-      return isValid
-    })
-
-    // Process tables in parallel
-    const extractionPromises = validPages.map(async ({ pageNumber, filename }, index) => {
-      // Use the previous table as context if available
-      let contextMarkdown = ''
-      if (index > 0) {
-        // We need to wait for previous extractions, but only for providing context
-        // This doesn't block parallel execution of API calls
-        try {
-          const previousResults = await Promise.any(
-            extractionPromises.slice(0, index).map(p => p.catch(() => null))
-          )
-          if (previousResults) {
-            contextMarkdown = previousResults.markdown
-          }
-        } catch {
-          // Continue without context if we can't get previous results
-        }
-      }
-
-      const markdown = await extractTextViaVisionAPI({ filename }, contextMarkdown) ?? ''
-
-      return {
-        page_idx: Number(pageNumber - 1),
-        markdown,
-      }
-    })
-    
-    // Wait for all extractions to complete
-    const tables = await Promise.all(extractionPromises)
-
-    // Sort tables by page index to maintain order
-    tables.sort((a, b) => a.page_idx - b.page_idx)
-
-    job.log('Extracted tables: ' + tables.map((t) => t.markdown).join(', '))
-
-    return {
-      markdown:
-        jsonToMarkdown(json) +
-        '\n\n This is some of the important tables from the markdown with more precision:' +
-        tables
-          .map(
-            ({ page_idx, markdown }) =>
-              `\n#### Page ${page_idx}:
-                ${markdown}`
-          )
-          .join('\n'),
-    }
-  } catch (error) {
-    job.editMessage(`❌ Error interpreting the PDF: ${error.message}`)
-    throw new UnrecoverableError(`Download Failed: ${error.message}`)
-  }
-}
-
-const extractTextViaVisionAPI = async ( 
-  { filename, }: { filename: string }, 
-  context: string 
-) => {
-  const result = await openai.chat.completions.create({
-    model: 'gpt-4o-mini',
-    messages: [
-      { role: 'system', content: 'You are a CSRD expert and will extract text from a PDF with extract from the tables.', },
-      { role: 'user', content: `I need you to extract tables related to CO2 emissions from this PDF screenshot. Please follow these exact instructions:
-
-1. Extract only tables and their headers from the screenshot
-2. Completely ignore any unrelated text (headers, illustrations, descriptions, footnotes, disclaimers)
-3. For any missing or empty cells in tables, use "n.a." as a placeholder
-4. Format all tables using proper Markdown syntax
-5. ONLY respond with the Markdown tables - no additional text or commentary
-6. If no tables are found in the image, respond with an empty string
-
-I'll send you the screenshot momentarily. Can you follow these instructions precisely?`, },
-      { role: 'assistant', content: 'Sure. Sounds good. Send the screenshot and I will extract the table(s) if there are any and return in markdown format as accurately as possible without any other comment.', },
-      { role: 'user', content: 'This is previous table extracted from previous pages:' + context, },
-      { role: 'assistant', content: 'Thanks, noted. Lets look at the screenshot.', },
-      { role: 'user', content: [ { type: 'image_url', image_url: { url: base64Encode(filename), detail: 'high' }, }, ], },
-    ],
-  })
-  return result.choices[0].message.content
-}
-
-const base64Encode = (filename: string) => {
-  const data = readFileSync(path.resolve(filename)).toString('base64')
-  return 'data:image/png;base64,' + data
-}
-
 export default nlmExtractTables
+
+
+

--- a/src/workers/nlmParsePDF.ts
+++ b/src/workers/nlmParsePDF.ts
@@ -135,6 +135,10 @@ const nlmParsePDF = new DiscordWorker(
             {
               ...base,
               name: 'indexMarkdown ' + name,
+              data: {
+                ...base.data,
+                markdown,
+              },
               queueName: QUEUE_NAMES.INDEX_MARKDOWN,
               children: [
                 {


### PR DESCRIPTION
I removed the call to vision API and simplified the parse tables worker by extracting the core logic into the jobs folder and injecting a dynamic logger into the worker (preparing the discord worker for leaving discord eventually).

Now we also pass markdown in the job data directly from parsePDF to indexMarkdown (before it just circled via parseTables worker so we could add markdown from the now-removed Vision API)

This worker's logic has a questionable future if we switch to docling since then we can get markdown directly and don't get the json step that we currently extract the tables from, but I am using this worker as an experiment anyway to decouple from discord a bit more. 