### PR TITLE
[1235] Modified Dedup and Backfill Scripts for Reports Table

### DIFF
--- a/k8s/jobs/README.md
+++ b/k8s/jobs/README.md
@@ -21,8 +21,6 @@ These manifests are **not** wired into `k8s/base/kustomization.yaml` (Flux). App
 
 Upserts `Report` registry rows from identity fields (`reportURL`, `reportS3Url`, `reportSha256`) already stored on `ReportingPeriod`. Clusters periods by shared identity, merges web-only and GCS-only clusters when the PDF file name matches (same company), and sets `reportYear` from the URL path when possible.
 
-Run **dedupe → backfill → dedupe again** so existing split rows are merged before backfill and any remaining pairs are cleaned up after.
-
 1. **Run the dedupe job first** (see above).
 2. Edit `backfill-report-from-periods.yaml`: set `metadata.namespace` to `garbo-stage` or `garbo`.
 3. **Dry run** (recommended): change `args` to include `--dry-run`.

--- a/k8s/jobs/README.md
+++ b/k8s/jobs/README.md
@@ -19,7 +19,9 @@ These manifests are **not** wired into `k8s/base/kustomization.yaml` (Flux). App
 
 ## Report backfill from periods
 
-Upserts `Report` registry rows from identity fields (`reportURL`, `reportS3Url`, `reportSha256`) already stored on `ReportingPeriod`. Run this **after** the dedupe job so there are no pre-existing duplicate `Report` rows before the upsert logic runs.
+Upserts `Report` registry rows from identity fields (`reportURL`, `reportS3Url`, `reportSha256`) already stored on `ReportingPeriod`. Clusters periods by shared identity, merges web-only and GCS-only clusters when the PDF file name matches (same company), and sets `reportYear` from the URL path when possible.
+
+Run **dedupe → backfill → dedupe again** so existing split rows are merged before backfill and any remaining pairs are cleaned up after.
 
 1. **Run the dedupe job first** (see above).
 2. Edit `backfill-report-from-periods.yaml`: set `metadata.namespace` to `garbo-stage` or `garbo`.

--- a/scripts/backfill-report-from-periods.ts
+++ b/scripts/backfill-report-from-periods.ts
@@ -9,14 +9,14 @@
  *
  * This script:
  *   1. Loads all periods that have at least one identity field set; skips the rest.
- *   2. Clusters periods that reference the same document using union-find on the
- *      three identity fields (sha256 > S3 > URL). A cluster represents one PDF.
+ *   2. Clusters periods that reference the same document (shared sha/S3/URL keys, then
+ *      merge web-only vs GCS-only clusters for the same company when the PDF file name matches).
  *   3. For each cluster, derives the richest `Report` payload:
  *        url       = non-S3 reportURL if available, else reportS3Url
  *        sourceUrl = non-S3 reportURL (always stored when known)
  *        s3Url     = reportS3Url
  *        sha256    = reportSha256
- *        reportYear = max year across all periods in the cluster
+ *        reportYear = year from PDF file name when present (2000–2026), else max data year in cluster
  *        wikidataId / companyName = from the company with the most periods in the cluster
  *   4. Calls `upsertReportInRegistry` for each cluster — this is the same multi-key
  *      dedup logic used at write time, so it safely merges with existing `Report` rows.
@@ -37,7 +37,9 @@ import { writeFileSync } from 'node:fs'
 import { prisma } from '../src/lib/prisma'
 import { registryService } from '../src/api/services/registryService'
 import {
-  isLikelyStoredObjectUrl,
+  isStorageUrl,
+  parseReportYearFromUrl,
+  pdfBasenameFromUrl,
   trimStr,
 } from '../src/api/services/registryReportIdentity'
 import { invalidateRegistryCache } from '../src/api/services/registryCache'
@@ -67,13 +69,100 @@ class DisjointSet {
   }
 }
 
-function addToIndex(map: Map<string, Set<string>>, key: string, id: string) {
-  let s = map.get(key)
-  if (!s) {
-    s = new Set()
-    map.set(key, s)
+function registerPeriodIdentity(
+  owner: Map<string, string>,
+  dsu: DisjointSet,
+  periodId: string,
+  key: string
+) {
+  const existing = owner.get(key)
+  if (existing) dsu.union(periodId, existing)
+  else owner.set(key, periodId)
+}
+
+function unionPeriodsByIdentityKeys(periods: PeriodRow[], dsu: DisjointSet) {
+  const owner = new Map<string, string>()
+  for (const p of periods) {
+    const sha = trimStr(p.reportSha256)
+    const s3 =
+      trimStr(p.reportS3Url) ??
+      (isStorageUrl(p.reportURL) ? trimStr(p.reportURL) : null)
+    const url = trimStr(p.reportURL)
+
+    if (sha) registerPeriodIdentity(owner, dsu, p.id, `sha:${sha}`)
+    if (s3) registerPeriodIdentity(owner, dsu, p.id, `s3:${s3}`)
+    if (url) registerPeriodIdentity(owner, dsu, p.id, `url:${url}`)
   }
-  s.add(id)
+}
+
+interface ClusterMeta {
+  root: string
+  periods: PeriodRow[]
+  wikidataId: string
+  webUrl: string | null
+  s3Url: string | null
+  sha256: string | null
+}
+
+function shouldMergeComplementaryClusters(
+  a: ClusterMeta,
+  b: ClusterMeta
+): boolean {
+  const shaA = trimStr(a.sha256)
+  const shaB = trimStr(b.sha256)
+  if (shaA && shaB && shaA === shaB) return true
+
+  const pairs: [string | null, string | null][] = [
+    [a.webUrl, b.s3Url],
+    [b.webUrl, a.s3Url],
+  ]
+  for (const [web, s3] of pairs) {
+    if (!web || !s3) continue
+    const webBase = pdfBasenameFromUrl(web)
+    const s3Base = pdfBasenameFromUrl(s3)
+    if (webBase && s3Base && webBase === s3Base) return true
+  }
+  return false
+}
+
+function mergeComplementaryClusters(
+  clusters: Map<string, PeriodRow[]>
+): Map<string, PeriodRow[]> {
+  const metas: ClusterMeta[] = []
+  for (const [root, clusterPeriods] of clusters) {
+    const { wikidataId } = dominantCompany(clusterPeriods)
+    metas.push({
+      root,
+      periods: clusterPeriods,
+      wikidataId,
+      webUrl: bestWebUrl(clusterPeriods),
+      s3Url: bestS3Url(clusterPeriods),
+      sha256: bestSha256(clusterPeriods),
+    })
+  }
+
+  const clusterDsu = new DisjointSet()
+  for (const meta of metas) clusterDsu.find(meta.root)
+
+  for (let i = 0; i < metas.length; i++) {
+    for (let j = i + 1; j < metas.length; j++) {
+      const a = metas[i]!
+      const b = metas[j]!
+      if (a.wikidataId !== b.wikidataId) continue
+      if (shouldMergeComplementaryClusters(a, b)) {
+        clusterDsu.union(a.root, b.root)
+      }
+    }
+  }
+
+  const merged = new Map<string, PeriodRow[]>()
+  for (const meta of metas) {
+    const mergedRoot = clusterDsu.find(meta.root)
+    const list = merged.get(mergedRoot)
+    if (list) list.push(...meta.periods)
+    else merged.set(mergedRoot, [...meta.periods])
+  }
+  return merged
 }
 
 // ── Period row type ───────────────────────────────────────────────────────────
@@ -98,7 +187,7 @@ interface PeriodRow {
 function bestWebUrl(periods: PeriodRow[]): string | null {
   for (const p of periods) {
     const u = trimStr(p.reportURL)
-    if (u && !isLikelyStoredObjectUrl(u)) return u
+    if (u && !isStorageUrl(u)) return u
   }
   return null
 }
@@ -112,7 +201,7 @@ function bestS3Url(periods: PeriodRow[]): string | null {
     if (u) return u
     // Also treat reportURL as s3Url when it looks like a storage URL
     const ru = trimStr(p.reportURL)
-    if (ru && isLikelyStoredObjectUrl(ru)) return ru
+    if (ru && isStorageUrl(ru)) return ru
   }
   return null
 }
@@ -128,18 +217,33 @@ function bestSha256(periods: PeriodRow[]): string | null {
   return null
 }
 
-/**
- * Max year string from the cluster — represents the primary data year for the document.
- * A PDF typically covers multiple years (as comparisons), so the max year is the one
- * the document is "about".
- */
-function maxYear(periods: PeriodRow[]): string | null {
+/** Max data year across periods in the cluster (fallback for catalog `reportYear`). */
+function maxDataYear(periods: PeriodRow[]): string | null {
   let best: string | null = null
   for (const p of periods) {
     const y = trimStr(p.year)
     if (y && (!best || y > best)) best = y
   }
   return best
+}
+
+function resolveReportYear(
+  periods: PeriodRow[],
+  webUrl: string | null,
+  s3Url: string | null
+): string | undefined {
+  const fromFileName =
+    parseReportYearFromUrl(s3Url) ?? parseReportYearFromUrl(webUrl)
+  const fromMaxDataYear = maxDataYear(periods)
+
+  if (fromFileName && fromMaxDataYear && fromFileName !== fromMaxDataYear) {
+    console.warn(
+      `  [year] file name year ${fromFileName} differs from max period data year ${fromMaxDataYear} (periods: ${periods.map((p) => p.id).join(', ')})`
+    )
+  }
+
+  const year = fromFileName ?? fromMaxDataYear
+  return year ?? undefined
 }
 
 /**
@@ -212,39 +316,11 @@ async function main() {
       return
     }
 
-    // 2. Cluster periods by document identity.
+    // 2. Cluster periods by document identity, then merge complementary web/GCS clusters.
     const dsu = new DisjointSet()
-    const bySha = new Map<string, Set<string>>()
-    const byS3 = new Map<string, Set<string>>()
-    const byUrl = new Map<string, Set<string>>()
+    unionPeriodsByIdentityKeys(periods, dsu)
 
-    for (const p of periods) {
-      const sha = trimStr(p.reportSha256)
-      const s3 =
-        trimStr(p.reportS3Url) ??
-        (isLikelyStoredObjectUrl(p.reportURL) ? trimStr(p.reportURL) : null)
-      const url = trimStr(p.reportURL)
-
-      if (sha) addToIndex(bySha, sha, p.id)
-      if (s3) addToIndex(byS3, s3, p.id)
-      if (url) addToIndex(byUrl, url, p.id)
-    }
-
-    for (const ids of bySha.values()) {
-      const arr = [...ids]
-      for (let i = 1; i < arr.length; i++) dsu.union(arr[0]!, arr[i]!)
-    }
-    for (const ids of byS3.values()) {
-      const arr = [...ids]
-      for (let i = 1; i < arr.length; i++) dsu.union(arr[0]!, arr[i]!)
-    }
-    for (const ids of byUrl.values()) {
-      const arr = [...ids]
-      for (let i = 1; i < arr.length; i++) dsu.union(arr[0]!, arr[i]!)
-    }
-
-    // Group periods by cluster root.
-    const clusters = new Map<string, PeriodRow[]>()
+    let clusters = new Map<string, PeriodRow[]>()
     for (const p of periods) {
       const root = dsu.find(p.id)
       const list = clusters.get(root)
@@ -252,7 +328,15 @@ async function main() {
       else clusters.set(root, [p])
     }
 
-    console.log(`Grouped into ${clusters.size} document cluster(s).`)
+    const clustersBeforeMerge = clusters.size
+    clusters = mergeComplementaryClusters(clusters)
+    if (clusters.size < clustersBeforeMerge) {
+      console.log(
+        `Merged complementary clusters: ${clustersBeforeMerge} → ${clusters.size} document cluster(s).`
+      )
+    } else {
+      console.log(`Grouped into ${clusters.size} document cluster(s).`)
+    }
 
     // 3. Upsert one Report per cluster.
     let created = 0
@@ -266,7 +350,7 @@ async function main() {
       const webUrl = bestWebUrl(clusterPeriods)
       const s3Url = bestS3Url(clusterPeriods)
       const sha256 = bestSha256(clusterPeriods)
-      const year = maxYear(clusterPeriods)
+      const year = resolveReportYear(clusterPeriods, webUrl, s3Url)
       const { wikidataId, companyName } = dominantCompany(clusterPeriods)
 
       // `url` is required by upsertReportInRegistry — must always be set.

--- a/scripts/dedupe-report-registry.ts
+++ b/scripts/dedupe-report-registry.ts
@@ -7,6 +7,8 @@
  * - the same non-null `url`
  * - cross-link: row A's `url` equals row B's `sourceUrl` (e.g. crawler row keyed by `url`
  *   vs pipeline row with `sourceUrl` set to that report URL)
+ * - same `wikidataId` and exact PDF file name: web/source URL basename equals storage URL basename
+ *   (e.g. GCS object name matches the tail of the company report link)
  *
  * This matches how `buildReportMatchConditions` / `upsertReportInRegistry` can match rows, and
  * supports the partial unique index on `s3Url` (migration `20260504120000_report_s3url_partial_unique`).
@@ -31,6 +33,7 @@ import { invalidateRegistryCache } from '../src/api/services/registryCache'
 import { createServerCache, disconnectRedisCache } from '../src/createCache'
 import {
   copyMissingFields,
+  linkReportRowsByPdfBasename,
   pickRowToKeep,
   trimStr,
   type RegistryReportIdentityRow,
@@ -121,6 +124,8 @@ function findDuplicateComponents(
       }
     }
   }
+
+  linkReportRowsByPdfBasename(rows, dsu)
 
   const rootToIds = new Map<string, string[]>()
   for (const r of rows) {
@@ -213,7 +218,7 @@ async function main() {
 
     if (componentIdLists.length === 0) {
       console.log(
-        'No duplicate report identity groups found (same s3Url, sourceUrl, sha256, url, or url↔sourceUrl link).'
+        'No duplicate report identity groups found (same s3Url, sourceUrl, sha256, url, url↔sourceUrl link, or matching PDF basename per company).'
       )
       if (!dryRun) {
         await invalidateRegistryRedisCache()

--- a/src/api/services/registryReportIdentity.ts
+++ b/src/api/services/registryReportIdentity.ts
@@ -28,6 +28,125 @@ export function trimStr(s: string | null | undefined): string | null {
   return trimmed.length ? trimmed : null
 }
 
+/** Backfill / one-off catalog year parsing (tight window for current registry cleanup). */
+const REPORT_CATALOG_YEAR_MIN = 2000
+const REPORT_CATALOG_YEAR_MAX = 2026
+
+export function isValidReportCatalogYear(year: string): boolean {
+  if (!/^\d{4}$/.test(year)) return false
+  const n = Number(year)
+  return n >= REPORT_CATALOG_YEAR_MIN && n <= REPORT_CATALOG_YEAR_MAX
+}
+
+/** Last path segment of a report URL, lowercased (e.g. `annual-report-2024.pdf`). */
+export function pdfBasenameFromUrl(raw: string | null | undefined): string | null {
+  const value = trimStr(raw)
+  if (!value) return null
+  try {
+    const pathname = decodeURIComponent(new URL(value).pathname)
+    const segment = pathname.split('/').filter(Boolean).pop()
+    if (!segment || segment.length < 3) return null
+    return segment.toLowerCase()
+  } catch {
+    return null
+  }
+}
+
+const REPORT_YEAR_TOKEN = /^(200\d|201\d|202[0-6])$/
+
+/**
+ * Latest plausible publication year in the PDF file name (last URL path segment only).
+ * When several years appear in the basename, returns the highest (2000–2026).
+ */
+export function parseReportYearFromUrl(
+  raw: string | null | undefined
+): string | null {
+  const basename = pdfBasenameFromUrl(raw)
+  if (!basename) return null
+
+  const years: number[] = []
+  for (const token of basename.split(/[^0-9]+/)) {
+    if (!REPORT_YEAR_TOKEN.test(token)) continue
+    const year = Number(token)
+    if (year >= REPORT_CATALOG_YEAR_MIN && year <= REPORT_CATALOG_YEAR_MAX) {
+      years.push(year)
+    }
+  }
+  if (years.length === 0) return null
+  return String(Math.max(...years))
+}
+
+export function webUrlsForBasenameMatch(
+  row: Pick<RegistryReportIdentityRow, 'url' | 'sourceUrl'>
+): string[] {
+  const urls: string[] = []
+  const primary = trimStr(row.url)
+  const source = trimStr(row.sourceUrl)
+  if (primary && !isStorageUrl(primary)) urls.push(primary)
+  if (source && !isStorageUrl(source) && !urls.includes(source)) urls.push(source)
+  return urls
+}
+
+export function storageUrlsForBasenameMatch(
+  row: Pick<RegistryReportIdentityRow, 'url' | 's3Url'>
+): string[] {
+  const urls: string[] = []
+  const s3 = trimStr(row.s3Url)
+  const primary = trimStr(row.url)
+  if (s3) urls.push(s3)
+  if (primary && isStorageUrl(primary) && !urls.includes(primary)) {
+    urls.push(primary)
+  }
+  return urls
+}
+
+export interface ReportIdentityUnionFind {
+  find(id: string): string
+  union(a: string, b: string): void
+}
+
+/** Links rows when a web/source URL and a storage URL share the same PDF file name and company. */
+export function linkReportRowsByPdfBasename(
+  rows: RegistryReportIdentityRow[],
+  dsu: ReportIdentityUnionFind
+): void {
+  const webByKey = new Map<string, string[]>()
+  const storageByKey = new Map<string, string[]>()
+
+  for (const row of rows) {
+    const wikidataId = trimStr(row.wikidataId)
+    if (!wikidataId) continue
+
+    for (const url of webUrlsForBasenameMatch(row)) {
+      const basename = pdfBasenameFromUrl(url)
+      if (!basename) continue
+      const key = `${wikidataId}\0${basename}`
+      const ids = webByKey.get(key)
+      if (ids) ids.push(row.id)
+      else webByKey.set(key, [row.id])
+    }
+
+    for (const url of storageUrlsForBasenameMatch(row)) {
+      const basename = pdfBasenameFromUrl(url)
+      if (!basename) continue
+      const key = `${wikidataId}\0${basename}`
+      const ids = storageByKey.get(key)
+      if (ids) ids.push(row.id)
+      else storageByKey.set(key, [row.id])
+    }
+  }
+
+  for (const [key, storageIds] of storageByKey) {
+    const webIds = webByKey.get(key)
+    if (!webIds) continue
+    for (const storageId of storageIds) {
+      for (const webId of webIds) {
+        if (storageId !== webId) dsu.union(storageId, webId)
+      }
+    }
+  }
+}
+
 export function numberOfIdentityFieldsInRow(
   row: RegistryReportIdentityRow
 ): number {

--- a/src/api/services/registryReportIdentity.ts
+++ b/src/api/services/registryReportIdentity.ts
@@ -39,7 +39,9 @@ export function isValidReportCatalogYear(year: string): boolean {
 }
 
 /** Last path segment of a report URL, lowercased (e.g. `annual-report-2024.pdf`). */
-export function pdfBasenameFromUrl(raw: string | null | undefined): string | null {
+export function pdfBasenameFromUrl(
+  raw: string | null | undefined
+): string | null {
   const value = trimStr(raw)
   if (!value) return null
   try {
@@ -83,7 +85,8 @@ export function webUrlsForBasenameMatch(
   const primary = trimStr(row.url)
   const source = trimStr(row.sourceUrl)
   if (primary && !isStorageUrl(primary)) urls.push(primary)
-  if (source && !isStorageUrl(source) && !urls.includes(source)) urls.push(source)
+  if (source && !isStorageUrl(source) && !urls.includes(source))
+    urls.push(source)
   return urls
 }
 

--- a/tests/registryReportIdentity.test.ts
+++ b/tests/registryReportIdentity.test.ts
@@ -1,6 +1,9 @@
 import {
   buildReportMatchConditions,
   copyMissingFields,
+  linkReportRowsByPdfBasename,
+  parseReportYearFromUrl,
+  pdfBasenameFromUrl,
   pickRowToKeep,
   type RegistryReportIdentityRow,
 } from '../src/api/services/registryReportIdentity'
@@ -103,6 +106,88 @@ describe('registryReportIdentity', () => {
       s3Url: 'https://s3',
     })
     expect(pickRowToKeep([low, high]).id).toBe(high.id)
+  })
+
+  describe('pdfBasenameFromUrl', () => {
+    it('returns the lowercased last path segment', () => {
+      expect(
+        pdfBasenameFromUrl(
+          'https://storage.googleapis.com/bucket/path/Annual_Report_2024.pdf'
+        )
+      ).toBe('annual_report_2024.pdf')
+      expect(
+        pdfBasenameFromUrl(
+          'https://company.com/investors/Annual_Report_2024.pdf'
+        )
+      ).toBe('annual_report_2024.pdf')
+    })
+  })
+
+  describe('parseReportYearFromUrl', () => {
+    it('extracts the latest year from the file name only (2000–2026)', () => {
+      expect(
+        parseReportYearFromUrl(
+          'https://storage.googleapis.com/b/klimat_Q123_2024_report.pdf'
+        )
+      ).toBe('2024')
+      expect(
+        parseReportYearFromUrl(
+          'https://company.com/docs/compare_2022_2024_annual.pdf'
+        )
+      ).toBe('2024')
+    })
+
+    it('ignores years in parent path segments', () => {
+      expect(
+        parseReportYearFromUrl(
+          'https://storage.googleapis.com/b/2019/archive/sustainability-report.pdf'
+        )
+      ).toBeNull()
+    })
+
+    it('ignores years outside 2000–2026', () => {
+      expect(
+        parseReportYearFromUrl(
+          'https://storage.googleapis.com/b/annual_report_1999.pdf'
+        )
+      ).toBeNull()
+    })
+  })
+
+  describe('linkReportRowsByPdfBasename', () => {
+    it('unions a web-only row with a storage-only row for the same company and file name', () => {
+      const web = row({
+        id: 'web',
+        wikidataId: 'Q1',
+        url: 'https://company.com/docs/Annual_Report_2024.pdf',
+      })
+      const gcs = row({
+        id: 'gcs',
+        wikidataId: 'Q1',
+        url: 'https://storage.googleapis.com/bucket/Annual_Report_2024.pdf',
+        s3Url: 'https://storage.googleapis.com/bucket/Annual_Report_2024.pdf',
+      })
+
+      const parent = new Map<string, string>()
+      const dsu = {
+        find(id: string) {
+          let p = parent.get(id) ?? id
+          while (parent.get(p) && parent.get(p) !== p) {
+            p = parent.get(p)!
+          }
+          parent.set(id, p)
+          return p
+        },
+        union(a: string, b: string) {
+          const ra = this.find(a)
+          const rb = this.find(b)
+          if (ra !== rb) parent.set(rb, ra)
+        },
+      }
+
+      linkReportRowsByPdfBasename([web, gcs], dsu)
+      expect(dsu.find('web')).toBe(dsu.find('gcs'))
+    })
   })
 
   it('copyMissingFields fills empty slots from the row being deleted', () => {


### PR DESCRIPTION
### ✨ What’s Changed?

After further testing in stage a few improvements were identified for the deduping and backfilling before we want to deploy to prod. 

While the reports table is not necessarily blocking atm if it's not fully clean, it will be harder to clean down the road and will be more important to be right/reliable. But some manually cleaning will likely be needed simply due to how we've worked (or haven't worked) with the report urls previously



### 📋 Checklist

- [ ] PR title starts with `[#issue-number]`; if no issue is applicable use: `[fix]`, `[feat]`, `[ops]`, or `[prod]`
- [ ] I’ve added/updated tests (or noted why they’re not needed)
- [ ] I’ve verified the change runs locally (and in Docker/k8s if relevant)
- [ ] If this changes the API contract, I’ve called that out clearly (and considered backward compatibility)
- [ ] If this includes a DB change, I’ve included a migration + rollout/rollback notes
- [ ] I’ve considered observability (logs/metrics/traces) and added what’s needed
- [ ] I’ve set labels, linked issue, and milestone (if applicable)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->
