### PR TITLE
[hotfix] coalesce company list cache rebuilds and add in-memory fallback when Redis is missing

### DIFF
--- a/src/api/routes/external/company.read.ts
+++ b/src/api/routes/external/company.read.ts
@@ -6,6 +6,7 @@ import { getTags } from '../../../config/openapi'
 import { CompanySearchQuery, WikidataIdParams } from '../../types'
 import { cachePlugin } from '../../plugins/cache'
 import { companyService } from '../../services/companyService'
+import { getCompaniesListCached } from '../../services/companyListReadThroughCache'
 import {
   CompanyList,
   wikidataIdParamSchema,
@@ -67,14 +68,7 @@ export async function companyReadRoutes(app: FastifyInstance) {
         await redisCache.set(cacheKey, JSON.stringify(currentEtag))
       }
 
-      const dataCacheKey = `companies:data:${databaseFingerprint}`
-
-      let companies = await redisCache.get(dataCacheKey)
-
-      if (!companies) {
-        companies = await companyService.getAllCompaniesWithMetadata()
-        await redisCache.set(dataCacheKey, JSON.stringify(companies))
-      }
+      const companies = await getCompaniesListCached(databaseFingerprint)
 
       reply.header('ETag', `${currentEtag}`)
 

--- a/src/api/routes/internal/internal.company.read.ts
+++ b/src/api/routes/internal/internal.company.read.ts
@@ -6,6 +6,7 @@ import { getTags } from '../../../config/openapi'
 import { CompanySearchQuery, WikidataIdParams } from '../../types'
 import { cachePlugin } from '../../plugins/cache'
 import { companyService } from '../../services/companyService'
+import { getCompaniesListCached } from '../../services/companyListReadThroughCache'
 import {
   CompanyList,
   wikidataIdParamSchema,
@@ -71,14 +72,7 @@ export async function internalCompanyReadRoutes(app: FastifyInstance) {
         await redisCache.set(cacheKey, JSON.stringify(currentEtag))
       }
 
-      const dataCacheKey = `companies:data:${databaseFingerprint}`
-
-      let companies = await redisCache.get(dataCacheKey)
-
-      if (!companies) {
-        companies = await companyService.getAllCompaniesWithMetadata()
-        await redisCache.set(dataCacheKey, JSON.stringify(companies))
-      }
+      const companies = await getCompaniesListCached(databaseFingerprint)
 
       reply.header('ETag', `${currentEtag}`)
 

--- a/src/api/services/companyListReadThroughCache.ts
+++ b/src/api/services/companyListReadThroughCache.ts
@@ -1,0 +1,52 @@
+import { redisCache } from '@/index'
+import { companyService } from './companyService'
+
+type CompaniesList = Awaited<
+  ReturnType<typeof companyService.getAllCompaniesWithMetadata>
+>
+
+/** In-flight full-list loads keyed by `companies:data:${fingerprint}`. */
+const inflightLoads = new Map<string, Promise<CompaniesList>>()
+
+/**
+ * When Redis is down or empty, we still keep at most one copy of the last built
+ * list in memory. The key includes the data fingerprint, so it invalidates
+ * automatically when the fingerprint changes.
+ */
+let memoryListByKey: { key: string; data: CompaniesList } | null = null
+
+/**
+ * Resolves the full company list from Redis when possible; otherwise coalesces
+ * concurrent `getAllCompaniesWithMetadata()` calls and stores the result in
+ * Redis (best effort) and in memory for Redis outages.
+ */
+export async function getCompaniesListCached(
+  databaseFingerprint: string
+): Promise<CompaniesList> {
+  const dataCacheKey = `companies:data:${databaseFingerprint}`
+
+  const fromRedis = await redisCache.get(dataCacheKey)
+  if (fromRedis) {
+    return fromRedis as CompaniesList
+  }
+
+  if (memoryListByKey?.key === dataCacheKey) {
+    return memoryListByKey.data
+  }
+
+  let load = inflightLoads.get(dataCacheKey)
+  if (!load) {
+    load = (async () => {
+      const data = await companyService.getAllCompaniesWithMetadata()
+      await redisCache.set(dataCacheKey, JSON.stringify(data))
+      memoryListByKey = { key: dataCacheKey, data }
+      return data
+    })()
+    load.finally(() => {
+      inflightLoads.delete(dataCacheKey)
+    })
+    inflightLoads.set(dataCacheKey, load)
+  }
+
+  return load
+}


### PR DESCRIPTION
This change reduces load and response times for GET company list routes when the Redis-backed cache is cold or Redis is temporarily unavailable.

- Single-flight loading: Concurrent requests for the same data fingerprint now share a single getAllCompaniesWithMetadata() load instead of each triggering a full rebuild.
- In-memory fallback: After a successful full load, the result is held in process memory (keyed by the same cache key as the Redis entry) so repeated requests are not forced back to the database when Redis reads fail.
- Refactor: The logic lives in a shared helper, getCompaniesListCached, used by both the public and internal “list all companies” routes.

Why Cold cache and Redis outages could cause many parallel requests to each run the full company list query and post-processing, which is expensive and can contribute to gateway timeouts. Coalescing and a small memory fallback address that class of issues without changing the API contract or response shape.