### PR TITLE
[47] Update url handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4960,14 +4960,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -11486,10 +11486,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.3",

--- a/src/lib/DiffWorker.ts
+++ b/src/lib/DiffWorker.ts
@@ -2,7 +2,7 @@ import { DiscordJob, DiscordWorker } from './DiscordWorker'
 import { Queue } from 'bullmq'
 import redis from '../config/redis'
 import saveToAPI from '../workers/saveToAPI'
-import { defaultMetadata } from './saveUtils'
+import { canonicalPublicReportUrl, defaultMetadata } from './saveUtils'
 import discord from '../discord'
 
 export interface ChangeDescription {
@@ -66,7 +66,11 @@ function addCustomMethods(job: DiffJob) {
         apiSubEndpoint,
         change,
         job.data.autoApprove || !requiresApproval,
-        defaultMetadata(job.data.url),
+        defaultMetadata(
+          canonicalPublicReportUrl(
+            job.data as { url: string; sourceUrl?: string }
+          )
+        ),
         `Updates to the company's ${apiSubEndpoint}`
       )
     } else if (diff) {
@@ -76,7 +80,11 @@ function addCustomMethods(job: DiffJob) {
         job.data.wikidata,
         {
           ...change.newValue,
-          metadata: defaultMetadata(job.data.url),
+          metadata: defaultMetadata(
+            canonicalPublicReportUrl(
+              job.data as { url: string; sourceUrl?: string }
+            )
+          ),
         }
       )
     }

--- a/src/lib/saveUtils.ts
+++ b/src/lib/saveUtils.ts
@@ -37,10 +37,7 @@ export function canonicalPublicReportUrl(data: {
   sourceUrl?: string
 }): string {
   const { url, sourceUrl } = data
-  if (
-    typeof sourceUrl === 'string' &&
-    /^https?:\/\//i.test(sourceUrl.trim())
-  ) {
+  if (typeof sourceUrl === 'string' && /^https?:\/\//i.test(sourceUrl.trim())) {
     return sourceUrl.trim()
   }
   return url

--- a/src/lib/saveUtils.ts
+++ b/src/lib/saveUtils.ts
@@ -27,6 +27,25 @@ export function formatAsReportingPeriods(
 
 import { askPrompt } from './openai'
 
+/**
+ * When pipeline-api cached a PDF to S3, `job.data.url` is the S3 public URL and
+ * `sourceUrl` is the original report link. For DB/UI we prefer the original HTTP(S)
+ * link when present; otherwise use `url` (file uploads: S3; legacy link jobs: same as source).
+ */
+export function canonicalPublicReportUrl(data: {
+  url: string
+  sourceUrl?: string
+}): string {
+  const { url, sourceUrl } = data
+  if (
+    typeof sourceUrl === 'string' &&
+    /^https?:\/\//i.test(sourceUrl.trim())
+  ) {
+    return sourceUrl.trim()
+  }
+  return url
+}
+
 export const defaultMetadata = (url: string) => ({
   source: url,
   comment: 'Parsed by Garbo AI',

--- a/src/workers/checkDB.ts
+++ b/src/workers/checkDB.ts
@@ -2,7 +2,7 @@ import { FlowProducer } from 'bullmq'
 import { DiscordJob, DiscordWorker } from '../lib/DiscordWorker'
 import { apiFetch } from '../lib/api'
 import redis from '../config/redis'
-import { getCompanyURL } from '../lib/saveUtils'
+import { canonicalPublicReportUrl, getCompanyURL } from '../lib/saveUtils'
 import { QUEUE_NAMES } from '../queues'
 import {
   extractScopeEntriesFromFollowUp,
@@ -12,6 +12,8 @@ import {
 export class CheckDBJob extends DiscordJob {
   declare data: DiscordJob['data'] & {
     companyName: string
+    /** Original report URL when pipeline cached PDF to S3 (parsePdf). */
+    sourceUrl?: string
     wikidata: { node: string }
     fiscalYear: {
       startMonth: number
@@ -29,8 +31,17 @@ const flow = new FlowProducer({ connection: redis })
 const checkDB = new DiscordWorker(
   QUEUE_NAMES.CHECK_DB,
   async (job: CheckDBJob) => {
-    const { companyName, url, fiscalYear, wikidata, threadId, channelId } =
-      job.data
+    const {
+      companyName,
+      url,
+      sourceUrl,
+      fiscalYear,
+      wikidata,
+      threadId,
+      channelId,
+    } = job.data
+
+    const canonicalSource = canonicalPublicReportUrl({ url, sourceUrl })
 
     const childrenEntries = await job.getChildrenEntries()
 
@@ -76,7 +87,7 @@ const checkDB = new DiscordWorker(
 
     if (!existingCompany) {
       const metadata = {
-        source: url,
+        source: canonicalSource,
         comment: 'Created by Garbo AI',
       }
 

--- a/src/workers/diffReportingPeriods.ts
+++ b/src/workers/diffReportingPeriods.ts
@@ -1,4 +1,4 @@
-import { diffChanges } from '../lib/saveUtils'
+import { canonicalPublicReportUrl, diffChanges } from '../lib/saveUtils'
 import { getReportingPeriodDates } from '../lib/reportingPeriodDates'
 import { QUEUE_NAMES } from '../queues'
 import { ChangeDescription, DiffWorker, DiffJob } from '../lib/DiffWorker'
@@ -7,6 +7,8 @@ import apiConfig from '../config/api'
 export class DiffReportingPeriodsJob extends DiffJob {
   declare data: DiffJob['data'] & {
     companyName: string
+    /** Original report URL when pipeline cached PDF to S3 (parsePdf). */
+    sourceUrl?: string
     existingCompany: any
     wikidata: { node: string }
     fiscalYear: any
@@ -23,6 +25,7 @@ const diffReportingPeriods = new DiffWorker<DiffReportingPeriodsJob>(
   async (job) => {
     const {
       url,
+      sourceUrl,
       wikidata,
       fiscalYear,
       companyName,
@@ -32,6 +35,8 @@ const diffReportingPeriods = new DiffWorker<DiffReportingPeriodsJob>(
       biogenic = [],
       economy = [],
     } = job.data
+
+    const reportURLForPeriod = canonicalPublicReportUrl({ url, sourceUrl })
 
     console.log(job.isDataApproved())
 
@@ -69,7 +74,9 @@ const diffReportingPeriods = new DiffWorker<DiffReportingPeriodsJob>(
           endDate,
           // Only assign reportURL to the reporting period that matches the report year
           reportURL:
-            reportYear !== null && year === reportYear ? url : undefined,
+            reportYear !== null && year === reportYear
+              ? reportURLForPeriod
+              : undefined,
         }
       })
 


### PR DESCRIPTION
- Prefer original report URL for DB-facing fields when available: Added canonicalPublicReportUrl({ url, sourceUrl }) in src/lib/saveUtils.ts. If sourceUrl is a real http(s) link (link uploads cached to S3), Garbo uses that as the canonical “report URL”; otherwise it falls back to url (file uploads → S3 public URL).
- Reporting periods: src/workers/diffReportingPeriods.ts now sets reportURL to that canonical URL (instead of always using job.data.url).
- Company creation metadata: src/workers/checkDB.ts uses the canonical URL for metadata.source when creating a new company.
- Diff approval / save metadata: src/lib/DiffWorker.ts uses the canonical URL for defaultMetadata(...) so approvals/saves reference the original link when present.
- Lockfile: package-lock.json updated (axios + proxy-from-env bumps via lockfile resolution).