### PR TITLE
Increase garbo API memory limit to prevent OOMKill

### DIFF
--- a/k8s/base/api.yaml
+++ b/k8s/base/api.yaml
@@ -36,9 +36,9 @@ spec:
         - image: ghcr.io/klimatbyran/garbo
           resources:
             requests:
-              memory: '400Mi'
+              memory: '800Mi'
             limits:
-              memory: '768Mi'
+              memory: '1.5Gi'
           name: garbo
           ports:
             - containerPort: 3000


### PR DESCRIPTION
## Summary
- Bumped memory request from `400Mi` to `800Mi`
- Bumped memory limit from `768Mi` to `1.5Gi` to prevent OOMKill on traffic/workload spikes

## Test plan
- [ ] Flux picks up the change and rolls out new pods in staging and prod
- [ ] No OOMKill events after rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)