### PR TITLE
implemented callback url support so garbo console can handover to games

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,3 +93,6 @@ DOCLING_RUN_LOCAL=true
 
 # Firecrawl API key, only needed if you want to use the Firecrawl integration.
 FIRECRAWL_API_KEY=
+
+# Optional: allowed callback URLs for webhooks to 'games' for this garbo console. Example: http://localhost:3007/api/webhook,http://localhost:3008/api/webhook
+ALLOWED_CALLBACK_URLS=

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the main repository for the AI bot we call Garbo. Garbo is a bot that can run on Discord or via our UI [Validation frontend](https://github.com/Klimatbyran/validate-frontend). Garbo is powered by LLM:s to fetch and extract GHG self-reported data from companies. It automates the process of data extraction, evaluation, and formatting, providing a streamlined workflow for handling environmental data.
 
-Garbo is invoked through a set of commands in Discord or in our UI and has a pipeline of tasks and jobs that will be started in order for her to both extract, evaluate and format the data autonomously.
+Garbo is invoked through a set of commands in Discord or in our UI and has a pipeline of tasks and jobs that will be started in order for her to both extract, evaluate and format the data autonomously. It can also be used as a headless PDF processor: submit a job with a `callbackUrl` and Garbo will parse and index the PDF, then hand off to your service via a POST request instead of running its own extraction pipeline — see [Callback Handover](./doc/pipeline.md#callback-handover-garbo-game-integration) for details.
 
 Do you have an idea? Jump into the code or head to our [Discord server](https://discord.gg/N5P64QPQ6v) to discuss your thoughts.
 

--- a/doc/pipeline.md
+++ b/doc/pipeline.md
@@ -95,7 +95,8 @@ await flow.add({
 flowchart TD
     A[parsePdf] -->|not cached| B[doclingParsePDF]
     B --> C[indexMarkdown]
-    C --> D[precheck]
+    C -->|no callbackUrl| D[precheck]
+    C -->|callbackUrl set| CB[POST callbackUrl\n'{url}']
     A -- cached? --> D
     D --> F[guessWikidata]
     D --> G[followUp-fiscalYear]
@@ -145,15 +146,17 @@ flowchart TD
     url: string
     threadId: string,
     autoApprove: boolean
+    forceReindex?: boolean
+    callbackUrl?: string
 }
 ```
 
-`url` defines the report URL, `threadId` references the Discord thread where the bot will respond, and `autoApprove` controls whether user approvals are required for data updates.
+`url` defines the report URL, `autoApprove` controls whether user approvals are required for data updates. `forceReindex` deletes any existing vector index before parsing so the PDF is re-processed from scratch. `callbackUrl` enables the [callback handover mode](#callback-handover-garbo-game-integration) described below.
 
 **Functionality:**
 
 - Checks if the report is already indexed in the VectorDB.
-- If cached, directly queues `precheck` with:
+- If cached (and `forceReindex` is not set), directly queues `precheck` with:
 
 ```typescript
 {
@@ -164,12 +167,13 @@ flowchart TD
 }
 ```
 
-- If not cached, creates a flow:
+- If not cached (or `forceReindex` is set), creates a flow. When `callbackUrl` is provided the flow terminates at `indexMarkdown` and fires the callback instead of continuing into the extraction pipeline:
 
 ```mermaid
 flowchart LR
     B[doclingParsePDF] --> C[indexMarkdown]
-    C --> D[precheck]
+    C -->|no callbackUrl| D[precheck]
+    C -->|callbackUrl set| CB[POST callbackUrl]
 ```
 
 Return Value: Job id when enqueuing `precheck` from the cache path; otherwise true after starting the flow.
@@ -213,15 +217,16 @@ Return Value: Job id when enqueuing `precheck` from the cache path; otherwise tr
     url: string
     threadId: string,
     autoApprove: boolean
+    callbackUrl?: string
 }
 ```
 
 The job receives the standard properties and awaits the `markdown` output from its child job [doclingParsePDF](#doclingparsepdf).
 
 **Functionality:**
-Indexes the parsed markdown into the VectorDB for downstream retrieval.
+Indexes the parsed markdown into the VectorDB for downstream retrieval. If `callbackUrl` is set, fires a `POST` request to that URL once indexing is complete (see [Callback Handover](#callback-handover-garbo-game-integration)).
 
-**Return Value:** _none_
+**Return Value:** `{ markdown: string }`
 
 ### precheck
 
@@ -801,6 +806,63 @@ The job checks if the companies url by querying the API with the wikidata id and
 ```
 
 The job returns the url to the company page.
+
+## Callback Handover (garbo-game integration)
+
+Garbo supports handing off to an external service — such as garbo-game — after a PDF has been parsed and indexed, instead of running the built-in extraction pipeline. This is controlled by the optional `callbackUrl` field on the `parsePdf` job.
+
+### How it works
+
+When `callbackUrl` is present, `parsePdf` builds a shorter flow that stops at `indexMarkdown`:
+
+```
+doclingParsePDF → indexMarkdown → POST callbackUrl { url }
+```
+
+The `precheck` step and everything downstream (extraction, diff, save) are **not** queued. Once `indexMarkdown` has stored the report in the vector database it fires a single `POST` request to the callback URL with the body:
+
+```json
+{ "url": "<report PDF url>" }
+```
+
+The receiving service can then query the vector database directly using the `url` as the key to retrieve the indexed markdown and run its own extraction logic.
+
+### Security: URL allowlist
+
+Callback URLs must be explicitly whitelisted. Set the `ALLOWED_CALLBACK_URLS` environment variable to a comma-separated list of allowed URL prefixes:
+
+```
+ALLOWED_CALLBACK_URLS=https://garbo-game.example.com,https://other-allowed-service.example.com
+```
+
+A callback URL is accepted if it starts with any of the listed prefixes. If the list is empty, all callbacks are rejected.
+
+### Triggering parsePdf with a callback
+
+Add a job to the `PARSE_PDF` queue with `callbackUrl` in the data:
+
+```typescript
+parsePdf.queue.add('parse', {
+  url: 'https://example.com/sustainability-report.pdf',
+  callbackUrl: 'https://garbo-game.example.com/api/pdf-ready',
+  autoApprove: true,
+})
+```
+
+Or via an HTTP request to whatever API endpoint enqueues the job, including the same fields in the request body.
+
+### What the callback receiver must do
+
+The endpoint at `callbackUrl` receives:
+
+```
+POST /your/endpoint
+Content-Type: application/json
+
+{ "url": "https://example.com/sustainability-report.pdf" }
+```
+
+It should respond with a 2xx status. A non-2xx response causes the `indexMarkdown` job to fail and retry according to its retry policy.
 
 ## Docling configuration
 

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -1,0 +1,32 @@
+import 'dotenv/config'
+
+const allowedCallbackUrls = (process.env.ALLOWED_CALLBACK_URLS ?? '')
+  .split(',')
+  .map((u) => u.trim())
+  .filter(Boolean)
+
+export function isAllowedCallbackUrl(url: string): boolean {
+  if (allowedCallbackUrls.length === 0) return false
+  return allowedCallbackUrls.some((allowed) => url.startsWith(allowed))
+}
+
+export async function fireCallback(
+  callbackUrl: string,
+  payload: Record<string, unknown>,
+  log: (msg: string) => void = console.log
+): Promise<void> {
+  if (!isAllowedCallbackUrl(callbackUrl)) {
+    throw new Error(`Callback URL not in whitelist: ${callbackUrl}`)
+  }
+
+  log(`Firing callback to ${callbackUrl}`)
+  const res = await fetch(callbackUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  log(`Callback response: ${res.status}`)
+  if (!res.ok) {
+    throw new Error(`Callback to ${callbackUrl} failed with status ${res.status}`)
+  }
+}

--- a/src/workers/indexMarkdown.ts
+++ b/src/workers/indexMarkdown.ts
@@ -2,16 +2,18 @@ import config from '../config/chromadb'
 import { DiscordWorker, DiscordJob } from '../lib/DiscordWorker'
 import { vectorDB } from '../lib/vectordb'
 import { QUEUE_NAMES } from '../queues'
+import { fireCallback } from '../lib/webhook'
 
 class IndexMarkdownJob extends DiscordJob {
   declare data: DiscordJob['data'] & {
     markdown: string
+    callbackUrl?: string
   }
 }
 
-const indexMarkdown = new DiscordWorker(
+const indexMarkdown = new DiscordWorker<IndexMarkdownJob>(
   QUEUE_NAMES.INDEX_MARKDOWN,
-  async (job: IndexMarkdownJob) => {
+  async (job) => {
     const { url } = job.data
 
     // Accept markdown from own data or from child job results (e.g., Docling parser)
@@ -38,6 +40,11 @@ const indexMarkdown = new DiscordWorker(
       await vectorDB.addReport(url, markdown)
       job.editMessage(`✅ Saving to vector database...`)
       job.log('Done!')
+
+      const { callbackUrl } = job.data
+      if (callbackUrl) {
+        await fireCallback(callbackUrl, { url }, (msg) => job.log(msg))
+      }
 
       return { markdown }
     } catch (error) {

--- a/src/workers/parsePdf.ts
+++ b/src/workers/parsePdf.ts
@@ -1,4 +1,4 @@
-import { DiscordWorker } from '../lib/DiscordWorker'
+import { DiscordWorker, DiscordJob } from '../lib/DiscordWorker'
 import { FlowProducer } from 'bullmq'
 import redis from '../config/redis'
 import precheck from './precheck'
@@ -8,13 +8,17 @@ import { QUEUE_NAMES } from '../queues'
 const flow = new FlowProducer({ connection: redis })
 flow.on('error', (err) => console.error('FlowProducer connection error:', err))
 
-const parsePdf = new DiscordWorker(
+class ParsePdfJob extends DiscordJob {
+  declare data: DiscordJob['data'] & {
+    forceReindex?: boolean
+    callbackUrl?: string
+  }
+}
+
+const parsePdf = new DiscordWorker<ParsePdfJob>(
   QUEUE_NAMES.PARSE_PDF,
   async (job) => {
-    const { url, forceReindex } = job.data as {
-      url: string
-      forceReindex?: boolean
-    }
+    const { url, forceReindex, callbackUrl } = job.data
     job.log(`forceReindex flag: ${Boolean(forceReindex)}`)
     job.opts.attempts = 1
 
@@ -48,26 +52,30 @@ const parsePdf = new DiscordWorker(
       if (!exists || forceReindex) {
         job.editMessage(`✅ PDF queued. Parsing via Docling and indexing...`)
 
-        const precheckFlow = await flow.add({
+        const indexMarkdownStep = {
           ...base,
-          name: 'precheck ' + name,
-          queueName: QUEUE_NAMES.PRECHECK,
+          name: 'indexMarkdown ' + name,
+          queueName: QUEUE_NAMES.INDEX_MARKDOWN,
           children: [
             {
               ...base,
-              name: 'indexMarkdown ' + name,
-              queueName: QUEUE_NAMES.INDEX_MARKDOWN,
-              children: [
-                {
-                  ...base,
-                  name: 'doclingParsePDF',
-                  queueName: QUEUE_NAMES.DOCLING_PARSE_PDF,
-                },
-              ],
+              name: 'doclingParsePDF',
+              queueName: QUEUE_NAMES.DOCLING_PARSE_PDF,
             },
           ],
-        })
-        job.log('flow started: ' + precheckFlow.job?.id)
+        }
+
+        const rootFlow = callbackUrl
+          ? indexMarkdownStep
+          : {
+              ...base,
+              name: 'precheck ' + name,
+              queueName: QUEUE_NAMES.PRECHECK,
+              children: [indexMarkdownStep],
+            }
+
+        const addedFlow = await flow.add(rootFlow)
+        job.log('flow started: ' + addedFlow.job?.id)
       } else {
         job.editMessage(`✅ PDF already interpreted and indexed. Continuing...`)
 


### PR DESCRIPTION
### ✨ What’s Changed?

This PR adds support to send a callbackUrl to garbo that makes garbo stop after indexing the markdown and hand over to the callback url (for example the climate plans pipeline). For example, now you can call Garbo like this:

```
 curl -X POST http://localhost:3001/api/queues/parsePdf \
  -H "Content-Type: application/json" \
  -d '{
    "urls": ["https://www.aneby.se/download/18.10e76864165add3787c19774/1538745539859/Milj%C3%B6m%C3%A5l%20f%C3%B6r%20Aneby%20kommun%202011-2025.pdf"],
    "callbackUrl": "http://localhost:3007/api/webhook"
  }'

```

### 🔍 How to Review / Test

Start `pipeline-api `(the pending PR about this needs to be merged first),` climate-plans-pipeline` and `garbo` locally. then call the command above!

### 📋 Checklist

- [ ] PR title starts with `[#issue-number]`; if no issue is applicable use: `[fix]`, `[feat]`, `[ops]`, or `[prod]`
- [ ] I’ve added/updated tests (or noted why they’re not needed)
- [x] I’ve verified the change runs locally (and in Docker/k8s if relevant)
- [ ] If this changes the API contract, I’ve called that out clearly (and considered backward compatibility)
- [ ] If this includes a DB change, I’ve included a migration + rollout/rollback notes
- [ ] I’ve considered observability (logs/metrics/traces) and added what’s needed
- [ ] I’ve set labels, linked issue, and milestone (if applicable)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->
