### PR TITLE
[Fix] Update calculated total to fallback to stated total if null

### DIFF
--- a/src/lib/company-emissions/companyEmissionsCalculator.ts
+++ b/src/lib/company-emissions/companyEmissionsCalculator.ts
@@ -77,17 +77,23 @@ export function calculateScope3Total(scope3: any): number | null {
 /**
  * Calculates total emissions from an Emissions object.
  * Combines scope 1+2 and scope 3 emissions.
+ * If no scope 1, scope 1+2, scope 2, or scope 3 emissions are available,
+ * falls back to the combined statedTotalEmissions.
  * Returns null if no data is available.
  */
 export function calculatedTotalEmissions(emissions: Emissions): number | null {
-  const { scope1, scope2, scope3, scope1And2 } = emissions || {}
+  const { scope1, scope2, scope3, scope1And2, statedTotalEmissions } =
+    emissions || {}
 
   const scope1And2Total = calculateScope1And2Total(scope1, scope2, scope1And2)
   const scope3Total = calculateScope3Total(scope3)
 
-  // If both are null, return null (no data available)
+  // If both are null, fall back to combined stated total
   if (scope1And2Total === null && scope3Total === null) {
-    return null
+    const statedTotal = statedTotalEmissions?.total
+    return statedTotal != null && typeof statedTotal === 'number'
+      ? statedTotal
+      : null
   }
 
   // Otherwise, sum them (treating null as 0 for calculation, but we already handled the all-null case)

--- a/tests/companyEmissionsCalculator.spec.ts
+++ b/tests/companyEmissionsCalculator.spec.ts
@@ -1,4 +1,28 @@
-import { calculateScope3Total } from '../src/lib/company-emissions/companyEmissionsCalculator'
+import {
+  calculateScope3Total,
+  calculatedTotalEmissions,
+} from '../src/lib/company-emissions/companyEmissionsCalculator'
+
+describe('calculatedTotalEmissions', () => {
+  it('falls back to combined statedTotalEmissions when no scope 1, 1+2, 2 or 3 emissions', () => {
+    const emissions = {
+      statedTotalEmissions: { total: 500, unit: 'tCO2e' },
+    }
+    expect(calculatedTotalEmissions(emissions)).toBe(500)
+  })
+
+  it('returns null when no scope emissions and no statedTotalEmissions', () => {
+    expect(calculatedTotalEmissions({})).toBeNull()
+  })
+
+  it('returns null when no scope emissions and statedTotalEmissions.total is null', () => {
+    expect(
+      calculatedTotalEmissions({
+        statedTotalEmissions: { total: null, unit: 'tCO2e' },
+      }),
+    ).toBeNull()
+  })
+})
 
 describe('calculateScope3Total', () => {
   it('uses statedTotalEmissions when categories exist but all totals are null/undefined', () => {


### PR DESCRIPTION
If there are no values for any individual scope, then we should fallback to the statedTotal

Garo is a company where this is needed