### PR TITLE
adding null handling if there was no base year before

### DIFF
--- a/src/workers/diffBaseYear.ts
+++ b/src/workers/diffBaseYear.ts
@@ -35,7 +35,7 @@ const diffBaseYear = new DiffWorker<DiffBaseYearJob>(
 
       const change: ChangeDescription = {
         type: 'baseYear',
-        oldValue: { baseYear: existingCompany.baseYear.year },
+        oldValue: { baseYear: existingCompany?.baseYear?.year ?? null },
         newValue: { baseYear: baseYear },
       }
 


### PR DESCRIPTION
base year workers crashed if the existing company had no base year (if that worker hadn't run before). this PR fixes that.