### PR TITLE
[FEAT] Multi-model support for prompt testing framework

### DIFF
--- a/src/jobs/promptTestingFramework/comparison-test.ts
+++ b/src/jobs/promptTestingFramework/comparison-test.ts
@@ -1,4 +1,5 @@
 import { extractDataFromMarkdown } from '../utils/extractWithAI'
+import { AskOptions } from './types'
 import { writeFileSync, existsSync, mkdirSync, readFileSync } from 'fs'
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
@@ -65,6 +66,7 @@ interface PromptConfig {
   prompt: string
   schema?: z.ZodSchema
   baseline?: boolean
+  askOptions?: AskOptions
 }
 
 interface ComparisonTestConfig {
@@ -412,14 +414,16 @@ const executeTestRun = async (
   markdown: string,
   prompt: string,
   schema: z.ZodSchema,
-  dataKey: string
+  dataKey: string,
+  askOptions?: AskOptions
 ): Promise<{ result: any; duration: number }> => {
   const runStartTime = Date.now()
   const result = await extractDataFromMarkdown(
     markdown,
     dataKey,
     prompt,
-    schema
+    schema,
+    askOptions
   )
   return {
     result,
@@ -442,7 +446,7 @@ const executeMultipleRuns = async (
   const schema = promptConfig.schema || baseSchema
 
   const promises = Array.from({ length: runsPerTest }, () =>
-    executeTestRun(testFile.markdown, promptConfig.prompt, schema, dataKey)
+    executeTestRun(testFile.markdown, promptConfig.prompt, schema, dataKey, promptConfig.askOptions)
   )
 
   const settledResults = await Promise.allSettled(promises)
@@ -826,8 +830,13 @@ export const runComparisonTest = async (
 
         results.push(testResult)
 
+        const timingStr = timings.map((t) => `${t}ms`).join(', ')
+        const avgTiming = calculateAverage(timings)
         console.log(
           `    ✅ ${testFile.name} - Accuracy: ${accuracy.toFixed(1)}%, Success: ${successRate.toFixed(1)}%`
+        )
+        console.log(
+          `       ⏱  Timings: [${timingStr}] avg: ${avgTiming.toFixed(0)}ms`
         )
         console.log(
           `       🔗 Prompt: ${promptHash}, Schema: ${schemaHash}, File: ${fileHash}`

--- a/src/jobs/promptTestingFramework/run-suite.ts
+++ b/src/jobs/promptTestingFramework/run-suite.ts
@@ -36,7 +36,12 @@ const main = async () => {
   try {
     const testSuite = await loadTestSuite(suiteName)
     const resolvedDataKey =
-      dataKey ?? (suiteName.includes('scope3') ? 'scope3' : 'scope12')
+      dataKey ??
+      (suiteName.includes('scope3')
+        ? 'scope3'
+        : suiteName === 'scope1' || suiteName === 'scope2'
+          ? suiteName
+          : 'scope12')
     const testFiles = loadTestFiles(
       suiteName,
       testSuite,

--- a/src/jobs/promptTestingFramework/types.ts
+++ b/src/jobs/promptTestingFramework/types.ts
@@ -1,5 +1,13 @@
 import { z } from 'zod'
 
+export interface AskOptions {
+  model?: string
+  temperature?: number
+  max_tokens?: number
+  baseURL?: string
+  apiKey?: string
+}
+
 export interface TestSuite {
   expectedResults: {
     [key: string]: any
@@ -12,6 +20,7 @@ export interface TestSuite {
     prompt: string
     schema: z.ZodSchema
     baseline?: boolean
+    askOptions?: AskOptions
   }>
 }
 

--- a/src/jobs/scope1/tests/expected-results.ts
+++ b/src/jobs/scope1/tests/expected-results.ts
@@ -5,7 +5,7 @@ export const expectedResults = {
   // Default result for most test files
 
   lundbergs_fastigheter: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -17,7 +17,7 @@ export const expectedResults = {
     ],
   },
   coor: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -29,7 +29,7 @@ export const expectedResults = {
     ],
   },
   bergmanbeving: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: null,
@@ -41,7 +41,7 @@ export const expectedResults = {
     ],
   },
   duni: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -53,7 +53,7 @@ export const expectedResults = {
     ],
   },
   nibe: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -65,7 +65,7 @@ export const expectedResults = {
     ],
   },
   powercell: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -77,7 +77,7 @@ export const expectedResults = {
     ],
   },
   hemnet: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -89,7 +89,7 @@ export const expectedResults = {
     ],
   },
   vitec: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -101,7 +101,7 @@ export const expectedResults = {
     ],
   },
   bico: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -113,7 +113,7 @@ export const expectedResults = {
     ],
   },
   nivika: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -126,7 +126,7 @@ export const expectedResults = {
   },
 
   eastnine: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -138,7 +138,7 @@ export const expectedResults = {
     ],
   },
   castellum: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -150,7 +150,7 @@ export const expectedResults = {
     ],
   },
   heba: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -162,7 +162,7 @@ export const expectedResults = {
     ],
   },
   aqgroup: {
-    scope12: [
+    scope1: [
       {
         absoluteMostRecentYearInReport: 2024,
         year: 2024,
@@ -175,7 +175,7 @@ export const expectedResults = {
     ],
   },
   systembolaget: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -187,7 +187,7 @@ export const expectedResults = {
     ],
   },
   swedavia: {
-    scope12: [
+    scope1: [
       {
         absoluteMostRecentYearInReport: 2024,
         year: 2024,
@@ -200,7 +200,7 @@ export const expectedResults = {
     ],
   },
   alfalaval: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -212,7 +212,7 @@ export const expectedResults = {
     ],
   },
   storaenso: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -224,7 +224,7 @@ export const expectedResults = {
     ],
   },
   thule: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -236,7 +236,7 @@ export const expectedResults = {
     ],
   },
   lantmannen: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -248,7 +248,7 @@ export const expectedResults = {
     ],
   },
   rusta: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -260,7 +260,7 @@ export const expectedResults = {
     ],
   },
   folksam: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -272,7 +272,7 @@ export const expectedResults = {
     ],
   },
   catena: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: null,
@@ -281,7 +281,7 @@ export const expectedResults = {
     ],
   },
   xvivo: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -293,7 +293,7 @@ export const expectedResults = {
     ],
   },
   'svensk-exportkredit': {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: null,
@@ -302,7 +302,7 @@ export const expectedResults = {
     ],
   },
   epiroc: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -314,7 +314,7 @@ export const expectedResults = {
     ],
   },
   vattenfall: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -326,7 +326,7 @@ export const expectedResults = {
     ],
   },
   icagruppen: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -338,7 +338,7 @@ export const expectedResults = {
     ],
   },
   scandic: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -350,7 +350,7 @@ export const expectedResults = {
     ],
   },
   sas: {
-    scope12: [
+    scope1: [
       {
         absoluteMostRecentYearInReport: 2024,
         year: 2024,
@@ -363,7 +363,7 @@ export const expectedResults = {
     ],
   },
   nyfosa: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -375,7 +375,7 @@ export const expectedResults = {
     ],
   },
   emilshus: {
-    scope12: [
+    scope1: [
       {
         absoluteMostRecentYearInReport: 2024,
         year: 2024,
@@ -388,7 +388,7 @@ export const expectedResults = {
     ],
   },
   rise: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {
@@ -400,7 +400,7 @@ export const expectedResults = {
     ],
   },
   garo: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: null,
@@ -412,7 +412,7 @@ export const expectedResults = {
     ],
   },
   byggmax: {
-    scope12: [
+    scope1: [
       {
         year: 2024,
         scope1: {

--- a/src/jobs/scope1/tests/test-suite.ts
+++ b/src/jobs/scope1/tests/test-suite.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import 'dotenv/config'
 import type { TestSuite } from '../../promptTestingFramework/types'
 import { expectedResults } from './expected-results'
 import { prompt } from '../prompt'
@@ -8,9 +8,20 @@ export const testSuite: TestSuite = {
   expectedResults,
   testVariations: [
     {
-      name: 'only scope 1',
-      prompt: prompt,
-      schema: schema,
+      name: 'OpenAI gpt-4o baseline',
+      prompt,
+      schema,
+      baseline: true,
+    },
+    {
+      name: 'Berget Mistral-Medium-3.5',
+      prompt,
+      schema,
+      askOptions: {
+        baseURL: 'https://api.berget.ai/v1',
+        apiKey: process.env.BERGET_AI_TOKEN,
+        model: 'mistralai/Mistral-Medium-3.5-128B',
+      },
     },
   ],
 }

--- a/src/jobs/utils/extractWithAI.ts
+++ b/src/jobs/utils/extractWithAI.ts
@@ -1,19 +1,23 @@
 import { askStreamWithContext } from '../../lib/ai-utils'
-import { vectorDB } from '../../lib/vectordb'
+import { AskOptions } from '../promptTestingFramework/types'
 import { z } from 'zod'
 
 export const extractDataFromMarkdown = async (
   markdown: string,
   type: string,
   prompt: string,
-  schema: z.ZodSchema
+  schema: z.ZodSchema,
+  askOptions?: AskOptions
 ) => {
   try {
-    return await askStreamWithContext(markdown, prompt, schema, type)
+    return await askStreamWithContext(markdown, prompt, schema, type, askOptions)
   } catch (error: any) {
     const message = error?.message || String(error)
     const name = error?.name || 'Error'
     const stack = error?.stack || undefined
+    console.error(`[extractDataFromMarkdown] ERROR: ${name}: ${message}`)
+    if (error?.status) console.error(`[extractDataFromMarkdown] HTTP status: ${error.status}`)
+    if (error?.error) console.error(`[extractDataFromMarkdown] API error body:`, JSON.stringify(error.error, null, 2))
     // Return a JSON string so downstream parsers can JSON.parse it
     return JSON.stringify({
       error: { name, message, stack, stage: 'askStreamWithContext', type },
@@ -28,6 +32,7 @@ export const extractDataFromUrl = async (
   schema: z.ZodSchema,
   queryTexts: string[]
 ) => {
+  const { vectorDB } = await import('../../lib/vectordb')
   let markdown = ''
   try {
     markdown = await vectorDB.getRelevantMarkdown(url, queryTexts, 15)

--- a/src/lib/ai-utils.ts
+++ b/src/lib/ai-utils.ts
@@ -4,13 +4,15 @@ import {
   ChatCompletionUserMessageParam,
 } from 'openai/resources/chat/completions'
 import { zodResponseFormat } from 'openai/helpers/zod'
+import { AskOptions } from '../jobs/promptTestingFramework/types'
 import { z } from 'zod'
 
 export const askStreamWithContext = async (
   markdown: string,
   prompt: string,
   schema: z.ZodSchema,
-  type: string
+  type: string,
+  askOptions?: AskOptions
 ) => {
   const response = await askStream(
     [
@@ -33,7 +35,8 @@ export const askStreamWithContext = async (
       .filter((m) => m?.content),
     {
       response_format: zodResponseFormat(schema, type.replace(/\//g, '-')),
-    }
+    },
+    askOptions
   )
 
   return response

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -13,6 +13,7 @@ import {
 import openaiConfig from '../config/openai'
 import { Stream } from 'openai/streaming'
 import { RequestOptions } from 'openai/core'
+import { AskOptions } from '../jobs/promptTestingFramework/types'
 
 const openai = new OpenAI({
   apiKey: openaiConfig.apiKey,
@@ -56,22 +57,32 @@ const askStream = async (
   )[],
   options: RequestOptions & {
     onParagraph?: (response: string, paragraph: string) => void
-  } & { response_format?: ResponseFormatJSONSchema }
+  } & { response_format?: ResponseFormatJSONSchema },
+  askOptions?: AskOptions
 ) => {
   const { stream: _, ...safeOpenAIOptions } = options
 
+  const client =
+    askOptions?.baseURL || askOptions?.apiKey
+      ? new OpenAI({ baseURL: askOptions.baseURL, apiKey: askOptions.apiKey })
+      : openai
+
+  const model = askOptions?.model ?? 'gpt-4o-2024-08-06'
   const config = {
     messages: messages.filter((m) => m.content),
-    model: 'gpt-4o-2024-08-06',
-    temperature: 0.1,
+    model,
+    temperature: askOptions?.temperature ?? 0.1,
     stream: true,
-    max_tokens: 16384,
+    max_tokens: askOptions?.max_tokens ?? 16384,
     response_format: options.response_format,
     ...safeOpenAIOptions,
   } satisfies ChatCompletionCreateParamsStreaming
 
+  console.log(`[askStream] → ${model} @ ${askOptions?.baseURL ?? 'OpenAI'}`)
+  const t0 = Date.now()
+
   const stream: Stream<ChatCompletionChunk> =
-    await openai.chat.completions.create(config)
+    await client.chat.completions.create(config)
 
   let response = ''
   let paragraph = ''
@@ -87,6 +98,8 @@ const askStream = async (
   // send the rest if there is any
   if (options?.onParagraph && paragraph)
     options?.onParagraph(response, paragraph)
+
+  console.log(`[askStream] ← ${model} ${Date.now() - t0}ms, ${response.length} chars`)
 
   return response
 }


### PR DESCRIPTION
## Summary

- Adds `AskOptions` interface (`model`, `temperature`, `max_tokens`, `baseURL`, `apiKey`) to `promptTestingFramework/types.ts`
- Threads `AskOptions` through `askStream` → `extractWithAI` → `askStreamWithContext` so each prompt config in a test suite can target a different model or any OpenAI-compatible endpoint
- Adds per-run timing output in comparison test results
- Scope1 test suite and expected results updated accordingly

## Test plan

- [ ] Run existing prompt test suite and verify it still works with default model (`gpt-4o-2024-08-06`)
- [ ] Add an `askOptions` with a different model/baseURL to a prompt config and confirm it routes to the correct endpoint
- [ ] Check timing output appears in comparison test logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)