### PR TITLE
Fix precheck infinite loop and bad company name lookup on re-runs

### DIFF
--- a/src/workers/parsePdf.ts
+++ b/src/workers/parsePdf.ts
@@ -76,7 +76,7 @@ const parsePdf = new DiscordWorker(
         job.editMessage(`✅ PDF already interpreted and indexed. Continuing...`)
 
         const markdown = await vectorDB.getRelevantMarkdown(url, [
-          'GHG accounting, tCO2e (location-based method), ton CO2e, scope, scope 1, scope 2, scope 3, co2, emissions, emissions, 2021, 2023, 2022, gri protocol, CO2, ghg, greenhouse, gas, climate, change, global, warming, carbon, växthusgaser, utsläpp, basår, koldioxidutsläpp, koldioxid, klimatmål',
+          'company name, annual report, about the company, introduction, company overview, who we are, our business, bolagets namn, årsredovisning, om bolaget',
         ])
 
         const added = await precheck.queue.add('precheck', {

--- a/src/workers/precheck.ts
+++ b/src/workers/precheck.ts
@@ -1,4 +1,4 @@
-import { FlowProducer } from 'bullmq'
+import { FlowProducer, DelayedError } from 'bullmq'
 import redis from '../config/redis'
 import wikidata from '../prompts/wikidata'
 import { askPrompt, askStream } from '../lib/openai'
@@ -88,7 +88,7 @@ const precheck = new DiscordWorker(
       if (waitingForCompanyName) {
         job.log('Still waiting for user to provide company name manually...')
         await job.moveToDelayed(Date.now() + 30000) // Check again in 30 seconds
-        return
+        throw new DelayedError()
       }
 
       // Send message asking for manual input
@@ -104,7 +104,7 @@ const precheck = new DiscordWorker(
       // Mark the job as waiting for company name
       await job.updateData({ ...job.data, waitingForCompanyName: true })
       await job.moveToDelayed(Date.now() + 300000) // Check again in 5 minutes
-      return
+      throw new DelayedError()
     }
 
     return processWithCompanyName(companyName)


### PR DESCRIPTION
## Summary

- **Infinite error loop fix**: `precheck` calls `moveToDelayed` when waiting for a company name, then returned normally. BullMQ tried to call `moveToFinished` on the now-delayed job → "not in active state" error loop. Fixed by throwing `DelayedError` instead of returning, which tells BullMQ to skip finalization.

- **Wrong Chroma query on re-runs**: When a PDF is already indexed, `parsePdf` queried Chroma with emissions keywords and passed that as `cachedMarkdown` to precheck. But precheck only uses that markdown to find the company name — emissions chunks don't help. Fixed by using company-name-focused keywords instead.

## Test plan

- [ ] Run a re-indexed PDF (already in Chroma) and verify company name is found without asking the user
- [ ] Trigger a PDF where company name can't be found — verify no error loop in logs, just clean 5-minute polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)