### PR TITLE
fix: upsert company description by (companyId, language) instead of id

### DIFF
--- a/src/api/routes/internal/company.update.ts
+++ b/src/api/routes/internal/company.update.ts
@@ -69,18 +69,19 @@ export async function companyUpdateRoutes(app: FastifyInstance) {
           logoUrl: logoUrl ?? undefined,
           lei,
         })
-        // Create descriptions
-        descriptions?.map(async (description) => {
-          const createdMetadata = await metadataService.createMetadata({
-            user: request.user,
-            metadata,
+        await Promise.all(
+          (descriptions ?? []).map(async (description) => {
+            const createdMetadata = await metadataService.createMetadata({
+              user: request.user,
+              metadata,
+            })
+            await companyService.upsertDescription({
+              description,
+              companyId: wikidataId,
+              metadataId: createdMetadata.id,
+            })
           })
-          await companyService.upsertDescription({
-            description,
-            companyId: wikidataId,
-            metadataId: createdMetadata.id,
-          })
-        })
+        )
         redisCache.clear()
         return reply.send({ ok: true })
       } catch (error) {

--- a/src/api/services/companyService.ts
+++ b/src/api/services/companyService.ts
@@ -192,7 +192,12 @@ class CompanyService {
     metadataId?: string
   }) {
     return prisma.description.upsert({
-      where: { id: description.id ?? '' },
+      where: {
+        companyId_language: {
+          companyId,
+          language: description.language,
+        },
+      },
       create: {
         text: description.text,
         language: description.language,


### PR DESCRIPTION
## Summary
- `upsertDescription` was using `where: { id: description.id ?? '' }` but workers never send a description `id`, so Prisma always fell back to `id = ''`, found nothing, and tried to INSERT — crashing with a unique constraint violation on `(companyId, language)` for any company processed more than once
- Fixed by using the correct compound unique key `companyId_language` as the upsert lookup
- Also wrapped the descriptions `.map(async ...)` in `Promise.all` so errors are caught by the surrounding try/catch and the response isn't sent before writes complete

## Test plan
- [ ] Run the description pipeline on a company that already has a description saved — should update without error
- [ ] Run on a new company — should create as before
- [ ] Verify the prod crash (`P2002` unique constraint on `companyId, language`) no longer occurs