### PR TITLE
Add CHROMA_CONCURRENCY env var to worker deployment

### DIFF
--- a/k8s/base/worker.yaml
+++ b/k8s/base/worker.yaml
@@ -96,6 +96,11 @@ spec:
                 secretKeyRef:
                   name: env
                   key: CHROMA_CHUNK_SIZE
+            - name: CHROMA_CONCURRENCY
+              valueFrom:
+                secretKeyRef:
+                  name: env
+                  key: CHROMA_CONCURRENCY
             - name: REDIS_HOST
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary
- Wires `CHROMA_CONCURRENCY` from the `env` secret into the worker pod, making it configurable without a code change
- Previously it was missing from the deployment and silently falling back to the hardcoded default of `2` in the Zod schema

## Action needed
Add `CHROMA_CONCURRENCY` to the `env` secret in the cluster with your desired value (e.g. `4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)