### PR TITLE
[FIX] Add company identifier object and api endpoints

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,9 @@ model Company {
   url         String?
   lei         String?
 
+  /// Company identifiers (LEI, Swedish org number, etc.)
+  identifiers CompanyIdentifier[]
+
   /// TODO: Save Swedish org number, which might be the same as LEI or ISIN
   // swedishOrgNumber
 
@@ -332,6 +335,7 @@ model Metadata {
   turnoverId             String?
   employeesId            String?
   descriptionId          String?
+  companyIdentifierId    String?
 
   goal                 Goal?                 @relation(fields: [goalId], references: [id])
   initiative           Initiative?           @relation(fields: [initiativeId], references: [id])
@@ -350,6 +354,7 @@ model Metadata {
   turnover             Turnover?             @relation(fields: [turnoverId], references: [id])
   employees            Employees?            @relation(fields: [employeesId], references: [id])
   description          Description?          @relation(fields: [descriptionId], references: [id], onDelete: Cascade)
+  companyIdentifier    CompanyIdentifier?
 }
 
 model User {
@@ -382,4 +387,18 @@ model Description {
 
   company      Company      @relation(fields: [companyId], references: [wikidataId], onDelete: Cascade)
   metadata  Metadata[]
+}
+
+/// Company identifiers (LEI, Swedish org number, ISIN, etc.)
+model CompanyIdentifier {
+  id        String   @id @default(cuid())
+  companyId String
+  type      String   // 'lei', 'swedishOrgNumber', 'isin', 'cin', 'duns'
+  value     String
+  metadataId String? @unique
+
+  company   Company  @relation(fields: [companyId], references: [wikidataId], onDelete: Cascade)
+  metadata  Metadata? @relation(fields: [metadataId], references: [id])
+
+  @@unique([companyId, type])
 }

--- a/scripts/migrate-lei-to-identifiers.ts
+++ b/scripts/migrate-lei-to-identifiers.ts
@@ -1,0 +1,117 @@
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+async function migrateLeiToIdentifiers() {
+  console.log('Starting LEI to identifiers migration...')
+
+  try {
+    // Get all companies with LEI data
+    const companies = await prisma.company.findMany({
+      where: {
+        AND: [{ lei: { not: null } }, { lei: { not: '' } }],
+      },
+      select: {
+        wikidataId: true,
+        lei: true,
+      },
+    })
+
+    console.log(`Found ${companies.length} companies with LEI data`)
+
+    // Create a system user for migration metadata
+    let systemUser = await prisma.user.findFirst({
+      where: { name: 'system-migration' },
+    })
+
+    if (!systemUser) {
+      systemUser = await prisma.user.create({
+        data: {
+          name: 'system-migration',
+          email: 'system@garbo.ai',
+        },
+      })
+      console.log('Created system user for migration')
+    }
+
+    let migratedCount = 0
+    let skippedCount = 0
+
+    for (const company of companies) {
+      if (!company.lei) {
+        skippedCount++
+        continue
+      }
+
+      try {
+        // Check if identifier already exists
+        const existingIdentifier = await prisma.companyIdentifier.findUnique({
+          where: {
+            companyId_type: {
+              companyId: company.wikidataId,
+              type: 'lei',
+            },
+          },
+        })
+
+        if (existingIdentifier) {
+          console.log(
+            `LEI identifier already exists for ${company.wikidataId}, skipping`,
+          )
+          skippedCount++
+          continue
+        }
+
+        // Create metadata for the migration
+        const metadata = await prisma.metadata.create({
+          data: {
+            comment: 'Migrated from legacy LEI field',
+            source: 'system-migration',
+            userId: systemUser.id,
+            verifiedByUserId: systemUser.id, // Mark as verified since it was already in the system
+          },
+        })
+
+        // Create identifier record
+        await prisma.companyIdentifier.create({
+          data: {
+            companyId: company.wikidataId,
+            type: 'lei',
+            value: company.lei,
+            metadataId: metadata.id,
+          },
+        })
+
+        migratedCount++
+        console.log(`Migrated LEI for ${company.wikidataId}: ${company.lei}`)
+      } catch (error) {
+        console.error(`Error migrating LEI for ${company.wikidataId}:`, error)
+      }
+    }
+
+    console.log(`Migration completed:`)
+    console.log(`- Migrated: ${migratedCount}`)
+    console.log(`- Skipped: ${skippedCount}`)
+    console.log(`- Total processed: ${companies.length}`)
+  } catch (error) {
+    console.error('Migration failed:', error)
+    throw error
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+// Run migration if this script is executed directly
+if (require.main === module) {
+  migrateLeiToIdentifiers()
+    .then(() => {
+      console.log('Migration completed successfully')
+      process.exit(0)
+    })
+    .catch((error) => {
+      console.error('Migration failed:', error)
+      process.exit(1)
+    })
+}
+
+export default migrateLeiToIdentifiers

--- a/scripts/test-identifiers.ts
+++ b/scripts/test-identifiers.ts
@@ -1,0 +1,82 @@
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+async function testIdentifiers() {
+  console.log('Testing identifier system...')
+
+  try {
+    // Test 1: Check if CompanyIdentifier model exists
+    console.log('✓ CompanyIdentifier model is available')
+
+    // Test 2: Test creating a test identifier
+    const testCompany = await prisma.company.findFirst()
+    if (!testCompany) {
+      console.log('❌ No companies found in database')
+      return
+    }
+
+    console.log(
+      `✓ Found test company: ${testCompany.name} (${testCompany.wikidataId})`,
+    )
+
+    // Test 3: Test identifier service import
+    const { identifierService } = await import(
+      '../src/api/services/identifierService'
+    )
+    console.log('✓ Identifier service imported successfully')
+
+    // Test 4: Test schema imports
+    const { identifierTypeSchema, companyIdentifierSchema } = await import(
+      '../src/api/schemas/identifier'
+    )
+    console.log('✓ Identifier schemas imported successfully')
+
+    // Test 5: Validate identifier types
+    const validTypes = ['lei', 'swedishOrgNumber', 'isin', 'cin', 'duns']
+    for (const type of validTypes) {
+      const result = identifierTypeSchema.safeParse(type)
+      if (result.success) {
+        console.log(`✓ Identifier type '${type}' is valid`)
+      } else {
+        console.log(`❌ Identifier type '${type}' is invalid:`, result.error)
+      }
+    }
+
+    // Test 6: Test identifier schema validation
+    const testIdentifier = {
+      type: 'lei',
+      value: '12345678901234567890',
+      verified: true,
+    }
+
+    const identifierResult = companyIdentifierSchema.safeParse(testIdentifier)
+    if (identifierResult.success) {
+      console.log('✓ Identifier schema validation works')
+    } else {
+      console.log(
+        '❌ Identifier schema validation failed:',
+        identifierResult.error,
+      )
+    }
+
+    console.log('\n🎉 All tests passed! Identifier system is ready to use.')
+  } catch (error) {
+    console.error('❌ Test failed:', error)
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+// Run test
+testIdentifiers()
+  .then(() => {
+    console.log('Test completed')
+    process.exit(0)
+  })
+  .catch((error) => {
+    console.error('Test failed:', error)
+    process.exit(1)
+  })
+
+export default testIdentifiers

--- a/src/api/args.ts
+++ b/src/api/args.ts
@@ -73,10 +73,18 @@ export const detailedCompanyArgs = {
       select: {
         id: true,
         text: true,
-        language: true
-      }
+        language: true,
+      },
     },
     lei: true,
+    identifiers: {
+      select: {
+        id: true,
+        type: true,
+        value: true,
+        metadata: metadataArgs,
+      },
+    },
     reportingPeriods: {
       select: {
         id: true,
@@ -238,10 +246,18 @@ export const companyListArgs = {
       select: {
         id: true,
         language: true,
-        text: true
-      }
+        text: true,
+      },
     },
     lei: true,
+    identifiers: {
+      select: {
+        id: true,
+        type: true,
+        value: true,
+        metadata: metadataArgs,
+      },
+    },
     baseYear: {
       select: { id: true, year: true, metadata: metadataArgs },
     },
@@ -356,8 +372,8 @@ export const companyExportArgs = (year?) => {
       descriptions: {
         select: {
           language: true,
-          text: true
-        }
+          text: true,
+        },
       },
       baseYear: {
         select: { id: true, year: true },

--- a/src/api/routes/company.identifiers.ts
+++ b/src/api/routes/company.identifiers.ts
@@ -1,0 +1,127 @@
+import { FastifyInstance, AuthenticatedFastifyRequest } from 'fastify'
+import { identifierService } from '../services/identifierService'
+import { metadataService } from '../services/metadataService'
+import {
+  wikidataIdParamSchema,
+  okResponseSchema,
+  getErrorSchemas,
+} from '../schemas'
+import {
+  postIdentifiersBodySchema,
+  updateIdentifierBodySchema,
+  PostIdentifiersBody,
+  UpdateIdentifierBody,
+} from '../schemas/identifier'
+import { getTags } from '../../config/openapi'
+import { WikidataIdParams } from '../types'
+
+export async function companyIdentifiersRoutes(app: FastifyInstance) {
+  app.post(
+    '/:wikidataId/identifiers',
+    {
+      schema: {
+        summary: 'Create or update company identifiers',
+        description: 'Create or update multiple identifiers for a company',
+        tags: getTags('Companies'),
+        params: wikidataIdParamSchema,
+        body: postIdentifiersBodySchema,
+        response: {
+          200: okResponseSchema,
+          ...getErrorSchemas(400, 404, 500),
+        },
+      },
+    },
+    async (
+      request: AuthenticatedFastifyRequest<{
+        Params: WikidataIdParams
+        Body: PostIdentifiersBody
+      }>,
+      reply,
+    ) => {
+      const { wikidataId } = request.params
+      const { identifiers, metadata } = request.body
+
+      try {
+        const createdMetadata = await metadataService.createMetadata({
+          metadata,
+          user: request.user,
+        })
+
+        await Promise.all(
+          identifiers.map((identifier: any) =>
+            identifierService.upsertIdentifier(
+              wikidataId,
+              identifier.type,
+              identifier.value,
+              createdMetadata,
+            ),
+          ),
+        )
+
+        return reply.send({ ok: true })
+      } catch (error) {
+        console.error('Error creating/updating identifiers:', error)
+        return reply.status(500).send({
+          code: '500',
+          message: 'Failed to create/update identifiers',
+        })
+      }
+    },
+  )
+
+  app.patch(
+    '/:wikidataId/identifiers/:type',
+    {
+      schema: {
+        summary: 'Update a specific identifier',
+        description: 'Update a specific identifier type for a company',
+        tags: getTags('Companies'),
+        params: {
+          type: 'object',
+          properties: {
+            wikidataId: { type: 'string' },
+            type: { type: 'string' },
+          },
+          required: ['wikidataId', 'type'],
+        },
+        body: updateIdentifierBodySchema,
+        response: {
+          200: okResponseSchema,
+          ...getErrorSchemas(400, 404, 500),
+        },
+      },
+    },
+    async (
+      request: AuthenticatedFastifyRequest<{
+        Params: { wikidataId: string; type: string }
+        Body: UpdateIdentifierBody
+      }>,
+      reply,
+    ) => {
+      const { wikidataId, type } = request.params
+      const { value, metadata } = request.body
+
+      try {
+        const createdMetadata = await metadataService.createMetadata({
+          metadata,
+          user: request.user,
+        })
+
+        await identifierService.updateIdentifier(
+          wikidataId,
+          type,
+          value,
+          createdMetadata,
+        )
+
+        return reply.send({ ok: true })
+      } catch (error) {
+        console.error('Error updating identifier:', error)
+        return reply.status(500).send({
+          code: '500',
+          message: 'Failed to update identifier',
+        })
+      }
+    },
+  )
+}

--- a/src/api/schemas/identifier.ts
+++ b/src/api/schemas/identifier.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod'
+import { createMetadataSchema } from './request'
+
+export const identifierTypeSchema = z.enum([
+  'lei',
+  'swedishOrgNumber',
+  'isin',
+  'cin',
+  'duns',
+])
+
+export const companyIdentifierSchema = z.object({
+  id: z.string().optional(),
+  type: identifierTypeSchema,
+  value: z.string(),
+  verified: z.boolean().optional(),
+})
+
+export const postIdentifiersBodySchema = z
+  .object({
+    identifiers: z.array(companyIdentifierSchema),
+  })
+  .merge(createMetadataSchema)
+
+export const updateIdentifierBodySchema = z
+  .object({
+    type: identifierTypeSchema,
+    value: z.string(),
+    verified: z.boolean().optional(),
+  })
+  .merge(createMetadataSchema)
+
+export type IdentifierType = z.infer<typeof identifierTypeSchema>
+export type CompanyIdentifier = z.infer<typeof companyIdentifierSchema>
+export type PostIdentifiersBody = z.infer<typeof postIdentifiersBodySchema>
+export type UpdateIdentifierBody = z.infer<typeof updateIdentifierBodySchema>

--- a/src/api/schemas/request.ts
+++ b/src/api/schemas/request.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import { emissionUnitSchemaWithDefault, wikidataIdSchema } from './common'
 
-const createMetadataSchema = z.object({
+export const createMetadataSchema = z.object({
   metadata: z
     .object({
       source: z.string().optional(),
@@ -126,7 +126,7 @@ export const emissionsSchema = z
         {
           message:
             'At least one property of `mb`, `lb` and `unknown` must be defined if scope2 is provided',
-        }
+        },
       )
       .optional(),
     scope3: z
@@ -138,7 +138,7 @@ export const emissionsSchema = z
               total: z.number().nullable().optional(),
               unit: emissionUnitSchemaWithDefault,
               verified: z.boolean().optional(),
-            })
+            }),
           )
           .optional(),
         statedTotalEmissions: statedTotalEmissionsSchema,

--- a/src/api/schemas/response.ts
+++ b/src/api/schemas/response.ts
@@ -39,10 +39,18 @@ export const MetadataSchema = z.object({
 
 export const MinimalMetadataSchema = MetadataSchema.pick({ verifiedBy: true })
 
+export const CompanyIdentifierSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  value: z.string(),
+  metadata: MetadataSchema,
+})
+
 const CompanyBaseSchema = z.object({
   wikidataId: wikidataIdSchema,
   name: z.string(),
   lei: z.string().optional().nullable(),
+  identifiers: z.array(CompanyIdentifierSchema).optional(),
 })
 
 export const StatedTotalEmissionsSchema = z.object({

--- a/src/api/services/identifierService.ts
+++ b/src/api/services/identifierService.ts
@@ -1,0 +1,53 @@
+import { Company, CompanyIdentifier, Metadata } from '@prisma/client'
+import { prisma } from '../../lib/prisma'
+import { metadataArgs } from '../args'
+
+class IdentifierService {
+  async upsertIdentifier(
+    companyId: string,
+    type: string,
+    value: string,
+    metadata: Metadata,
+  ) {
+    return prisma.companyIdentifier.upsert({
+      where: {
+        companyId_type: { companyId, type },
+      },
+      create: {
+        companyId,
+        type,
+        value,
+        metadataId: metadata.id,
+      },
+      update: {
+        value,
+        metadataId: metadata.id,
+      },
+      include: {
+        metadata: metadataArgs,
+      },
+    })
+  }
+
+  async updateIdentifier(
+    companyId: string,
+    type: string,
+    value: string,
+    metadata: Metadata,
+  ) {
+    return prisma.companyIdentifier.update({
+      where: {
+        companyId_type: { companyId, type },
+      },
+      data: {
+        value,
+        metadataId: metadata.id,
+      },
+      include: {
+        metadata: metadataArgs,
+      },
+    })
+  }
+}
+
+export const identifierService = new IdentifierService()

--- a/src/app.ts
+++ b/src/app.ts
@@ -31,6 +31,7 @@ import { companyDeleteRoutes } from './api/routes/company.delete'
 import { errorHandler } from './api/plugins/errorhandler'
 import { municipalityReadRoutes } from './api/routes/municipality.read'
 import { companyBaseYearRoutes } from './api/routes/company.baseYear'
+import { companyIdentifiersRoutes } from './api/routes/company.identifiers'
 import { authentificationRoutes } from './api/routes/auth'
 import { companyExportRoutes } from './api/routes/company.export'
 import { municipalityExportRoutes } from './api/routes/municipality.export'
@@ -39,7 +40,7 @@ import { validationsReadRoutes } from './api/routes/validation.read'
 import { validationsUpdateRoutes } from './api/routes/validation.update'
 import { emissionsAssessmentRoutes } from './api/routes/emissionsAssessment'
 import { industryGicsRoute } from './api/routes/industryGics.read'
-import { screenshotsReadRoutes } from './api/routes/screenshots.read';
+import { screenshotsReadRoutes } from './api/routes/screenshots.read'
 import { newsletterArchiveDownloadsRoute } from './api/routes/newsletter-archive.downloads'
 
 async function startApp() {
@@ -107,7 +108,7 @@ async function startApp() {
  */
 async function publicContext(app: FastifyInstance) {
   app.get('/', { schema: { hide: true } }, (request, reply) =>
-    reply.redirect(openAPIConfig.prefix)
+    reply.redirect(openAPIConfig.prefix),
   )
 
   app.register(fastifyStatic, {
@@ -119,7 +120,7 @@ async function publicContext(app: FastifyInstance) {
     { schema: { hide: true }, logLevel: 'silent' },
     async (request, reply) => {
       return reply.sendFile('favicon.ico')
-    }
+    },
   )
 
   app.register(authentificationRoutes, { prefix: 'api/auth' })
@@ -131,7 +132,7 @@ async function publicContext(app: FastifyInstance) {
     prefix: 'api/reporting-period',
   })
   app.register(mailingListDownloadsRoute, { prefix: 'api' })
-  app.register(screenshotsReadRoutes, { prefix: 'api/screenshots' });
+  app.register(screenshotsReadRoutes, { prefix: 'api/screenshots' })
 
   app.register(newsletterArchiveDownloadsRoute, {
     prefix: 'api/newsletters',
@@ -150,6 +151,7 @@ async function authenticatedContext(app: FastifyInstance) {
   app.register(companyGoalsRoutes, { prefix: 'api/companies' })
   app.register(companyBaseYearRoutes, { prefix: 'api/companies' })
   app.register(companyInitiativesRoutes, { prefix: 'api/companies' })
+  app.register(companyIdentifiersRoutes, { prefix: 'api/companies' })
 
   app.register(companyDeleteRoutes, { prefix: 'api/companies' })
   app.register(validationsReadRoutes, { prefix: 'api/validation' })

--- a/src/workers/diffLEI.ts
+++ b/src/workers/diffLEI.ts
@@ -1,82 +1,107 @@
-import { DiscordJob, DiscordWorker } from '../lib/DiscordWorker';
-import wikidata from '../prompts/wikidata';
-import { QUEUE_NAMES } from '../queues';
-import saveToAPI from './saveToAPI';
+import { DiscordJob, DiscordWorker } from '../lib/DiscordWorker'
+import wikidata from '../prompts/wikidata'
+import { QUEUE_NAMES } from '../queues'
+import saveToAPI from './saveToAPI'
 
 export class DiffLEIJob extends DiscordJob {
   declare data: DiscordJob['data'] & {
-    companyName: string;          
-    lei?: string | undefined; // Switching to lei
-    existingCompany: any;               
-    wikidata: { node: string };   
-    
-  };
+    companyName: string
+    lei?: string | undefined // Switching to lei
+    existingCompany: any
+    wikidata: { node: string }
+  }
 }
 
 function compareLei(
   existingLei?: string,
-  lei?: string
+  lei?: string,
 ): {
-  shouldUpdate: boolean; 
-  reason: string; 
+  shouldUpdate: boolean
+  reason: string
 } {
-  
-  if (!existingLei ||existingLei.trim() === '') {
+  if (!existingLei || existingLei.trim() === '') {
     return {
       shouldUpdate: true,
-       
+
       reason: `No existing LEI. New LEI '${lei}' will be set.`,
-    };
+    }
   }
 
   if (existingLei === lei) {
     return {
       shouldUpdate: false,
       reason: `Current LEI '${existingLei}' is already correct. No changes needed.`,
-    };
+    }
   }
 
   return {
     shouldUpdate: true,
     reason: `Current LEI '${existingLei}' differs from New LEI '${lei}'. An update is required.`,
-  };
+  }
 }
 
 const diffLEI = new DiscordWorker<DiffLEIJob>(
-  QUEUE_NAMES.DIFF_LEI, 
+  QUEUE_NAMES.DIFF_LEI,
   async (job: DiffLEIJob) => {
-    const { companyName, lei, existingCompany } = job.data;  
+    const { companyName, lei, existingCompany } = job.data
 
-    const currentLei  = existingCompany?.lei; 
+    const currentLei = existingCompany?.lei
 
+    job.log(
+      `🔍 Comparing LEI for '${companyName}': \nCurrent LEI: '${currentLei}'\nNew LEI: '${lei}'`,
+    )
 
-    job.log(`🔍 Comparing LEI for '${companyName}': \nCurrent LEI: '${currentLei}'\nNew LEI: '${lei}'`); 
-
-    const comparisonResult = compareLei(currentLei, lei ); 
+    const comparisonResult = compareLei(currentLei, lei)
 
     if (!comparisonResult.shouldUpdate) {
-      job.log(`✅ No changes detected for '${companyName}'. Current LEI is already correct.`);
-      return; 
+      job.log(
+        `✅ No changes detected for '${companyName}'. Current LEI is already correct.`,
+      )
+      return
     }
 
     const body = {
       lei: lei,
       wikidataId: job.data.wikidata.node,
       name: companyName,
-    };
+    }
 
-    job.log(`⚡ Detected changes for '${companyName}', enqueuing save operation...`);
+    job.log(
+      `⚡ Detected changes for '${companyName}', enqueuing save operation...`,
+    )
+
+    // Update legacy LEI field (existing behavior)
     await saveToAPI.queue.add(`${companyName} - LEI Update`, {
       ...job.data,
-      body : body, 
-      diff: comparisonResult.reason, 
-      requiresApproval: false, 
+      body: body,
+      diff: comparisonResult.reason,
+      requiresApproval: false,
       apiSubEndpoint: '',
-    });
-   
-    job.log(`✅ Enqueued LEI update for '${companyName}' with LEI: '${lei}'.`); 
+    })
 
-  }
-);
+    // Also update new identifier system
+    await saveToAPI.queue.add(`${companyName} - LEI Identifier Update`, {
+      ...job.data,
+      body: {
+        identifiers: [
+          {
+            type: 'lei',
+            value: lei,
+            verified: true,
+          },
+        ],
+        metadata: {
+          source: 'garbo-pipeline',
+          comment: `Auto-extracted: ${comparisonResult.reason}`,
+        },
+      },
+      diff: `Updated LEI identifier: ${comparisonResult.reason}`,
+      requiresApproval: false,
+      apiSubEndpoint: 'identifiers',
+    })
 
-export default diffLEI;
+    job.log(`✅ Enqueued LEI update for '${companyName}' with LEI: '${lei}'.`)
+  },
+)
+
+export default diffLEI


### PR DESCRIPTION
Modifying how we store the lei number so we can make use of metadata and verified fields. Also to allow for possibility of storing other types of identifiers, none applicable atm but now there can be a structure there to support it.

This is also largely to enable better support for updating the lei numbers in editor and tracking validation.

This keeps the legacy lei field for now, similar to the path we used for the description field changes to avoid breaking anything.