### PR TITLE
Robustify Docling error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+local/
 dist
 .env
 .aider*

--- a/src/workers/doclingParsePDF.ts
+++ b/src/workers/doclingParsePDF.ts
@@ -430,7 +430,9 @@ const doclingParsePDF = new DiscordWorker(
         )
       }
     } catch (error) {
-      job.log('Error: ' + error)
+      job.log(
+        `[${new Date().toISOString()}] attempt ${job.attemptsMade}/${job.opts.attempts} failed: ${error}`
+      )
       job.editMessage(
         `Failed to parse PDF: ${error.message || 'Unknown error'}`
       )
@@ -498,8 +500,14 @@ async function pollTaskAndGetResult(
         if (statusResponse.status === 404) {
           // Task no longer exists — Docling likely restarted and lost in-memory state.
           // Clear taskId so the next BullMQ retry resubmits from scratch.
-          await job.updateData({ ...job.data, taskId: undefined, resultUrl: undefined })
-          throw new Error('Task not found on Docling (container may have restarted). Will resubmit on retry.')
+          await job.updateData({
+            ...job.data,
+            taskId: undefined,
+            resultUrl: undefined,
+          })
+          throw new Error(
+            'Task not found on Docling (container may have restarted). Will resubmit on retry.'
+          )
         }
 
         const msg = `Status check failed with status: ${statusResponse.status}`
@@ -516,7 +524,9 @@ async function pollTaskAndGetResult(
         job.log('Task complete, exiting polling loop')
         taskComplete = true
       } else if (statusData.task_status === 'failure') {
-        throw new UnrecoverableError(`Task failed: ${JSON.stringify(statusData)}`)
+        throw new UnrecoverableError(
+          `Task failed: ${JSON.stringify(statusData)}`
+        )
       } else {
         // Task is still pending or processing
         job.log(

--- a/src/workers/doclingParsePDF.ts
+++ b/src/workers/doclingParsePDF.ts
@@ -165,13 +165,15 @@ async function fetchWithRetry(
   options: RequestInit,
   job: DoclingParsePDFJob,
   maxRetries: number = 3,
-  timeoutMs: number = 30000
+  timeoutMs: number = 30000,
+  retryOn5xx: boolean = false
 ): Promise<Response> {
   let lastError: Error | undefined
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+    const jitter = Math.floor(Math.random() * 1000)
 
     try {
       const response = await fetch(url, {
@@ -179,6 +181,16 @@ async function fetchWithRetry(
         signal: controller.signal,
       })
       clearTimeout(timeoutId)
+
+      if (retryOn5xx && response.status >= 500 && attempt < maxRetries) {
+        const delayMs = 1000 * Math.pow(2, attempt - 1) + jitter
+        job.log(
+          `Server error ${response.status} on attempt ${attempt}/${maxRetries}. Retrying in ${delayMs}ms...`
+        )
+        await sleep(delayMs)
+        continue
+      }
+
       return response
     } catch (error) {
       clearTimeout(timeoutId)
@@ -186,8 +198,7 @@ async function fetchWithRetry(
       const isLastAttempt = attempt === maxRetries
 
       if (!isLastAttempt) {
-        // Exponential backoff: 1s, 2s, 4s
-        const delayMs = 1000 * Math.pow(2, attempt - 1)
+        const delayMs = 1000 * Math.pow(2, attempt - 1) + jitter
         job.log(
           `Network error on attempt ${attempt}/${maxRetries}: ${lastError.message}. Retrying in ${delayMs}ms...`
         )
@@ -232,7 +243,7 @@ const workerOptions = {
   lockDuration: 30 * 60 * 1000,
   ...(docling.USE_BACKUP_API && {
     limiter: {
-      max: 2, // Max 2 concurrent jobs across all worker instances
+      max: 1, // Max 1 concurrent job across all worker instances (Docling handles one at a time)
       duration: 1, // Per 1ms (essentially "at any given time")
     },
   }),
@@ -333,22 +344,18 @@ const doclingParsePDF = new DiscordWorker(
           `Using ${useBackupAPI ? 'backup' : 'primary'} API (${useLocalFormat ? 'local format' : 'Berget format'}): ${endpoint}`
         )
 
-        const controller = new AbortController()
-        const timeoutId = setTimeout(() => controller.abort(), 30000) // 30 second timeout for initial request
-
-        let startResponse
-        try {
-          startResponse = await fetch(endpoint, {
+        const startResponse = await fetchWithRetry(
+          endpoint,
+          {
             method: 'POST',
             headers,
             body: JSON.stringify(job.data.doclingSettings),
-            signal: controller.signal,
-          })
-          clearTimeout(timeoutId)
-        } catch (error) {
-          clearTimeout(timeoutId)
-          throw error
-        }
+          },
+          job,
+          3,
+          60000, // 60s timeout — Docling may be slow to accept when busy
+          true // retry on 5xx (covers 502 when container is temporarily unreachable)
+        )
 
         job.log(
           `Response status: ${startResponse.status} ${startResponse.statusText}`
@@ -488,6 +495,14 @@ async function pollTaskAndGetResult(
       if (!statusResponse.ok) {
         const errorText = await statusResponse.text()
         job.log(`Status check error: ${errorText}`)
+
+        if (statusResponse.status === 404) {
+          // Task no longer exists — Docling likely restarted and lost in-memory state.
+          // Clear taskId so the next BullMQ retry resubmits from scratch.
+          await job.updateData({ ...job.data, taskId: undefined, resultUrl: undefined })
+          throw new Error('Task not found on Docling (container may have restarted). Will resubmit on retry.')
+        }
+
         throw new Error(
           `Status check failed with status: ${statusResponse.status}`
         )

--- a/src/workers/doclingParsePDF.ts
+++ b/src/workers/doclingParsePDF.ts
@@ -1,4 +1,5 @@
 import { DiscordWorker, DiscordJob } from '../lib/DiscordWorker'
+import { UnrecoverableError } from 'bullmq'
 import { QUEUE_NAMES } from '../queues'
 import docling from '../config/docling'
 import redis from '../config/redis'
@@ -182,7 +183,8 @@ async function fetchWithRetry(
       })
       clearTimeout(timeoutId)
 
-      if (retryOn5xx && response.status >= 500 && attempt < maxRetries) {
+      const isGatewayError = [502, 503, 504].includes(response.status)
+      if (retryOn5xx && isGatewayError && attempt < maxRetries) {
         const delayMs = 1000 * Math.pow(2, attempt - 1) + jitter
         job.log(
           `Server error ${response.status} on attempt ${attempt}/${maxRetries}. Retrying in ${delayMs}ms...`
@@ -362,18 +364,13 @@ const doclingParsePDF = new DiscordWorker(
         )
 
         if (!startResponse.ok) {
-          try {
-            const errorBody = await startResponse.text()
-            job.log(`Error response body: ${errorBody}`)
-            throw new Error(
-              `Docling API responded with status: ${startResponse.status}`
-            )
-          } catch (bodyError) {
-            job.log(`Failed to read error response body: ${bodyError.message}`)
-            throw new Error(
-              `Docling API responded with status: ${startResponse.status}`
-            )
+          const errorBody = await startResponse.text().catch(() => '')
+          job.log(`Error response body: ${errorBody}`)
+          const msg = `Docling API responded with status: ${startResponse.status}`
+          if ([502, 503, 504].includes(startResponse.status)) {
+            throw new Error(msg)
           }
+          throw new UnrecoverableError(msg)
         }
 
         const responseData = await startResponse.json()
@@ -413,6 +410,8 @@ const doclingParsePDF = new DiscordWorker(
           useBackupAPI
         )
       } catch (networkError) {
+        if (networkError instanceof UnrecoverableError) throw networkError
+
         job.log(
           `Network error details: ${JSON.stringify(
             {
@@ -503,9 +502,11 @@ async function pollTaskAndGetResult(
           throw new Error('Task not found on Docling (container may have restarted). Will resubmit on retry.')
         }
 
-        throw new Error(
-          `Status check failed with status: ${statusResponse.status}`
-        )
+        const msg = `Status check failed with status: ${statusResponse.status}`
+        if ([502, 503, 504].includes(statusResponse.status)) {
+          throw new Error(msg)
+        }
+        throw new UnrecoverableError(msg)
       }
 
       const statusData = await statusResponse.json()
@@ -515,7 +516,7 @@ async function pollTaskAndGetResult(
         job.log('Task complete, exiting polling loop')
         taskComplete = true
       } else if (statusData.task_status === 'failure') {
-        throw new Error(`Task failed: ${JSON.stringify(statusData)}`)
+        throw new UnrecoverableError(`Task failed: ${JSON.stringify(statusData)}`)
       } else {
         // Task is still pending or processing
         job.log(
@@ -542,9 +543,11 @@ async function pollTaskAndGetResult(
     if (!resultResponse.ok) {
       const errorText = await resultResponse.text()
       job.log(`Result fetch error: ${errorText}`)
-      throw new Error(
-        `Failed to fetch result with status: ${resultResponse.status}`
-      )
+      const msg = `Failed to fetch result with status: ${resultResponse.status}`
+      if ([502, 503, 504].includes(resultResponse.status)) {
+        throw new Error(msg)
+      }
+      throw new UnrecoverableError(msg)
     }
 
     const resultData = await resultResponse.json()

--- a/src/workers/parsePdf.ts
+++ b/src/workers/parsePdf.ts
@@ -62,6 +62,10 @@ const parsePdf = new DiscordWorker(
                   ...base,
                   name: 'doclingParsePDF',
                   queueName: QUEUE_NAMES.DOCLING_PARSE_PDF,
+                  opts: {
+                    attempts: 3,
+                    backoff: { type: 'fixed', delay: 30_000 },
+                  },
                 },
               ],
             },

--- a/src/workers/parsePdf.ts
+++ b/src/workers/parsePdf.ts
@@ -64,7 +64,7 @@ const parsePdf = new DiscordWorker(
                   queueName: QUEUE_NAMES.DOCLING_PARSE_PDF,
                   opts: {
                     attempts: 3,
-                    backoff: { type: 'fixed', delay: 30_000 },
+                    backoff: { type: 'fixed', delay: 120_000 },
                   },
                 },
               ],


### PR DESCRIPTION
## Summary

- Limit BullMQ concurrency to **max 1** across all worker instances — Docling handles one request at a time, previously allowed 2
- Retry initial POST submission on gateway errors (502/503/504) with jitter — covers cases where the container is temporarily unreachable or recovering
- Add **jitter** to exponential backoff to prevent thundering herd when multiple jobs retry simultaneously
- Extend initial POST timeout from 30s to 60s — Docling may be slow to accept when busy
- On **404 during status polling**, clear `taskId` from job data so the next BullMQ retry resubmits fresh instead of polling a dead task (happens when Docling container restarts and loses in-memory state)
- Retry `doclingParsePDF` jobs up to **3 times** with 30s backoff via BullMQ `attempts`
- Gateway errors (502/503/504) throw a retryable `Error`; all other failures throw `UnrecoverableError` so BullMQ does not retry them
- Docling-side task failure throws `UnrecoverableError` immediately — no point retrying
- `fetchWithRetry` internal retries now only apply to gateway errors, not all 5xx (e.g. 500 is not retried)

## Test plan

- [ ] Verify jobs queue correctly and only one hits Docling at a time
- [ ] Simulate Docling returning 502 during submission — confirm retry with backoff
- [ ] Simulate Docling returning 500 — confirm job fails immediately without retry
- [ ] Simulate Docling restart mid-job — confirm 404 clears taskId and next retry resubmits