### PR TITLE
[Prod] Minor Version Bump v5.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo",
-  "version": "5.4.4-rc.11",
+  "version": "5.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo",
-      "version": "5.4.4-rc.11",
+      "version": "5.5.0",
       "license": "MIT License",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garbo",
-  "version": "5.4.4-rc.11",
+  "version": "5.5.0",
   "description": "",
   "type": "module",
   "exports": {


### PR DESCRIPTION
# 🚀 Production Release PR

> **Title format:** `[Prod] Major/Minor/Patch Version Bump vX.X.X`

## 📦 Release Type
_Select the appropriate release type by marking with an `x`._

- [ ] Major version bump
- [x] Minor version bump
- [ ] Patch version bump

### Rollback Version
_Note the relevant rollback version to enable quick rollback if necessary._

v5.4.3

## 🔁 Environment Promotion
This release promotes changes **from `stage` to `production`**.

## 📋 What's Being Released
_Provide a summary of the features, fixes, or updates included in this production release._
- Tag options (e.g. [1109])
New tag-options feature: CRUD API (/api/tag-options), Prisma model + migration, tagOptionService, follow-up worker updates for company tags.
- Route reorg (internal vs external)
Routes split into internal/ and external/ folders
- Reports
New/updated reports create/read services and routes; database-dump endpoint extended with wikidataId and reportingPeriods and moved under reports.read.
POST endpoint for scraping company report (create report via request).
- Batch / pipeline ([76])
Batch id added in checkDB worker.
- Company logos
Schema and logic for company logoUrl; script to fetch logo path from Wikidata and push company logo URLs to DB; older logo script removed.
- Base year
Bugfix for base-year endpoint name; null handling when there was no base year before; saveToAPI throws when endpoint is missing.
- Auth
Auth plugin formatting/tidy and error handling 
- Dependencies & tooling
Dependency bumps; new PR CI workflow; Prettier run across codebase; ESLint config and type/test fixes.
- Docs / pipeline
assorted docs/scripts (e.g. municipality EV share 2025, evaluation scripts, import/export scripts) updated.
- Misc
Municipality data (e.g. EV share) updated with 2025 entry; vulnerability fix and audit level change; various worker/config changes (docling, discord, chromadb, etc.) and test updates.

## ✅ Checklist

- [x] Version number is updated correctly
- [x] All relevant changes have been QA-tested in staging
- [x] Rollback version has been updated
- [x] Title follows the required format: `[Prod] Major/Minor/Patch Version Bump vX.X.X`

---

_This template is for versioned production releases only. For other PR types, please select a different template._