### PR TITLE
[1211]: Added nations to global search result and added language property

### DIFF
--- a/src/api/routes/internal/globalSearch.read.ts
+++ b/src/api/routes/internal/globalSearch.read.ts
@@ -27,8 +27,11 @@ export async function globalSearchReadRoutes(app: FastifyInstance) {
       },
     },
     async (request, reply) => {
-      const { name } = request.body as GlobalSearchRequest
-      const result = await globalSearchService.getGlobalSearchResults(name)
+      const { name, currentLanguage } = request.body as GlobalSearchRequest
+      const result = await globalSearchService.getGlobalSearchResults(
+        name,
+        currentLanguage
+      )
 
       reply.send(result)
     }

--- a/src/api/schemas/request.ts
+++ b/src/api/schemas/request.ts
@@ -375,4 +375,5 @@ export const registryDeleteRequestBodySchema = z.array(
 
 export const globalSearchRequestSchema = z.object({
   name: z.string().min(1, 'name is required'),
+  currentLanguage: z.enum(['sv', 'en']),
 })

--- a/src/api/schemas/response.ts
+++ b/src/api/schemas/response.ts
@@ -660,6 +660,6 @@ export const globalSearchResponseSchema = z.array(
   z.object({
     name: z.string(),
     wikidataId: z.string().optional(),
-    type: z.enum(['company', 'municipality', 'region']),
+    type: z.enum(['company', 'municipality', 'region', 'nation']),
   })
 )

--- a/src/api/services/globalSearchService.ts
+++ b/src/api/services/globalSearchService.ts
@@ -1,6 +1,7 @@
 import { prisma } from '../../lib/prisma'
 import type { GlobalSearchResponse } from '../types'
 import { municipalityService } from './municipalityService'
+import { nationService } from './nationService'
 import { regionalService } from './regionalService'
 
 const MAX_CANDIDATES_PER_TYPE = 100
@@ -11,8 +12,8 @@ function normalizeSearchValue(value: string): string {
 }
 
 function compareByRelevance(
-  a: { name: string; type: 'company' | 'municipality' | 'region' },
-  b: { name: string; type: 'company' | 'municipality' | 'region' },
+  a: { name: string; type: 'company' | 'municipality' | 'region' | 'nation' },
+  b: { name: string; type: 'company' | 'municipality' | 'region' | 'nation' },
   normalizedQuery: string
 ) {
   const aName = normalizeSearchValue(a.name)
@@ -42,7 +43,10 @@ function compareByRelevance(
 }
 
 class GlobalSearchService {
-  async getGlobalSearchResults(name: string): Promise<GlobalSearchResponse> {
+  async getGlobalSearchResults(
+    name: string,
+    currentLanguage: 'sv' | 'en'
+  ): Promise<GlobalSearchResponse> {
     const normalizedQuery = normalizeSearchValue(name)
 
     if (!normalizedQuery) {
@@ -80,6 +84,16 @@ class GlobalSearchService {
       )
       .slice(0, MAX_CANDIDATES_PER_TYPE)
 
+    const nations = nationService
+      .getNations()
+      .filter((nation) => {
+        const countryNames = [nation.country?.sv, nation.country?.en]
+          .filter(Boolean)
+          .map((name) => name.toLocaleLowerCase('sv-SE'))
+        return countryNames.some((name) => name.includes(normalizedQuery))
+      })
+      .slice(0, MAX_CANDIDATES_PER_TYPE)
+
     return [
       ...companies.map((company) => ({
         name: company.name,
@@ -93,6 +107,10 @@ class GlobalSearchService {
       ...regions.map((region) => ({
         name: region.region,
         type: 'region' as const,
+      })),
+      ...nations.map((nation) => ({
+        name: nation.country?.[currentLanguage],
+        type: 'nation' as const,
       })),
     ]
       .sort((a, b) => compareByRelevance(a, b, normalizedQuery))


### PR DESCRIPTION
This pull request extends the global search functionality to support searching for nations, and adds support for handling the user's current language in search results. The changes update the API schema and internal logic to include a new "nation" type and ensure that search results are localized according to the user's language preference.

Global Search Feature Enhancements:

* Added support for searching nations by integrating the `nationService` and including nations in the global search results.
* Updated the search result sorting logic and relevant type definitions to handle the new "nation" type.

Localization Improvements:

* Modified the global search API to accept a `currentLanguage` parameter, and updated the service to return nation names in the requested language. 

API Schema Updates:

* Updated the global search request schema to require a `currentLanguage` field, and added "nation" as a valid type in the response schema.

Dependency Updates:

* Imported `nationService` in the global search service to enable nation search functionality.

Closes #1211 