### PR TITLE
[Fix] company caching

### DIFF
--- a/src/api/routes/company.read.ts
+++ b/src/api/routes/company.read.ts
@@ -83,8 +83,6 @@ export async function companyReadRoutes(app: FastifyInstance) {
         await redisCache.set(cacheKey, JSON.stringify(currentEtag))
       }
 
-      if (clientEtag === currentEtag) return reply.code(304).send()
-
       const dataCacheKey = `companies:data:${databaseFingerprint}`
 
       let companies = await redisCache.get(dataCacheKey)

--- a/src/api/routes/company.read.ts
+++ b/src/api/routes/company.read.ts
@@ -34,7 +34,6 @@ export async function companyReadRoutes(app: FastifyInstance) {
     },
 
     async (request, reply) => {
-      const clientEtag = request.headers['if-none-match']
       const cacheKey = 'companies:etag'
 
       let currentEtag: string = await redisCache.get(cacheKey)

--- a/src/api/routes/municipality.read.ts
+++ b/src/api/routes/municipality.read.ts
@@ -35,7 +35,7 @@ export async function municipalityReadRoutes(app: FastifyInstance) {
       schema: {
         summary: 'Get all municipalities',
         description:
-          'Retrieve a list of all municipalities with data about their emissions, carbon budget, climate plans, bike infrastructure, procurements, and much more.',
+          'Retrieve a list of all municipalities with data about their emissions, carbon budget, climate plans, bike infrastructure, procurements, and much more. Returns 304 Not Modified if the resource has not changed since the last request (based on ETag).',
         tags: getTags('Municipalities'),
 
         response: {
@@ -43,7 +43,7 @@ export async function municipalityReadRoutes(app: FastifyInstance) {
         },
       },
     },
-    async (_, reply) => {
+    async (request, reply) => {
       const currentTimestamp = getDataFileTimestamp()
       const etagValue = `"${currentTimestamp}"`
 

--- a/src/api/routes/municipality.read.ts
+++ b/src/api/routes/municipality.read.ts
@@ -35,7 +35,7 @@ export async function municipalityReadRoutes(app: FastifyInstance) {
       schema: {
         summary: 'Get all municipalities',
         description:
-          'Retrieve a list of all municipalities with data about their emissions, carbon budget, climate plans, bike infrastructure, procurements, and much more. Returns 304 Not Modified if the resource has not changed since the last request (based on ETag).',
+          'Retrieve a list of all municipalities with data about their emissions, carbon budget, climate plans, bike infrastructure, procurements, and much more.',
         tags: getTags('Municipalities'),
 
         response: {
@@ -43,14 +43,9 @@ export async function municipalityReadRoutes(app: FastifyInstance) {
         },
       },
     },
-    async (request, reply) => {
+    async (_, reply) => {
       const currentTimestamp = getDataFileTimestamp()
       const etagValue = `"${currentTimestamp}"`
-      const ifNoneMatch = request.headers['if-none-match']
-
-      if (ifNoneMatch === etagValue) {
-        return reply.code(304).send()
-      }
 
       const cachedMunicipalities = await redisCache.get(
         MUNICIPALITIES_CACHE_KEY,


### PR DESCRIPTION
Base company cache on fingerprint made up of all company data instead of only metadata updates. Update prompted by former cache strategy breaking when introducing future emissions trend slopes on backend.

Also remove 304 response - this might not be want we want, then feel free to leave other suggestions we can commit!