### PR TITLE
[#1169] feat(guessWikidata): add forceWikidataReview flag to opt out of auto-approve

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -115,6 +115,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -630,6 +631,7 @@
       "resolved": "https://registry.npmjs.org/@bull-board/ui/-/ui-6.21.3.tgz",
       "integrity": "sha512-s/PLBJab8cnoQAGVqjQb0v4oGe0KgB4aQ5G5g93doxzXB/D+wkXNL9P9+zLWLldBJXE57jL4CR99ttDCIiyNHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bull-board/api": "6.21.3"
       }
@@ -3766,6 +3768,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
       "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -4307,6 +4310,7 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -4526,6 +4530,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4579,6 +4584,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5127,9 +5133,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -5171,6 +5177,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6490,6 +6497,7 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -6882,9 +6890,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -6898,9 +6906,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -6909,7 +6917,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -6948,6 +6957,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fastify/ajv-compiler": "^4.0.5",
         "@fastify/error": "^4.0.0",
@@ -8052,6 +8062,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -10582,6 +10593,7 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
       "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -11219,6 +11231,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/engines": "5.22.0"
       },
@@ -12393,6 +12406,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12643,6 +12657,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13020,9 +13035,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -13038,6 +13053,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlchars": {
@@ -13208,6 +13238,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/workers/guessWikidata.ts
+++ b/src/workers/guessWikidata.ts
@@ -14,6 +14,7 @@ export class GuessWikidataJob extends DiscordJob {
     companyName: string
     overrideWikidataId: EntityId
     wikidata?: Wikidata
+    forceWikidataReview?: boolean
   }
 }
 
@@ -303,53 +304,55 @@ const guessWikidata = new DiscordWorker<GuessWikidataJob>(
       )
     }
 
-    try {
-      const checkIfWikidataExistInProductionRes = await fetch(
-        apiConfig.prodBaseURL + '/companies/' + wikidataForApproval.node,
-        { method: 'GET', headers: { 'Content-Type': 'application/json' } }
-      )
-      if (checkIfWikidataExistInProductionRes.ok) {
-        const checkIfWikidataExistInProduction =
-          await checkIfWikidataExistInProductionRes.json()
-        if (checkIfWikidataExistInProduction.wikidataId) {
-          // Auto-approve since company exists in production
-          const metadata = {
-            source: 'production-database',
-            comment: 'Company found in production database',
-          }
+    if (!job.data.forceWikidataReview) {
+      try {
+        const checkIfWikidataExistInProductionRes = await fetch(
+          apiConfig.prodBaseURL + '/companies/' + wikidataForApproval.node,
+          { method: 'GET', headers: { 'Content-Type': 'application/json' } }
+        )
+        if (checkIfWikidataExistInProductionRes.ok) {
+          const checkIfWikidataExistInProduction =
+            await checkIfWikidataExistInProductionRes.json()
+          if (checkIfWikidataExistInProduction.wikidataId) {
+            // Auto-approve since company exists in production
+            const metadata = {
+              source: 'production-database',
+              comment: 'Company found in production database',
+            }
 
-          await job.requestApproval(
-            'wikidata',
-            {
-              type: 'wikidata',
-              newValue: { wikidata: wikidataForApproval },
-            },
-            true, // auto-approved
-            metadata,
-            `Auto-approved wikidata for ${companyName}`
-          )
-
-          job.sendMessage({
-            content: `🚀 Company found in production database, we will approve automatically: ${companyName}`,
-            components: [],
-          })
-          return JSON.stringify(
-            {
-              status: 'approved',
-              wikidata: wikidataForApproval,
-              message: `Auto-approved wikidata for ${companyName} (found in production database)`,
+            await job.requestApproval(
+              'wikidata',
+              {
+                type: 'wikidata',
+                newValue: { wikidata: wikidataForApproval },
+              },
+              true, // auto-approved
               metadata,
-            },
-            null,
-            2
-          )
+              `Auto-approved wikidata for ${companyName}`
+            )
+
+            job.sendMessage({
+              content: `🚀 Company found in production database, we will approve automatically: ${companyName}`,
+              components: [],
+            })
+            return JSON.stringify(
+              {
+                status: 'approved',
+                wikidata: wikidataForApproval,
+                message: `Auto-approved wikidata for ${companyName} (found in production database)`,
+                metadata,
+              },
+              null,
+              2
+            )
+          }
         }
+      } catch (_error) {
+        job.sendMessage({
+          content: `😫 Could not find the company in the production database, we will have to as the human.`,
+          components: [],
+        })
       }
-    } catch (_error) {
-      job.sendMessage({
-        content: `😫 Could not find the company in the production database, we will have to as the human.`,
-        components: [],
-      })
     }
 
     job.log('Creating approval request for wikidata')


### PR DESCRIPTION
## ✨ What's Changed?

This pull request adds an opt-in `forceWikidataReview` flag to the `guessWikidata` worker that lets the uploader bypass the production-database auto-approve shortcut and force a manual review instead.

The change has two parts:

1. Extended `GuessWikidataJob.data` with an optional `forceWikidataReview?: boolean`. The flag propagates automatically from the parent `parsePdf` job through `precheck`, because `precheck.ts` spreads `...baseData` into its child jobs — no extra plumbing is needed inside garbo.
2. Wrapped the existing prod-DB auto-approve block in `if (!job.data.forceWikidataReview) { ... }`. When the flag is set, the worker skips the prod lookup entirely and falls through to the existing manual-review path further down in the same file. Default behavior is unchanged when the flag is absent or `false`.

Auto-approve when a wikidata ID is found in the production database was introduced deliberately in #707. This PR does not remove that behavior — it only adds a per-job opt-out for the cases #1169 describes, where the uploader suspects "Guess Wikidata" matched the wrong entity (for example ICA Latvia vs ICA Group).

Verified locally that the existing auto-approve path still runs when the flag is absent, and that the manual-review path is taken when `forceWikidataReview: true` is set on the job data.

## 📋 Checklist

- [x] PR title starts with [#issue-number]; if no issue is applicable use: [fix], [feat], [prod], or [copy]
- [x] Verified default behavior is preserved when the flag is not set
- [ ] End-to-end test pending — requires the matching pipeline-api PR so the flag can actually be set from upload

## 🛠 Related Issue

Closes #1169

Related:
- #707 — introduced the auto-approve behavior that this PR makes opt-out-able.
- `Klimatbyran/pipeline-api#45` — matching upload-side flag; will be linked here once that PR is opened.
