### PR TITLE
Track Chroma and AI call durations in ReportRunJob

### DIFF
--- a/prisma/migrations/20260506120425_save_chroma_ai_call_timing/migration.sql
+++ b/prisma/migrations/20260506120425_save_chroma_ai_call_timing/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "ReportRunJob" ADD COLUMN     "ai_duration_ms" INTEGER,
+ADD COLUMN     "chroma_duration_ms" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,13 +16,13 @@ model Company {
   // // We want to separate the company id from the URL slug
   // id          String  @id @default(cuid())
   /// wikidataId is our unique identifier to link to companies, also used to export to or import from wikidata
-  wikidataId  String  @id
-  name        String
-  description String?
+  wikidataId   String        @id
+  name         String
+  description  String?
   descriptions Description[]
   /// Company website URL
-  url         String?
-  lei         String?
+  url          String?
+  lei          String?
 
   /// TODO: Save Swedish org number, which might be the same as LEI or ISIN
   // swedishOrgNumber
@@ -97,19 +97,19 @@ model IndustryGics {
 
 /// A reporting period is a timespan for accounting emissions as well as financial data
 model ReportingPeriod {
-  id        String   @id @default(cuid())
-  startDate DateTime
-  endDate   DateTime
+  id           String   @id @default(cuid())
+  startDate    DateTime
+  endDate      DateTime
   /// The year needs to be the same year as the endDate.
-  year      String
+  year         String
   /// Save URLs to the sustainability- and potentially also the yearly report for this reporting period.
   /// This needs to be separate from the source URLs for each datapoint, since the data might be updated in a more recent report.
   /// At the same time, we also want to refer back to the actual reports from a given reporting period for comparisons.
-  reportURL String?
+  reportURL    String?
   /// Public URL to the cached/uploaded report PDF (e.g. S3/MinIO/CDN).
-  reportS3Url    String?
+  reportS3Url  String?
   /// Content hash for the cached/uploaded report PDF when available.
-  reportSha256   String?
+  reportSha256 String?
 
   companyId String
 
@@ -368,13 +368,13 @@ model Metadata {
 }
 
 model User {
-  id    String @id @default(cuid())
-  email String?
-  name  String @unique
-  displayName String?
-  githubId   String? @unique
+  id             String  @id @default(cuid())
+  email          String?
+  name           String  @unique
+  displayName    String?
+  githubId       String? @unique
   githubImageUrl String?
-  bot   Boolean @default(false)
+  bot            Boolean @default(false)
 
   // TODO: connect with github ID
   // TODO: store github profile image - or get it via API
@@ -389,14 +389,15 @@ enum Language {
 }
 
 model Description {
-  id          String @id() @default(cuid())
-  text        String
-  companyId   String
+  id        String   @id() @default(cuid())
+  text      String
+  companyId String
   language  Language
-  @@unique([companyId, language])
 
-  company      Company      @relation(fields: [companyId], references: [wikidataId], onDelete: Cascade)
-  metadata  Metadata[]
+  company  Company    @relation(fields: [companyId], references: [wikidataId], onDelete: Cascade)
+  metadata Metadata[]
+
+  @@unique([companyId, language])
 }
 
 model Report {
@@ -417,10 +418,10 @@ model Report {
 }
 
 model Batch {
-  id         String   @id @default(cuid())
+  id         String      @id @default(cuid())
   /// Human-assigned batch label; same string as pipeline `job.data.batchId` on jobs.
-  batchName  String   @unique @map("batch_name")
-  createdAt  DateTime @default(now())
+  batchName  String      @unique @map("batch_name")
+  createdAt  DateTime    @default(now())
   reportRuns ReportRun[]
 }
 
@@ -443,23 +444,23 @@ model ReportRun {
 }
 
 model ReportRunJob {
-  id                 String    @id @default(cuid())
-  jobId              String
-  queueName          String
-  wikidataId         String?
-  status             String // 'completed' | 'failed'
-  approvedTimestamp  String?   @map("approved_timestamp")
-  autoApprove        Boolean   @default(false) @map("auto_approve")
-  failedReason       String?
-  prompt             String?
-  queryTexts         Json? // string[]
-  markdown           String?
-  startedAt          DateTime?
-  finishedAt         DateTime  @default(now())
-  chromaDurationMs   Int?      @map("chroma_duration_ms")
-  aiDurationMs       Int?      @map("ai_duration_ms")
-  reportRunId        String
-  reportRun          ReportRun @relation(fields: [reportRunId], references: [id])
+  id                String    @id @default(cuid())
+  jobId             String
+  queueName         String
+  wikidataId        String?
+  status            String // 'completed' | 'failed'
+  approvedTimestamp String?   @map("approved_timestamp")
+  autoApprove       Boolean   @default(false) @map("auto_approve")
+  failedReason      String?
+  prompt            String?
+  queryTexts        Json? // string[]
+  markdown          String?
+  startedAt         DateTime?
+  finishedAt        DateTime  @default(now())
+  chromaDurationMs  Int?      @map("chroma_duration_ms")
+  aiDurationMs      Int?      @map("ai_duration_ms")
+  reportRunId       String
+  reportRun         ReportRun @relation(fields: [reportRunId], references: [id])
 
   @@index([reportRunId])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -456,6 +456,8 @@ model ReportRunJob {
   markdown           String?
   startedAt          DateTime?
   finishedAt         DateTime  @default(now())
+  chromaDurationMs   Int?      @map("chroma_duration_ms")
+  aiDurationMs       Int?      @map("ai_duration_ms")
   reportRunId        String
   reportRun          ReportRun @relation(fields: [reportRunId], references: [id])
 

--- a/src/lib/FollowUpWorker.ts
+++ b/src/lib/FollowUpWorker.ts
@@ -57,20 +57,22 @@ function addCustomMethods(job: FollowUpJob) {
     type
   ) => {
     job.log(`🔍 Querying vector DB for ${type}...`)
+    const chromaStart = Date.now()
     const markdown = await vectorDB.getRelevantMarkdown(
       url,
       queryTexts,
       15,
       (msg) => job.log(msg)
     )
-    job.log(`✅ Vector DB done for ${type} (${markdown.length} chars)`)
+    const chromaDurationMs = Date.now() - chromaStart
+    job.log(`✅ Vector DB done for ${type} (${markdown.length} chars, ${chromaDurationMs}ms)`)
     ensureValidFollowUpInputs(markdown, prompt, queryTexts, type)
 
     job.log(`Reflecting on: ${prompt}
-    
+
     Context:
     ${markdown}
-    
+
     `)
 
     const streamMessages = [
@@ -104,9 +106,11 @@ function addCustomMethods(job: FollowUpJob) {
       .filter((message) => message !== undefined)
       .filter((message) => message?.content)
 
+    const aiStart = Date.now()
     const response = await askStream(streamMessages, {
       response_format: zodResponseFormat(schema, type.replace(/\//g, '-')),
     })
+    const aiDurationMs = Date.now() - aiStart
 
     job.log('Response: ' + response)
 
@@ -117,6 +121,8 @@ function addCustomMethods(job: FollowUpJob) {
         prompt: prompt,
         queryTexts,
         schema: zodResponseFormat(schema, type.replace(/\//g, '-')),
+        chromaDurationMs,
+        aiDurationMs,
       },
     }
 

--- a/src/lib/FollowUpWorker.ts
+++ b/src/lib/FollowUpWorker.ts
@@ -65,7 +65,9 @@ function addCustomMethods(job: FollowUpJob) {
       (msg) => job.log(msg)
     )
     const chromaDurationMs = Date.now() - chromaStart
-    job.log(`✅ Vector DB done for ${type} (${markdown.length} chars, ${chromaDurationMs}ms)`)
+    job.log(
+      `✅ Vector DB done for ${type} (${markdown.length} chars, ${chromaDurationMs}ms)`
+    )
     ensureValidFollowUpInputs(markdown, prompt, queryTexts, type)
 
     job.log(`Reflecting on: ${prompt}

--- a/src/startWorkers.ts
+++ b/src/startWorkers.ts
@@ -76,6 +76,8 @@ for (const queueName of Object.values(QUEUE_NAMES)) {
           prompt: returnValue?.metadata?.prompt ?? null,
           queryTexts: returnValue?.metadata?.queryTexts ?? null,
           markdown: returnValue?.metadata?.context ?? null,
+          chromaDurationMs: returnValue?.metadata?.chromaDurationMs ?? null,
+          aiDurationMs: returnValue?.metadata?.aiDurationMs ?? null,
           startedAt: job.processedOn ? new Date(job.processedOn) : null,
           finishedAt: new Date(),
           reportRunId: reportRun.id,


### PR DESCRIPTION
## Summary

- Times the Chroma vector DB query and the AI streaming call in `FollowUpWorker`
- Adds `chroma_duration_ms` and `ai_duration_ms` columns to `ReportRunJob` (nullable ints)
- Persists both values when saving job results in `startWorkers.ts`

This gives us latency data per job over time — useful for spotting slow AI calls (we saw ~39s in testing) or slow Chroma queries.

## Test plan

- [ ] Run a follow-up worker job and check `ReportRunJob` row has non-null `chromaDurationMs` and `aiDurationMs`
- [ ] Verify failed jobs still save without errors (both fields nullable)
- [ ] Run `npx prisma migrate deploy` on staging before merging to prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)