### PR TITLE
[1109] Tags: Adjust auth options handling

### DIFF
--- a/src/api/plugins/auth.ts
+++ b/src/api/plugins/auth.ts
@@ -21,6 +21,10 @@ const unauthorizedError = {
 async function authPlugin(app: FastifyInstance) {
   app.decorateRequest('user')
   app.addHook('onRequest', async (request, reply) => {
+    // Let CORS handle preflight; browsers don't send Authorization on OPTIONS.
+    if (request.method === 'OPTIONS') {
+      return
+    }
     try {
       const token = request.headers['authorization']?.replace('Bearer ', '')
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -60,6 +60,8 @@ async function startApp() {
   app.setErrorHandler(errorHandler)
   app.register(cors, {
     origin: apiConfig.corsAllowOrigins as unknown as string[],
+    credentials: true,
+    allowedHeaders: ['Content-Type', 'Authorization'],
     exposedHeaders: ['etag'],
   })
 


### PR DESCRIPTION
When testing tags, ran into a CORs error. This is a fix for that to allow handling of OPTIONs from the broswer. Long term I'll adjust the validate tool to use relevative api path for garbo as well as for pipeline-api (set up only for pipeline api atm).