### PR TITLE
[1235] update patch response with error and update registry type

### DIFF
--- a/scripts/backfill-report-from-periods.ts
+++ b/scripts/backfill-report-from-periods.ts
@@ -39,6 +39,7 @@ import { registryService } from '../src/api/services/registryService'
 import {
   isStorageUrl,
   parseReportYearFromUrl,
+  pdfBasenamesMatchForIdentityLink,
   pdfBasenameFromUrl,
   trimStr,
 } from '../src/api/services/registryReportIdentity'
@@ -120,7 +121,9 @@ function shouldMergeComplementaryClusters(
     if (!web || !s3) continue
     const webBase = pdfBasenameFromUrl(web)
     const s3Base = pdfBasenameFromUrl(s3)
-    if (webBase && s3Base && webBase === s3Base) return true
+    if (webBase && s3Base && pdfBasenamesMatchForIdentityLink(webBase, s3Base)) {
+      return true
+    }
   }
   return false
 }
@@ -233,7 +236,7 @@ function resolveReportYear(
   s3Url: string | null
 ): string | undefined {
   const fromFileName =
-    parseReportYearFromUrl(s3Url) ?? parseReportYearFromUrl(webUrl)
+    parseReportYearFromUrl(webUrl) ?? parseReportYearFromUrl(s3Url)
   const fromMaxDataYear = maxDataYear(periods)
 
   if (fromFileName && fromMaxDataYear && fromFileName !== fromMaxDataYear) {

--- a/scripts/backfill-report-from-periods.ts
+++ b/scripts/backfill-report-from-periods.ts
@@ -121,7 +121,11 @@ function shouldMergeComplementaryClusters(
     if (!web || !s3) continue
     const webBase = pdfBasenameFromUrl(web)
     const s3Base = pdfBasenameFromUrl(s3)
-    if (webBase && s3Base && pdfBasenamesMatchForIdentityLink(webBase, s3Base)) {
+    if (
+      webBase &&
+      s3Base &&
+      pdfBasenamesMatchForIdentityLink(webBase, s3Base)
+    ) {
       return true
     }
   }

--- a/scripts/dedupe-report-registry.ts
+++ b/scripts/dedupe-report-registry.ts
@@ -7,8 +7,7 @@
  * - the same non-null `url`
  * - cross-link: row A's `url` equals row B's `sourceUrl` (e.g. crawler row keyed by `url`
  *   vs pipeline row with `sourceUrl` set to that report URL)
- * - same `wikidataId` and exact PDF file name: web/source URL basename equals storage URL basename
- *   (e.g. GCS object name matches the tail of the company report link)
+ * - same `wikidataId` and matching PDF file name on web vs storage (exact or legacy GCS prefix)
  *
  * This matches how `buildReportMatchConditions` / `upsertReportInRegistry` can match rows, and
  * supports the partial unique index on `s3Url` (migration `20260504120000_report_s3url_partial_unique`).
@@ -32,111 +31,10 @@ import { prisma } from '../src/lib/prisma'
 import { invalidateRegistryCache } from '../src/api/services/registryCache'
 import { createServerCache, disconnectRedisCache } from '../src/createCache'
 import {
-  copyMissingFields,
-  linkReportRowsByPdfBasename,
-  pickRowToKeep,
-  trimStr,
-  type RegistryReportIdentityRow,
-} from '../src/api/services/registryReportIdentity'
-
-class DisjointSet {
-  private readonly parent = new Map<string, string>()
-
-  find(x: string): string {
-    if (!this.parent.has(x)) this.parent.set(x, x)
-    let p = this.parent.get(x)!
-    if (p !== x) {
-      p = this.find(p)
-      this.parent.set(x, p)
-    }
-    return p
-  }
-
-  union(a: string, b: string) {
-    const ra = this.find(a)
-    const rb = this.find(b)
-    if (ra === rb) return
-    if (ra.localeCompare(rb) < 0) this.parent.set(rb, ra)
-    else this.parent.set(ra, rb)
-  }
-
-  unionAll(ids: string[]) {
-    const uniq = [...new Set(ids)]
-    if (uniq.length < 2) return
-    const head = uniq[0]!
-    for (let i = 1; i < uniq.length; i++) this.union(head, uniq[i]!)
-  }
-}
-
-function addToIndex(map: Map<string, Set<string>>, key: string, id: string) {
-  let set = map.get(key)
-  if (!set) {
-    set = new Set()
-    map.set(key, set)
-  }
-  set.add(id)
-}
-
-/** Groups of report ids (size ≥ 2) that should be merged into one row. */
-function findDuplicateComponents(
-  rows: RegistryReportIdentityRow[]
-): string[][] {
-  const dsu = new DisjointSet()
-  const byS3 = new Map<string, Set<string>>()
-  const bySource = new Map<string, Set<string>>()
-  const bySha = new Map<string, Set<string>>()
-  const byUrl = new Map<string, Set<string>>()
-
-  for (const r of rows) {
-    const s3 = trimStr(r.s3Url)
-    const su = trimStr(r.sourceUrl)
-    const sh = trimStr(r.sha256)
-    const u = trimStr(r.url)
-    if (s3) addToIndex(byS3, s3, r.id)
-    if (su) addToIndex(bySource, su, r.id)
-    if (sh) addToIndex(bySha, sh, r.id)
-    if (u) addToIndex(byUrl, u, r.id)
-  }
-
-  for (const ids of byS3.values()) dsu.unionAll([...ids])
-  for (const ids of bySource.values()) dsu.unionAll([...ids])
-  for (const ids of bySha.values()) dsu.unionAll([...ids])
-  for (const ids of byUrl.values()) dsu.unionAll([...ids])
-
-  // url on one row === sourceUrl on another (crawler vs pipeline)
-  for (const r of rows) {
-    const u = trimStr(r.url)
-    if (u) {
-      const linked = bySource.get(u)
-      if (linked) {
-        for (const oid of linked) {
-          if (oid !== r.id) dsu.union(r.id, oid)
-        }
-      }
-    }
-    const su = trimStr(r.sourceUrl)
-    if (su) {
-      const linked = byUrl.get(su)
-      if (linked) {
-        for (const oid of linked) {
-          if (oid !== r.id) dsu.union(r.id, oid)
-        }
-      }
-    }
-  }
-
-  linkReportRowsByPdfBasename(rows, dsu)
-
-  const rootToIds = new Map<string, string[]>()
-  for (const r of rows) {
-    const root = dsu.find(r.id)
-    const list = rootToIds.get(root)
-    if (list) list.push(r.id)
-    else rootToIds.set(root, [r.id])
-  }
-
-  return [...rootToIds.values()].filter((ids) => ids.length > 1)
-}
+  findDuplicateReportGroups,
+  mergeDuplicateReportRows,
+} from '../src/api/services/registryReportDedupe'
+import type { RegistryReportIdentityRow } from '../src/api/services/registryReportIdentity'
 
 async function invalidateRegistryRedisCache() {
   const registryCache = createServerCache({ maxAge: 24 * 60 * 60 * 1000 })
@@ -152,12 +50,9 @@ async function mergeDuplicateGroup(
 ) {
   if (rows.length < 2) return { merged: 0, deleted: 0, mapping: [] as string[] }
 
-  const rowToKeep = pickRowToKeep(rows)
-  const rowsToDelete = rows.filter((r) => r.id !== rowToKeep.id)
-  const merged: RegistryReportIdentityRow = { ...rowToKeep }
-  for (const row of rowsToDelete) {
-    Object.assign(merged, copyMissingFields(merged, row))
-  }
+  const merged = mergeDuplicateReportRows(rows)
+  const rowToKeep = rows.find((r) => r.id === merged.id)!
+  const rowsToDelete = rows.filter((r) => r.id !== merged.id)
 
   const mapping: string[] = []
   for (const row of rowsToDelete) {
@@ -169,7 +64,7 @@ async function mergeDuplicateGroup(
       s ? `${s.slice(0, 72)}${s.length > 72 ? '…' : ''}` : '—'
     console.log(
       `[dry-run] Would merge ${rows.length} rows → keep ${rowToKeep.id}, delete ${rowsToDelete.map((r) => r.id).join(', ')}\n` +
-        `          url=${preview(merged.url)} sourceUrl=${preview(merged.sourceUrl)} s3Url=${preview(merged.s3Url)}`
+        `          url=${preview(merged.url)} sourceUrl=${preview(merged.sourceUrl)} s3Url=${preview(merged.s3Url)} reportYear=${merged.reportYear ?? '—'}`
     )
     return { merged: 1, deleted: rowsToDelete.length, mapping }
   }
@@ -213,7 +108,7 @@ async function main() {
       orderBy: { id: 'asc' },
     })) as RegistryReportIdentityRow[]
 
-    const componentIdLists = findDuplicateComponents(allRows)
+    const componentIdLists = findDuplicateReportGroups(allRows)
     const rowById = new Map(allRows.map((r) => [r.id, r]))
 
     if (componentIdLists.length === 0) {

--- a/src/api/plugins/errorhandler.ts
+++ b/src/api/plugins/errorhandler.ts
@@ -44,6 +44,19 @@ export function errorHandler(
           ? { error, ...(garboChunkHeader && { garboChunk: garboChunkHeader }) }
           : undefined,
     })
+  } else if (
+    error instanceof Prisma.PrismaClientKnownRequestError &&
+    error.code === 'P2002'
+  ) {
+    reply.status(409).send({
+      code: 'CONFLICT',
+      message:
+        'A report with this URL, source URL, S3 URL, or hash already exists.',
+      details:
+        apiConfig.nodeEnv === 'development'
+          ? { error, ...(garboChunkHeader && { garboChunk: garboChunkHeader }) }
+          : undefined,
+    })
   } else {
     reply.status(500).send({
       code: 'INTERNAL_SERVER_ERROR',

--- a/src/api/routes/internal/registry.update.ts
+++ b/src/api/routes/internal/registry.update.ts
@@ -4,7 +4,6 @@ import { getTags } from '../../../config/openapi'
 import {
   registryUpdateRequestBodySchema,
   registryUpdateResponseSchema,
-  errorResponseSchema,
   getErrorSchemas,
 } from '../../schemas'
 import { registryService } from '@/api/services/registryService'
@@ -24,8 +23,7 @@ export async function registryUpdateRoutes(app: FastifyInstance) {
         body: registryUpdateRequestBodySchema,
         response: {
           200: registryUpdateResponseSchema,
-          409: errorResponseSchema,
-          ...getErrorSchemas(404),
+          ...getErrorSchemas(404, 409),
         },
       },
     },

--- a/src/api/routes/internal/registry.update.ts
+++ b/src/api/routes/internal/registry.update.ts
@@ -1,8 +1,10 @@
 import { FastifyInstance } from 'fastify'
+import { Prisma } from '@prisma/client'
 import { getTags } from '../../../config/openapi'
 import {
   registryUpdateRequestBodySchema,
   registryUpdateResponseSchema,
+  errorResponseSchema,
   getErrorSchemas,
 } from '../../schemas'
 import { registryService } from '@/api/services/registryService'
@@ -22,22 +24,36 @@ export async function registryUpdateRoutes(app: FastifyInstance) {
         body: registryUpdateRequestBodySchema,
         response: {
           200: registryUpdateResponseSchema,
+          409: errorResponseSchema,
           ...getErrorSchemas(404),
         },
       },
     },
     async (request, reply) => {
-      const updatedReport = await registryService.updateReportInRegistry(
-        request.body as z.infer<typeof registryUpdateRequestBodySchema>
-      )
+      try {
+        const updatedReport = await registryService.updateReportInRegistry(
+          request.body as z.infer<typeof registryUpdateRequestBodySchema>
+        )
 
-      if (!updatedReport) {
-        return reply.status(404).send({ message: 'Report not found' })
+        if (!updatedReport) {
+          return reply.status(404).send({ message: 'Report not found' })
+        }
+
+        await invalidateRegistryCache(redisCache, request.log)
+
+        reply.send(updatedReport)
+      } catch (error) {
+        if (
+          error instanceof Prisma.PrismaClientKnownRequestError &&
+          error.code === 'P2002'
+        ) {
+          return reply.status(409).send({
+            message:
+              'A report with this URL, source URL, S3 URL, or hash already exists.',
+          })
+        }
+        throw error
       }
-
-      await invalidateRegistryCache(redisCache, request.log)
-
-      reply.send(updatedReport)
     }
   )
 }

--- a/src/api/schemas/response.ts
+++ b/src/api/schemas/response.ts
@@ -414,20 +414,21 @@ export const ReportsCompanyList = z.array(
   })
 )
 
-export const RegistryList = z.array(
-  z.object({
-    id: z.string(),
-    url: z.string().url(),
-    sourceUrl: z.string().url().nullable().optional(),
-    s3Url: z.string().url().nullable().optional(),
-    s3Key: z.string().nullable().optional(),
-    s3Bucket: z.string().nullable().optional(),
-    sha256: z.string().nullable().optional(),
-    companyName: z.string().optional().nullable(),
-    wikidataId: z.string().optional().nullable(),
-    reportYear: z.string().optional().nullable(),
-  })
-)
+// Read/response shape: allow legacy non-URL strings in DB so PATCH/GET do not 500 on serialize.
+export const RegistryReportSchema = z.object({
+  id: z.string(),
+  url: z.string(),
+  sourceUrl: z.string().nullable().optional(),
+  s3Url: z.string().nullable().optional(),
+  s3Key: z.string().nullable().optional(),
+  s3Bucket: z.string().nullable().optional(),
+  sha256: z.string().nullable().optional(),
+  companyName: z.string().optional().nullable(),
+  wikidataId: z.string().optional().nullable(),
+  reportYear: z.string().optional().nullable(),
+})
+
+export const RegistryList = z.array(RegistryReportSchema)
 
 export const CompanyDetails = CompanyBase.extend({
   goals: z.array(GoalSchema).nullable(),
@@ -665,13 +666,7 @@ export const errorResponseSchema = z.object({
   message: z.string(),
 })
 
-export const registryUpdateResponseSchema = z.object({
-  id: z.string(),
-  companyName: z.string().nullable(),
-  wikidataId: z.string().nullable(),
-  reportYear: z.string().nullable(),
-  url: z.string().url(),
-})
+export const registryUpdateResponseSchema = RegistryReportSchema
 
 export const registryDeleteResponseSchema = z.object({
   message: z.string(),

--- a/src/api/services/registryReportDedupe.ts
+++ b/src/api/services/registryReportDedupe.ts
@@ -1,0 +1,127 @@
+import {
+  copyMissingFields,
+  linkReportRowsByPdfBasename,
+  pickRowToKeep,
+  preferReportYearFromWebUrls,
+  trimStr,
+  type RegistryReportIdentityRow,
+} from './registryReportIdentity'
+
+class DisjointSet {
+  private readonly parent = new Map<string, string>()
+
+  find(x: string): string {
+    if (!this.parent.has(x)) this.parent.set(x, x)
+    let p = this.parent.get(x)!
+    if (p !== x) {
+      p = this.find(p)
+      this.parent.set(x, p)
+    }
+    return p
+  }
+
+  union(a: string, b: string) {
+    const ra = this.find(a)
+    const rb = this.find(b)
+    if (ra === rb) return
+    if (ra.localeCompare(rb) < 0) this.parent.set(rb, ra)
+    else this.parent.set(ra, rb)
+  }
+
+  unionAll(ids: string[]) {
+    const uniq = [...new Set(ids)]
+    if (uniq.length < 2) return
+    const head = uniq[0]!
+    for (let i = 1; i < uniq.length; i++) this.union(head, uniq[i]!)
+  }
+}
+
+function addToIndex(map: Map<string, Set<string>>, key: string, id: string) {
+  let set = map.get(key)
+  if (!set) {
+    set = new Set()
+    map.set(key, set)
+  }
+  set.add(id)
+}
+
+/** Groups of report ids (size ≥ 2) that should be merged into one row. */
+export function findDuplicateReportGroups(
+  rows: RegistryReportIdentityRow[]
+): string[][] {
+  const dsu = new DisjointSet()
+  const byS3 = new Map<string, Set<string>>()
+  const bySource = new Map<string, Set<string>>()
+  const bySha = new Map<string, Set<string>>()
+  const byUrl = new Map<string, Set<string>>()
+
+  for (const r of rows) {
+    const s3 = trimStr(r.s3Url)
+    const su = trimStr(r.sourceUrl)
+    const sh = trimStr(r.sha256)
+    const u = trimStr(r.url)
+    if (s3) addToIndex(byS3, s3, r.id)
+    if (su) addToIndex(bySource, su, r.id)
+    if (sh) addToIndex(bySha, sh, r.id)
+    if (u) addToIndex(byUrl, u, r.id)
+  }
+
+  for (const ids of byS3.values()) dsu.unionAll([...ids])
+  for (const ids of bySource.values()) dsu.unionAll([...ids])
+  for (const ids of bySha.values()) dsu.unionAll([...ids])
+  for (const ids of byUrl.values()) dsu.unionAll([...ids])
+
+  for (const r of rows) {
+    const u = trimStr(r.url)
+    if (u) {
+      const linked = bySource.get(u)
+      if (linked) {
+        for (const oid of linked) {
+          if (oid !== r.id) dsu.union(r.id, oid)
+        }
+      }
+    }
+    const su = trimStr(r.sourceUrl)
+    if (su) {
+      const linked = byUrl.get(su)
+      if (linked) {
+        for (const oid of linked) {
+          if (oid !== r.id) dsu.union(r.id, oid)
+        }
+      }
+    }
+  }
+
+  linkReportRowsByPdfBasename(rows, dsu)
+
+  const rootToIds = new Map<string, string[]>()
+  for (const r of rows) {
+    const root = dsu.find(r.id)
+    const list = rootToIds.get(root)
+    if (list) list.push(r.id)
+    else rootToIds.set(root, [r.id])
+  }
+
+  return [...rootToIds.values()].filter((ids) => ids.length > 1)
+}
+
+export function mergeDuplicateReportRows(
+  rows: RegistryReportIdentityRow[]
+): RegistryReportIdentityRow {
+  if (rows.length < 2) {
+    throw new Error('mergeDuplicateReportRows: need at least two rows')
+  }
+
+  const rowToKeep = pickRowToKeep(rows)
+  const rowsToDelete = rows.filter((r) => r.id !== rowToKeep.id)
+  const merged: RegistryReportIdentityRow = { ...rowToKeep }
+
+  for (const row of rowsToDelete) {
+    Object.assign(merged, copyMissingFields(merged, row))
+  }
+
+  const yearFromWeb = preferReportYearFromWebUrls(merged)
+  if (yearFromWeb) merged.reportYear = yearFromWeb
+
+  return merged
+}

--- a/src/api/services/registryReportIdentity.ts
+++ b/src/api/services/registryReportIdentity.ts
@@ -54,6 +54,27 @@ export function pdfBasenameFromUrl(
   }
 }
 
+/** Legacy GCS object names: `company_q1234567_2020_original-file-name.pdf`. */
+const LEGACY_GCS_BASENAME_PREFIX = /^[a-z0-9_]+_q\d+_\d{4}_/i
+
+/** File name after stripping a legacy GCS prefix (may equal the full basename). */
+export function storageBasenameTailForMatch(storageBasename: string): string {
+  const tail = storageBasename.replace(LEGACY_GCS_BASENAME_PREFIX, '')
+  return tail.length >= 3 ? tail : storageBasename
+}
+
+/**
+ * Whether a web PDF name and a storage PDF name refer to the same file.
+ * Exact match, or storage name is `Company_Q{id}_{year}_` + web file name.
+ */
+export function pdfBasenamesMatchForIdentityLink(
+  webBasename: string,
+  storageBasename: string
+): boolean {
+  if (webBasename === storageBasename) return true
+  return webBasename === storageBasenameTailForMatch(storageBasename)
+}
+
 const REPORT_YEAR_TOKEN = /^(200\d|201\d|202[0-6])$/
 
 /**
@@ -148,6 +169,70 @@ export function linkReportRowsByPdfBasename(
       }
     }
   }
+
+  const webEntriesByWikidata = new Map<
+    string,
+    { rowId: string; basename: string }[]
+  >()
+  const storageEntriesByWikidata = new Map<
+    string,
+    { rowId: string; basename: string }[]
+  >()
+
+  for (const row of rows) {
+    const wikidataId = trimStr(row.wikidataId)
+    if (!wikidataId) continue
+
+    for (const url of webUrlsForBasenameMatch(row)) {
+      const basename = pdfBasenameFromUrl(url)
+      if (!basename) continue
+      const list = webEntriesByWikidata.get(wikidataId)
+      const entry = { rowId: row.id, basename }
+      if (list) list.push(entry)
+      else webEntriesByWikidata.set(wikidataId, [entry])
+    }
+
+    for (const url of storageUrlsForBasenameMatch(row)) {
+      const basename = pdfBasenameFromUrl(url)
+      if (!basename) continue
+      const list = storageEntriesByWikidata.get(wikidataId)
+      const entry = { rowId: row.id, basename }
+      if (list) list.push(entry)
+      else storageEntriesByWikidata.set(wikidataId, [entry])
+    }
+  }
+
+  for (const [wikidataId, storageEntries] of storageEntriesByWikidata) {
+    const webEntries = webEntriesByWikidata.get(wikidataId)
+    if (!webEntries) continue
+
+    for (const { rowId: storageId, basename: storageBase } of storageEntries) {
+      for (const { rowId: webId, basename: webBase } of webEntries) {
+        if (storageId === webId) continue
+        if (pdfBasenamesMatchForIdentityLink(webBase, storageBase)) {
+          dsu.union(storageId, webId)
+        }
+      }
+    }
+  }
+}
+
+/** Prefer catalog year from web URLs, then storage URLs, then the stored value. */
+export function preferReportYearFromWebUrls(
+  row: Pick<
+    RegistryReportIdentityRow,
+    'url' | 'sourceUrl' | 's3Url' | 'reportYear'
+  >
+): string | null {
+  for (const url of webUrlsForBasenameMatch(row)) {
+    const year = parseReportYearFromUrl(url)
+    if (year) return year
+  }
+  for (const url of storageUrlsForBasenameMatch(row)) {
+    const year = parseReportYearFromUrl(url)
+    if (year) return year
+  }
+  return trimStr(row.reportYear)
 }
 
 export function numberOfIdentityFieldsInRow(

--- a/tests/registryReportIdentity.test.ts
+++ b/tests/registryReportIdentity.test.ts
@@ -255,7 +255,8 @@ describe('registryReportIdentity', () => {
         wikidataId: 'Q1',
         reportYear: '2017',
         url: 'https://storage.googleapis.com/b/afry_q1_2021_afry_2021_annual.pdf',
-        s3Url: 'https://storage.googleapis.com/b/afry_q1_2021_afry_2021_annual.pdf',
+        s3Url:
+          'https://storage.googleapis.com/b/afry_q1_2021_afry_2021_annual.pdf',
       })
 
       expect(preferReportYearFromWebUrls(web)).toBe('2021')

--- a/tests/registryReportIdentity.test.ts
+++ b/tests/registryReportIdentity.test.ts
@@ -4,9 +4,16 @@ import {
   linkReportRowsByPdfBasename,
   parseReportYearFromUrl,
   pdfBasenameFromUrl,
+  pdfBasenamesMatchForIdentityLink,
+  preferReportYearFromWebUrls,
   pickRowToKeep,
+  storageBasenameTailForMatch,
   type RegistryReportIdentityRow,
 } from '../src/api/services/registryReportIdentity'
+import {
+  findDuplicateReportGroups,
+  mergeDuplicateReportRows,
+} from '../src/api/services/registryReportDedupe'
 
 function row(
   p: Partial<RegistryReportIdentityRow> & { id: string; url: string }
@@ -154,6 +161,31 @@ describe('registryReportIdentity', () => {
     })
   })
 
+  describe('pdfBasenamesMatchForIdentityLink', () => {
+    it('matches exact basenames and legacy GCS prefixed storage names', () => {
+      expect(
+        pdfBasenamesMatchForIdentityLink(
+          'addtech-annual-report-2019-2020.pdf',
+          'addtech_q10400997_2020_addtech-annual-report-2019-2020.pdf'
+        )
+      ).toBe(true)
+      expect(
+        storageBasenameTailForMatch(
+          'addtech_q10400997_2020_addtech-annual-report-2019-2020.pdf'
+        )
+      ).toBe('addtech-annual-report-2019-2020.pdf')
+    })
+
+    it('does not match unrelated PDFs for the same company', () => {
+      expect(
+        pdfBasenamesMatchForIdentityLink(
+          'annual-report-2023.pdf',
+          'annual-report-2024.pdf'
+        )
+      ).toBe(false)
+    })
+  })
+
   describe('linkReportRowsByPdfBasename', () => {
     it('unions a web-only row with a storage-only row for the same company and file name', () => {
       const web = row({
@@ -187,6 +219,68 @@ describe('registryReportIdentity', () => {
 
       linkReportRowsByPdfBasename([web, gcs], dsu)
       expect(dsu.find('web')).toBe(dsu.find('gcs'))
+    })
+
+    it('unions web and legacy GCS names when the storage basename embeds the web file name', () => {
+      const web = row({
+        id: 'web',
+        wikidataId: 'Q1',
+        url: 'https://company.com/docs/infranord-ar-2019.pdf',
+      })
+      const gcs = row({
+        id: 'gcs',
+        wikidataId: 'Q1',
+        url: 'https://storage.googleapis.com/bucket/infranord_q10535401_2019_infranord-ar-2019.pdf',
+        s3Url:
+          'https://storage.googleapis.com/bucket/infranord_q10535401_2019_infranord-ar-2019.pdf',
+      })
+
+      const groups = findDuplicateReportGroups([web, gcs])
+      expect(groups).toHaveLength(1)
+      expect(groups[0]).toEqual(expect.arrayContaining(['web', 'gcs']))
+    })
+  })
+
+  describe('mergeDuplicateReportRows', () => {
+    it('prefers reportYear from the web URL when merging', () => {
+      const web = row({
+        id: 'web',
+        wikidataId: 'Q1',
+        reportYear: '2021',
+        url: 'https://company.com/afry_2021_annual.pdf',
+        sourceUrl: 'https://company.com/afry_2021_annual.pdf',
+      })
+      const gcs = row({
+        id: 'gcs',
+        wikidataId: 'Q1',
+        reportYear: '2017',
+        url: 'https://storage.googleapis.com/b/afry_q1_2021_afry_2021_annual.pdf',
+        s3Url: 'https://storage.googleapis.com/b/afry_q1_2021_afry_2021_annual.pdf',
+      })
+
+      expect(preferReportYearFromWebUrls(web)).toBe('2021')
+      const merged = mergeDuplicateReportRows([web, gcs])
+      expect(merged.reportYear).toBe('2021')
+
+      const cisionWeb = row({
+        id: 'web',
+        wikidataId: 'Q1',
+        reportYear: '2022',
+        url: 'https://mb.cision.com/Main/1921081.pdf',
+        sourceUrl: 'https://mb.cision.com/Main/1921081.pdf',
+      })
+      const cisionGcs = row({
+        id: 'gcs',
+        wikidataId: 'Q1',
+        reportYear: '2021',
+        url: 'https://storage.googleapis.com/b/evolution_q1_2022_1921081.pdf',
+        s3Url: 'https://storage.googleapis.com/b/evolution_q1_2022_1921081.pdf',
+      })
+      expect(mergeDuplicateReportRows([cisionWeb, cisionGcs]).reportYear).toBe(
+        '2022'
+      )
+      expect(merged.sourceUrl).toBe(web.sourceUrl)
+      expect(merged.s3Url).toBe(gcs.s3Url)
     })
   })
 


### PR DESCRIPTION
### ✨ What’s Changed?

Fixes Validate registry **PATCH** reliability and hardens one-off **Report** cleanup scripts for stage legacy data (split web/S3 rows, incorrect `reportYear`).

- **API:** PATCH returns **409 Conflict** on unique violations instead of 500; response schema tolerates legacy URL values in the DB.
- **Scripts:** Link web/S3 rows via legacy GCS filenames (`Company_Q{id}_{year}_` + embedded web name); web-first `reportYear`; shared dedupe module.

#### Registry API

- Relax `RegistryReportSchema` for GET/PATCH (plain `string` URL fields) so legacy rows do not fail serialization.
- Map Prisma `P2002` → **409** in `registry.update` and the global error handler.
- Document **409** on the PATCH route.

#### Dedupe & backfill

- `pdfBasenamesMatchForIdentityLink` + second pass in `linkReportRowsByPdfBasename` for legacy GCS object names.
- `registryReportDedupe.ts` — shared `findDuplicateReportGroups` / `mergeDuplicateReportRows`.
- Backfill: same basename rules for complementary period clusters; **web-first** filename year in `resolveReportYear`.

#### Tests

- Unit tests for GCS-prefix matching, dedupe union, merge-year preference.


### 🔍 How to Review / Test
running scripts on local db

### 📋 Checklist

- [x] PR title starts with `[#issue-number]`; if no issue is applicable use: `[fix]`, `[feat]`, `[ops]`, or `[prod]`
- [x] I’ve added/updated tests (or noted why they’re not needed)
- [x] I’ve verified the change runs locally (and in Docker/k8s if relevant)
- [ ] If this changes the API contract, I’ve called that out clearly (and considered backward compatibility)
- [ ] If this includes a DB change, I’ve included a migration + rollout/rollback notes
- [ ] I’ve considered observability (logs/metrics/traces) and added what’s needed
- [x] I’ve set labels, linked issue, and milestone (if applicable)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->
