### PR TITLE
add missing environment variables & remove unused variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,8 @@
 
 NODE_ENV=development
 
-DATABASE_URL=postgresql://postgres:mysecretpassword@localhost:5432/garbo # Not used anywhere at the moment
+# Not needed when running the project locally
+DATABASE_URL=postgresql://postgres:mysecretpassword@localhost:5432/garbo 
 
 # API VARIABLES
 
@@ -49,8 +50,6 @@ DISCORD_CHANNEL_ID=
 NLM_INGESTOR_URL=http://0.0.0.0:5001
 
 CHROMA_HOST=http://127.0.0.1:8000
-# optional
-CHROMA_TOKEN=
 CHROMA_CHUNK_SIZE=2000
 
 REDIS_HOST=localhost
@@ -58,8 +57,17 @@ REDIS_PORT=6379
 # optional
 REDIS_PASSWORD=
 
+# Wikidata script variables
+# Optional, only necessary if running the wikidata script
+
+WIKIDATA_CONSUMER_KEY=
+WIKIDATA_CONSUMER_SECRET=
+WIKIDATA_TOKEN=
+WIKIDATA_TOKEN_SECRET=
+
 WIKI_USERNAME=
 WIKI_PASSWORD=
+
 MAILCHIMP_API_KEY=
 MAILCHIMP_LIST_ID=
 MAILCHIMP_SERVER_PREFIX=


### PR DESCRIPTION
Fix #914 

- Added the missing wikidata variables to the env.example, that are necessary to run the wikidata script
- Removed chroma token variable as it's not used in codebase anymore