### PR TITLE
made it configurable which extractEmissions workers should run

### DIFF
--- a/src/workers/extractEmissions.ts
+++ b/src/workers/extractEmissions.ts
@@ -1,11 +1,24 @@
-import { FlowProducer } from 'bullmq'
+import { FlowChildJob, FlowProducer } from 'bullmq'
 import redis from '../config/redis'
 import { DiscordJob, DiscordWorker } from '../lib/DiscordWorker'
 import { QUEUE_NAMES } from '../queues'
 
+type FollowUpKey =
+  | 'industryGics'
+  | 'scope1+2'
+  | 'scope3'
+  | 'biogenic'
+  | 'economy'
+  | 'goals'
+  | 'initiatives'
+  | 'baseYear'
+  | 'lei'
+  | 'descriptions'
+
 class ExtractEmissionsJob extends DiscordJob {
   declare data: DiscordJob['data'] & {
     companyName: string
+    runOnly?: (FollowUpKey | 'all')[]
   }
 }
 
@@ -14,7 +27,7 @@ const flow = new FlowProducer({ connection: redis })
 const extractEmissions = new DiscordWorker<ExtractEmissionsJob>(
   QUEUE_NAMES.EXTRACT_EMISSIONS,
   async (job) => {
-    const { companyName } = job.data
+    const { companyName, runOnly } = job.data
     job.sendMessage(`🤖 Fetching emissions data...`)
 
     const { wikidata, fiscalYear } = await job.getChildrenEntries()
@@ -29,54 +42,83 @@ const extractEmissions = new DiscordWorker<ExtractEmissionsJob>(
       },
     }
 
-    await flow.add({
-      name: companyName,
-      queueName: QUEUE_NAMES.CHECK_DB,
-      data: {
-        ...base.data,
-      },
-      children: [
-        {
+    job.log('🔍 Running these workers : ' + runOnly?.join(', '))
+
+    // a worker should run if it is explicitly in the runOnly array or if runOnly is 'all'
+    const shouldRun = (key: FollowUpKey) => {
+      if (!runOnly) return true
+      if (runOnly.includes('all')) return true
+      return runOnly.includes(key)
+    }
+    
+    const childrenJobs: { key: FollowUpKey, job: FlowChildJob }[] = [
+      {
+        key: 'industryGics',
+        job: {
           ...base,
           name: 'industryGics ' + companyName,
           queueName: QUEUE_NAMES.FOLLOW_UP_INDUSTRY_GICS,
-        },
-        {
+        }
+      },
+      {
+        key: 'scope1+2',
+        job: {
           ...base,
           name: 'scope1+2 ' + companyName,
           queueName: QUEUE_NAMES.FOLLOW_UP_SCOPE_12,
-        },
-        {
+        }
+      },
+      {
+        key: 'scope3',
+        job: {
           ...base,
           name: 'scope3 ' + companyName,
           queueName: QUEUE_NAMES.FOLLOW_UP_SCOPE_3,
-        },
-        {
+        }
+      },
+      {
+        key: 'biogenic',
+        job: {
           ...base,
           name: 'biogenic ' + companyName,
           queueName: QUEUE_NAMES.FOLLOW_UP_BIOGENIC,
-        },
-        {
+        }
+      },
+      {
+        key: 'economy',
+        job: {
           ...base,
           name: 'economy ' + companyName,
           queueName: QUEUE_NAMES.FOLLOW_UP_ECONOMY,
-        },
-        {
+        }
+      },
+      {
+        key: 'goals',
+        job: {
           ...base,
           name: 'goals ' + companyName,
           queueName: QUEUE_NAMES.FOLLOW_UP_GOALS,
-        },
-        {
+        }
+      },
+      {
+        key: 'initiatives',
+        job: {
           ...base,
           name: 'initiatives ' + companyName,
           queueName: QUEUE_NAMES.FOLLOW_UP_INITIATIVES,
-        },
-        {
+        }
+      },
+      {
+        key: 'baseYear',
+        job: {
           ...base,
           name: 'baseYear ' + companyName,
           queueName: QUEUE_NAMES.FOLLOW_UP_BASE_YEAR,
-        },
-        {
+        }
+      },  
+      {
+        key: 'lei',
+        job: {
           ...base,
           name: 'lei ' + companyName,
           queueName: QUEUE_NAMES.EXTRACT_LEI,
@@ -84,18 +126,33 @@ const extractEmissions = new DiscordWorker<ExtractEmissionsJob>(
             ...base.data,
             wikidataId: base.data.wikidata.node
           }
-        },
-        {
+        }
+      },
+      {
+        key: 'descriptions',
+        job: {
+          ...base,
           name: 'descriptions ' + companyName,
           queueName: QUEUE_NAMES.EXTRACT_DESCRIPTIONS,
           data: {
             ...job.data,
             companyId: wikidata.node,
             type: undefined,
-          },
+          }
+        }
+      }
+    ]
 
-        },
-      ],
+
+    await flow.add({
+      name: companyName,
+      queueName: QUEUE_NAMES.CHECK_DB,
+      data: {
+        ...base.data,
+      },
+      children: [
+        ...childrenJobs.filter((child) => shouldRun(child.key)).map((child) => child.job),
+      ].filter((e) => e !== null),
       opts: {
         attempts: 3,
       },


### PR DESCRIPTION
after this update you can pass `runOnly: ['scope3', 'scope1+2']` in `data` when you add a report to the queue and only those workers will re-run (initiatives, goals etc won't run or won't run again)