### PR TITLE
[1250] Reporting Periods Endpoints and Pipeline Changes

### DIFF
--- a/k8s/jobs/README.md
+++ b/k8s/jobs/README.md
@@ -32,11 +32,11 @@ Upserts `Report` registry rows from identity fields (`reportURL`, `reportS3Url`,
 
 5. Watch logs: `kubectl logs -n garbo-stage job/backfill-report-from-periods-<suffix> -f`
 
-## Link periods to CompanyReport (PR 1)
+## Link periods to CompanyReport
 
 Sets `ReportingPeriod.companyReportId` for all rows. One `CompanyReport` per company (latest Report). Dry-run prints `Resolution:` counts (watch `synthetic`) and a `Year mismatch:` list when the chosen PDF year ≠ max period year on that company.
 
-1. Deploy PR 1 schema (migration).
+1. Deploy migration `20260520120000_add_company_report` (CompanyReport table + nullable `companyReportId`).
 2. Recommended: dedupe + backfill-from-periods (above).
 3. Edit `link-periods-to-company-reports.yaml`: set `metadata.namespace`.
 4. Dry run: add `--dry-run` to `args`; review console output before live run.
@@ -48,10 +48,11 @@ Sets `ReportingPeriod.companyReportId` for all rows. One `CompanyReport` per com
 
 6. Watch logs: `kubectl logs -n garbo-stage job/link-periods-to-company-reports-<suffix> -f`
 
-## PR 2 schema (per-report period uniqueness)
+## Reporting periods per document (deploy order)
 
-Deploy order after PR 1 link job has run in that environment (no `companyReportId IS NULL`):
+After the link job has run in that environment (no `companyReportId IS NULL`):
 
 1. Deploy app + run migration `20260602120000_reporting_period_per_company_report` (`npm run migrate`).
-2. Writes upsert on `(companyReportId, year)` instead of `(companyId, year)`; same calendar year can exist under two `CompanyReport` rows after PR 1b.
-3. `POST .../reporting-periods` accepts optional `companyReportId` (body or per period); otherwise resolves shell from report URLs/hash or the company’s default `CompanyReport`.
+2. **Writes:** Upsert reporting periods on `(companyReportId, year)`; `POST .../reporting-periods` accepts optional `companyReportId` and job-level report URLs.
+3. **Public read:** `GET /companies` returns one period per data year (from the `CompanyReport` with the highest `reportYear`).
+4. **PDF year:** Pipeline save sets `documentReportYear` on `Report` and `CompanyReport`; registry upsert updates `reportYear` when the job sends a valid year.

--- a/k8s/jobs/README.md
+++ b/k8s/jobs/README.md
@@ -47,3 +47,11 @@ Sets `ReportingPeriod.companyReportId` for all rows. One `CompanyReport` per com
    ```
 
 6. Watch logs: `kubectl logs -n garbo-stage job/link-periods-to-company-reports-<suffix> -f`
+
+## PR 2 schema (per-report period uniqueness)
+
+Deploy order after PR 1 link job has run in that environment (no `companyReportId IS NULL`):
+
+1. Deploy app + run migration `20260602120000_reporting_period_per_company_report` (`npm run migrate`).
+2. Writes upsert on `(companyReportId, year)` instead of `(companyId, year)`; same calendar year can exist under two `CompanyReport` rows after PR 1b.
+3. `POST .../reporting-periods` accepts optional `companyReportId` (body or per period); otherwise resolves shell from report URLs/hash or the company’s default `CompanyReport`.

--- a/k8s/jobs/link-periods-to-company-reports.yaml
+++ b/k8s/jobs/link-periods-to-company-reports.yaml
@@ -2,10 +2,9 @@
 # NOT applied by Flux — use: kubectl create -f k8s/jobs/link-periods-to-company-reports.yaml
 #
 # Prerequisites:
-#   1. Deploy the PR 1 image (CompanyReport table + nullable companyReportId column)
+#   1. Deploy image with migration 20260520120000_add_company_report (CompanyReport + nullable companyReportId)
 #   2. Recommended: backfill-report-from-periods (after dedupe) so Report rows exist
-#   3. Run this job — links all periods to one CompanyReport per company (latest Report;
-#      prefers newest period Metadata.source, else highest Report.reportYear (richest row if tied))
+#   3. Run this job — one CompanyReport per company (latest Report by metadata URL or reportYear)
 #
 # - For dry-run only, set args to: ["scripts/link-periods-to-company-reports.ts", "--dry-run"]
 

--- a/prisma/migrations/20260520120000_add_company_report/migration.sql
+++ b/prisma/migrations/20260520120000_add_company_report/migration.sql
@@ -5,8 +5,9 @@
 -- (scripts/link-periods-to-company-reports.ts) populates the FK for existing rows.
 --
 -- @@unique([companyId, year]) on ReportingPeriod is kept in this migration.
--- It is replaced by @@unique([companyReportId, year]) in PR 2 once all rows
--- have companyReportId set and the write path has been updated.
+-- It is replaced by @@unique([companyReportId, year]) in migration
+-- 20260602120000_reporting_period_per_company_report once all rows have
+-- companyReportId set and the write path uses (companyReportId, year).
 
 -- CreateTable
 CREATE TABLE "CompanyReport" (
@@ -21,7 +22,7 @@ CREATE TABLE "CompanyReport" (
 );
 
 -- CreateIndex: one CompanyReport per (company, report).
--- Postgres allows multiple NULLs in unique constraints (synthetic shells per company).
+-- Postgres allows multiple NULLs in unique constraints (several rows with NULL registryReportId).
 CREATE UNIQUE INDEX "CompanyReport_companyId_registryReportId_key" ON "CompanyReport"("companyId", "registryReportId");
 
 -- AddForeignKey: CompanyReport -> Company

--- a/prisma/migrations/20260602120000_reporting_period_per_company_report/migration.sql
+++ b/prisma/migrations/20260602120000_reporting_period_per_company_report/migration.sql
@@ -1,4 +1,4 @@
--- PR 2: require companyReportId; one period row per (CompanyReport, year).
+-- Require companyReportId; one period row per (CompanyReport, year).
 -- Prerequisite: scripts/link-periods-to-company-reports.ts (no NULL companyReportId).
 
 DO $$

--- a/prisma/migrations/20260602120000_reporting_period_per_company_report/migration.sql
+++ b/prisma/migrations/20260602120000_reporting_period_per_company_report/migration.sql
@@ -1,0 +1,28 @@
+-- PR 2: require companyReportId; one period row per (CompanyReport, year).
+-- Prerequisite: scripts/link-periods-to-company-reports.ts (no NULL companyReportId).
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM "ReportingPeriod" WHERE "companyReportId" IS NULL LIMIT 1
+  ) THEN
+    RAISE EXCEPTION
+      'ReportingPeriod.companyReportId must be populated before this migration. Run scripts/link-periods-to-company-reports.ts';
+  END IF;
+END $$;
+
+ALTER TABLE "ReportingPeriod" DROP CONSTRAINT "ReportingPeriod_companyReportId_fkey";
+
+ALTER TABLE "ReportingPeriod" ALTER COLUMN "companyReportId" SET NOT NULL;
+
+ALTER TABLE "ReportingPeriod" ADD CONSTRAINT "ReportingPeriod_companyReportId_fkey"
+    FOREIGN KEY ("companyReportId") REFERENCES "CompanyReport"("id")
+    ON DELETE RESTRICT ON UPDATE CASCADE;
+
+DROP INDEX "ReportingPeriod_companyId_year_key";
+
+CREATE UNIQUE INDEX "ReportingPeriod_companyReportId_year_key"
+    ON "ReportingPeriod"("companyReportId", "year");
+
+CREATE INDEX "ReportingPeriod_companyId_year_idx"
+    ON "ReportingPeriod"("companyId", "year");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -113,17 +113,17 @@ model ReportingPeriod {
   reportSha256 String?
 
   companyId       String
-  /// FK to the document shell for this period's data. Nullable until PR 1 link script runs;
-  /// required with @@unique([companyReportId, year]) in PR 2.
-  companyReportId String?
+  /// FK to the document shell for this period's data.
+  companyReportId String
 
   metadata      Metadata[]
   economy       Economy?
   emissions     Emissions?
-  company       Company        @relation(fields: [companyId], references: [wikidataId], onDelete: Cascade)
-  companyReport CompanyReport? @relation(fields: [companyReportId], references: [id], onDelete: SetNull)
+  company       Company       @relation(fields: [companyId], references: [wikidataId], onDelete: Cascade)
+  companyReport CompanyReport @relation(fields: [companyReportId], references: [id], onDelete: Restrict)
 
-  @@unique([companyId, year])
+  @@unique([companyReportId, year])
+  @@index([companyId, year])
 }
 
 /// Reported emissions for a specific reporting period
@@ -427,7 +427,7 @@ model Report {
 /// One processed document per company. Links a registry Report to the company's pipeline data.
 /// Multiple CompanyReports per company are allowed — one per distinct PDF submitted.
 /// reportingPeriods point here so the same calendar year can exist under different reports
-/// without overwriting (@@unique([companyReportId, year]) enforced in PR 2).
+/// without overwriting (@@unique([companyReportId, year]) on ReportingPeriod).
 model CompanyReport {
   id                    String    @id @default(cuid())
   companyId             String

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -113,7 +113,7 @@ model ReportingPeriod {
   reportSha256 String?
 
   companyId       String
-  /// FK to the document shell for this period's data.
+  /// CompanyReport (processed PDF) this emissions year belongs to.
   companyReportId String
 
   metadata      Metadata[]
@@ -424,18 +424,15 @@ model Report {
   companyReports CompanyReport[]
 }
 
-/// One processed document per company. Links a registry Report to the company's pipeline data.
-/// Multiple CompanyReports per company are allowed — one per distinct PDF submitted.
-/// reportingPeriods point here so the same calendar year can exist under different reports
-/// without overwriting (@@unique([companyReportId, year]) on ReportingPeriod).
+/// One processed PDF per company (links to Report registry). Several per company when multiple PDFs exist.
 model CompanyReport {
   id                    String    @id @default(cuid())
   companyId             String
-  /// FK to Report registry row. Null only for synthetic shells (no metadata URL and no registry row).
+  /// Report registry row; null when no PDF could be matched (legacy link job only).
   registryReportId      String?
-  /// Max calendar year among linked periods after PR 1 link; document business year may differ.
+  /// PDF year label (e.g. 2025); may differ from max emissions data year on linked periods.
   reportYear            String?
-  /// Publication date of the PDF when available; used as tie-breaker in effective-view ranking.
+  /// PDF publication date; tie-break when two reports share the same reportYear.
   reportPublicationDate DateTime?
   createdAt             DateTime  @default(now())
 
@@ -443,8 +440,6 @@ model CompanyReport {
   report           Report?           @relation(fields: [registryReportId], references: [id], onDelete: SetNull)
   reportingPeriods ReportingPeriod[]
 
-  /// One CompanyReport per (company, report). Postgres allows multiple NULLs in unique
-  /// constraints, so synthetic legacy rows (registryReportId IS NULL) are permitted per company.
   @@unique([companyId, registryReportId])
 }
 

--- a/scripts/link-periods-to-company-reports.ts
+++ b/scripts/link-periods-to-company-reports.ts
@@ -1,16 +1,14 @@
 /**
- * Data migration: set ReportingPeriod.companyReportId (PR 1).
+ * Set ReportingPeriod.companyReportId on existing rows (one CompanyReport per company).
  *
- * Run after: PR 1 migration; 0b backfill recommended.
+ * Prerequisites: migration 20260520120000_add_company_report; registry dedupe +
+ * backfill-from-periods recommended.
  *
- * One CompanyReport per company → latest Report (newest period Metadata.source URL,
- * else highest Report.reportYear in registry, else synthetic). Does not split by
- * per-period reportURL. PR 1b may add a second shell after PR 2.
+ * Picks the latest Report per company (newest period metadata URL, else highest
+ * Report.reportYear, else synthetic). Does not split by per-period reportURL.
  *
  *   npx tsx scripts/link-periods-to-company-reports.ts --dry-run
  *   npx tsx scripts/link-periods-to-company-reports.ts
- *
- * Skips rows that already have companyReportId.
  */
 
 import 'dotenv/config'
@@ -301,7 +299,7 @@ async function main() {
 
     const byCompany = groupPeriodsByCompany(periods)
     console.log(
-      `Linking ${periods.length} period(s) across ${byCompany.size} companies (one shell per company).`
+      `Linking ${periods.length} period(s) across ${byCompany.size} companies (one CompanyReport per company).`
     )
 
     const companyReportCache = new Map<string, string>()
@@ -383,7 +381,7 @@ async function main() {
 
     if (yearMismatches.length > 0) {
       console.log(
-        `\nYear mismatch: chosen document year ≠ max calendar year on periods (${yearMismatches.length} companies). Often comparison years + latest PDF metadata — spot-check for accuracy / 1b:`
+        `\nYear mismatch: PDF year ≠ max data year on periods (${yearMismatches.length} companies). Often comparison years in one PDF — spot-check:`
       )
       for (const row of yearMismatches) {
         console.log(
@@ -398,7 +396,7 @@ async function main() {
 
     if (!dryRun && linked > 0) {
       console.log(
-        '\nSetting CompanyReport.reportYear to max linked period calendar year per shell…'
+        '\nSetting CompanyReport.reportYear to max linked period year per company…'
       )
 
       const companyReports = await prisma.companyReport.findMany({

--- a/scripts/migrateWithPrisma.ts
+++ b/scripts/migrateWithPrisma.ts
@@ -61,6 +61,16 @@ async function migrateData() {
       })
     }
 
+    const companyReportId = (
+      await prisma.companyReport.create({
+        data: {
+          companyId: createdCompany.wikidataId,
+          registryReportId: null,
+        },
+        select: { id: true },
+      })
+    ).id
+
     for (const period of reportingPeriods) {
       const createdPeriod = await prisma.reportingPeriod.create({
         data: {
@@ -68,6 +78,7 @@ async function migrateData() {
           endDate: new Date(period.endDate),
           year: period.endDate.slice(0, 4),
           companyId: createdCompany.wikidataId,
+          companyReportId,
           reportURL: period.reportURL,
           metadata: createMetadata(period.metadata),
         },

--- a/src/api/args.ts
+++ b/src/api/args.ts
@@ -18,6 +18,19 @@ export const economyArgs = {
   },
 } satisfies Prisma.EconomyDefaultArgs
 
+/** companyReport fields used when picking one period per data year on public read. */
+export const reportingPeriodCompanyReportSelect = {
+  year: true,
+  companyReportId: true,
+  companyReport: {
+    select: {
+      id: true,
+      reportYear: true,
+      reportPublicationDate: true,
+    },
+  },
+} as const
+
 export const reportingPeriodArgs = {
   include: {
     emissions: emissionsArgs,
@@ -83,9 +96,12 @@ export const detailedCompanyArgs = {
         id: true,
         startDate: true,
         endDate: true,
+        year: true,
+        companyReportId: true,
         reportURL: true,
         reportS3Url: true,
         reportSha256: true,
+        companyReport: reportingPeriodCompanyReportSelect.companyReport,
         economy: {
           select: {
             id: true,
@@ -254,9 +270,12 @@ export const companyListArgs = {
       select: {
         startDate: true,
         endDate: true,
+        year: true,
+        companyReportId: true,
         reportURL: true,
         reportS3Url: true,
         reportSha256: true,
+        companyReport: reportingPeriodCompanyReportSelect.companyReport,
         economy: {
           select: {
             turnover: {

--- a/src/api/routes/external/company.read.ts
+++ b/src/api/routes/external/company.read.ts
@@ -42,24 +42,32 @@ export async function companyReadRoutes(app: FastifyInstance) {
       const [
         companyCount,
         reportingPeriodCount,
+        companyReportCount,
         emissionsCount,
         latestMetadata,
+        latestCompanyReport,
       ] = await prisma.$transaction([
         prisma.company.count(),
         prisma.reportingPeriod.count(),
+        prisma.companyReport.count(),
         prisma.emissions.count(),
         prisma.metadata.findFirst({
           select: { updatedAt: true },
           orderBy: { updatedAt: 'desc' },
         }),
+        prisma.companyReport.findFirst({
+          select: { createdAt: true },
+          orderBy: { createdAt: 'desc' },
+        }),
       ])
 
-      // Create a unique fingerprint based on company data
       const databaseFingerprint = [
         companyCount,
         reportingPeriodCount,
+        companyReportCount,
         emissionsCount,
         latestMetadata?.updatedAt?.toISOString() || '',
+        latestCompanyReport?.createdAt?.toISOString() || '',
       ].join('|')
 
       if (!currentEtag || !currentEtag.startsWith(databaseFingerprint)) {
@@ -72,7 +80,7 @@ export async function companyReadRoutes(app: FastifyInstance) {
       let companies = await redisCache.get(dataCacheKey)
 
       if (!companies) {
-        companies = await companyService.getAllCompaniesWithMetadata()
+        companies = await companyService.getAllCompaniesForPublicRead()
         await redisCache.set(dataCacheKey, JSON.stringify(companies))
       }
 
@@ -102,7 +110,9 @@ export async function companyReadRoutes(app: FastifyInstance) {
       reply
     ) => {
       const { q } = request.query
-      const companies = await companyService.getAllCompaniesBySearchTerm(q)
+      const companies = await companyService.getAllCompaniesBySearchTerm(q, {
+        onePeriodPerDataYear: true,
+      })
       reply.send(companies)
     }
   )
@@ -124,7 +134,7 @@ export async function companyReadRoutes(app: FastifyInstance) {
     },
     async (request: FastifyRequest<{ Params: WikidataIdParams }>, reply) => {
       const { wikidataId } = request.params
-      const company = await companyService.getCompanyWithMetadata(wikidataId)
+      const company = await companyService.getCompanyForPublicRead(wikidataId)
       reply.send({
         ...company,
         // Add translations for GICS data

--- a/src/api/routes/internal/company.pipelineRead.ts
+++ b/src/api/routes/internal/company.pipelineRead.ts
@@ -1,0 +1,50 @@
+import { FastifyInstance, FastifyRequest } from 'fastify'
+
+import { getGics } from '../../../lib/gics'
+import { companyService } from '../../services/companyService'
+import {
+  getErrorSchemas,
+  InternalCompanyDetails,
+  wikidataIdParamSchema,
+} from '../../schemas'
+import { getTags } from '../../../config/openapi'
+import { WikidataIdParams } from '../../types'
+
+/**
+ * Staff JWT routes for Garbo workers (pipeline diff/save). Not exposed on the
+ * public client API — full reporting period rows, no effective-read filter.
+ */
+export async function pipelineCompanyReadRoutes(app: FastifyInstance) {
+  app.get(
+    '/:wikidataId',
+    {
+      schema: {
+        summary: 'Company with all reporting periods (pipeline)',
+        description:
+          'Full company payload for pipeline diff and approval. Includes every reporting period row (not the public one-period-per-year view).',
+        tags: getTags('Internal'),
+        params: wikidataIdParamSchema,
+        response: {
+          200: InternalCompanyDetails,
+          ...getErrorSchemas(400, 404),
+        },
+      },
+    },
+    async (request: FastifyRequest<{ Params: WikidataIdParams }>, reply) => {
+      const { wikidataId } = request.params
+      const company = await companyService.getCompanyWithMetadata(wikidataId)
+      reply.send({
+        ...company,
+        industry: company.industry
+          ? {
+              ...company.industry,
+              industryGics: {
+                ...company.industry.industryGics,
+                ...getGics(company.industry.industryGics.subIndustryCode),
+              },
+            }
+          : null,
+      })
+    }
+  )
+}

--- a/src/api/routes/internal/company.pipelineRead.ts
+++ b/src/api/routes/internal/company.pipelineRead.ts
@@ -1,20 +1,94 @@
 import { FastifyInstance, FastifyRequest } from 'fastify'
 
 import { getGics } from '../../../lib/gics'
+import { prisma } from '../../../lib/prisma'
 import { companyService } from '../../services/companyService'
 import {
+  CompanyList,
   getErrorSchemas,
   InternalCompanyDetails,
   wikidataIdParamSchema,
 } from '../../schemas'
 import { getTags } from '../../../config/openapi'
 import { WikidataIdParams } from '../../types'
+import { cachePlugin } from '../../plugins/cache'
+import { redisCache } from '../../../lib/redisCacheSingleton'
 
 /**
- * Staff JWT routes for Garbo workers (pipeline diff/save). Not exposed on the
- * public client API — full reporting period rows, no effective-read filter.
+ * Staff JWT routes for validate and pipeline workers. Full reporting period rows
+ * (not the one-period-per-data-year effective read used on client APIs).
  */
 export async function pipelineCompanyReadRoutes(app: FastifyInstance) {
+  app.register(cachePlugin)
+
+  app.get(
+    '/',
+    {
+      schema: {
+        summary: 'List companies with all reporting periods (pipeline)',
+        description:
+          'Staff list for validate and pipeline tooling. Includes every reporting period row per company (not the public one-period-per-data-year view).',
+        tags: getTags('Internal'),
+        response: {
+          200: CompanyList,
+        },
+      },
+    },
+    async (request, reply) => {
+      const cacheKey = 'pipeline-companies:etag'
+
+      let currentEtag: string = await redisCache.get(cacheKey)
+
+      const [
+        companyCount,
+        reportingPeriodCount,
+        companyReportCount,
+        emissionsCount,
+        latestMetadata,
+        latestCompanyReport,
+      ] = await prisma.$transaction([
+        prisma.company.count(),
+        prisma.reportingPeriod.count(),
+        prisma.companyReport.count(),
+        prisma.emissions.count(),
+        prisma.metadata.findFirst({
+          select: { updatedAt: true },
+          orderBy: { updatedAt: 'desc' },
+        }),
+        prisma.companyReport.findFirst({
+          select: { createdAt: true },
+          orderBy: { createdAt: 'desc' },
+        }),
+      ])
+
+      const databaseFingerprint = [
+        companyCount,
+        reportingPeriodCount,
+        companyReportCount,
+        emissionsCount,
+        latestMetadata?.updatedAt?.toISOString() || '',
+        latestCompanyReport?.createdAt?.toISOString() || '',
+      ].join('|')
+
+      if (!currentEtag || !currentEtag.startsWith(databaseFingerprint)) {
+        currentEtag = `${databaseFingerprint}-${new Date().toISOString()}`
+        await redisCache.set(cacheKey, JSON.stringify(currentEtag))
+      }
+
+      const dataCacheKey = `pipeline-companies:data:${databaseFingerprint}`
+
+      let companies = await redisCache.get(dataCacheKey)
+
+      if (!companies) {
+        companies = await companyService.getAllCompaniesWithMetadata()
+        await redisCache.set(dataCacheKey, JSON.stringify(companies))
+      }
+
+      reply.header('ETag', `${currentEtag}`)
+      reply.send(companies)
+    }
+  )
+
   app.get(
     '/:wikidataId',
     {

--- a/src/api/routes/internal/company.reportingPeriods.ts
+++ b/src/api/routes/internal/company.reportingPeriods.ts
@@ -194,6 +194,7 @@ export async function companyReportingPeriodsRoutes(app: FastifyInstance) {
         reportSourceUrl,
         reportS3Url,
         reportSha256,
+        documentReportYear: bodyDocumentReportYear,
       } = request.body
       const user = request.user
       let company
@@ -209,31 +210,23 @@ export async function companyReportingPeriodsRoutes(app: FastifyInstance) {
       }
 
       let resolvedCompanyReportId: string
+      let documentReportYear: string | undefined
       try {
-        const perPeriodCompanyReportId = reportingPeriods.find(
-          (period) => period.companyReportId
-        )?.companyReportId
-
-        const resolved = await companyReportService.resolveCompanyReportIdForSave(
-          company,
-          reportingPeriods,
-          {
-            companyReportId:
-              bodyCompanyReportId ?? perPeriodCompanyReportId,
-            reportIdentity: {
-              url: reportUrl,
-              sourceUrl: reportSourceUrl,
-              pdfCache:
-                reportS3Url || reportSha256
-                  ? {
-                      publicUrl: reportS3Url,
-                      sha256: reportSha256,
-                    }
-                  : undefined,
-            },
-          }
-        )
-        resolvedCompanyReportId = resolved.companyReportId
+        const prepared =
+          await companyReportService.prepareCompanyReportForPeriodSave(
+            company,
+            reportingPeriods,
+            {
+              bodyCompanyReportId,
+              documentReportYear: bodyDocumentReportYear,
+              reportUrl,
+              reportSourceUrl,
+              reportS3Url,
+              reportSha256,
+            }
+          )
+        resolvedCompanyReportId = prepared.companyReportId
+        documentReportYear = prepared.documentReportYear
       } catch (error) {
         if (error instanceof CompanyReportScopeError) {
           return reply.status(400).send({
@@ -297,14 +290,13 @@ export async function companyReportingPeriodsRoutes(app: FastifyInstance) {
           }) => {
             const year = endDate.getFullYear().toString()
 
-            let companyReportIdForPeriod = resolvedCompanyReportId
-            if (periodCompanyReportId) {
-              await companyReportService.assertCompanyReportBelongsToCompany(
+            const companyReportIdForPeriod =
+              await companyReportService.companyReportIdForPeriodSave(
+                company.wikidataId,
+                resolvedCompanyReportId,
                 periodCompanyReportId,
-                company.wikidataId
+                documentReportYear
               )
-              companyReportIdForPeriod = periodCompanyReportId
-            }
 
             const createdMetadata = await metadataService.createMetadata({
               metadata,

--- a/src/api/routes/internal/company.reportingPeriods.ts
+++ b/src/api/routes/internal/company.reportingPeriods.ts
@@ -5,6 +5,10 @@ import {
 } from 'fastify'
 import { emissionsService } from '../../services/emissionsService'
 import { companyService } from '../../services/companyService'
+import {
+  companyReportService,
+  CompanyReportScopeError,
+} from '../../services/companyReportService'
 import { reportingPeriodService } from '../../services/reportingPeriodService'
 import {
   getErrorSchemas,
@@ -181,7 +185,16 @@ export async function companyReportingPeriodsRoutes(app: FastifyInstance) {
       reply
     ) => {
       const { wikidataId } = request.params
-      const { reportingPeriods, metadata, replaceAllEmissions } = request.body
+      const {
+        reportingPeriods,
+        metadata,
+        replaceAllEmissions,
+        companyReportId: bodyCompanyReportId,
+        reportUrl,
+        reportSourceUrl,
+        reportS3Url,
+        reportSha256,
+      } = request.body
       const user = request.user
       let company
 
@@ -193,6 +206,42 @@ export async function companyReportingPeriodsRoutes(app: FastifyInstance) {
           code: '404',
           message: `There is no company with wikidataId ${wikidataId}`,
         })
+      }
+
+      let resolvedCompanyReportId: string
+      try {
+        const perPeriodCompanyReportId = reportingPeriods.find(
+          (period) => period.companyReportId
+        )?.companyReportId
+
+        const resolved = await companyReportService.resolveCompanyReportIdForSave(
+          company,
+          reportingPeriods,
+          {
+            companyReportId:
+              bodyCompanyReportId ?? perPeriodCompanyReportId,
+            reportIdentity: {
+              url: reportUrl,
+              sourceUrl: reportSourceUrl,
+              pdfCache:
+                reportS3Url || reportSha256
+                  ? {
+                      publicUrl: reportS3Url,
+                      sha256: reportSha256,
+                    }
+                  : undefined,
+            },
+          }
+        )
+        resolvedCompanyReportId = resolved.companyReportId
+      } catch (error) {
+        if (error instanceof CompanyReportScopeError) {
+          return reply.status(400).send({
+            code: '400',
+            message: error.message,
+          })
+        }
+        throw error
       }
 
       // If replaceAllEmissions is set, purge existing emissions for ALL reporting periods for the company before upserting
@@ -241,11 +290,22 @@ export async function companyReportingPeriodsRoutes(app: FastifyInstance) {
             economy = {},
             startDate,
             endDate,
+            companyReportId: periodCompanyReportId,
             reportURL,
             reportS3Url,
             reportSha256,
           }) => {
             const year = endDate.getFullYear().toString()
+
+            let companyReportIdForPeriod = resolvedCompanyReportId
+            if (periodCompanyReportId) {
+              await companyReportService.assertCompanyReportBelongsToCompany(
+                periodCompanyReportId,
+                company.wikidataId
+              )
+              companyReportIdForPeriod = periodCompanyReportId
+            }
+
             const createdMetadata = await metadataService.createMetadata({
               metadata,
               user,
@@ -267,6 +327,7 @@ export async function companyReportingPeriodsRoutes(app: FastifyInstance) {
                   reportS3Url: reportS3Url ?? undefined,
                   reportSha256: reportSha256 ?? undefined,
                   year,
+                  companyReportId: companyReportIdForPeriod,
                 }
               )
 
@@ -384,6 +445,12 @@ export async function companyReportingPeriodsRoutes(app: FastifyInstance) {
             'ERROR Creation or update of reporting periods failed',
             result.reason
           )
+          if (result.reason instanceof CompanyReportScopeError) {
+            return reply.status(400).send({
+              code: '400',
+              message: result.reason.message,
+            })
+          }
           return reply.status(500).send({
             code: 'INTERNAL_SERVER_ERROR',
             message: 'Creation or update of reporting periods failed.',

--- a/src/api/routes/internal/internal.company.read.ts
+++ b/src/api/routes/internal/internal.company.read.ts
@@ -171,9 +171,9 @@ export async function internalCompanyReadRoutes(app: FastifyInstance) {
     '/:wikidataId',
     {
       schema: {
-        summary: 'Get detailed company (first-party client)',
+        summary: 'Get detailed company (one period per data year)',
         description:
-          'Retrieve a company for Bolt and other first-party clients. One reporting period per data year (highest CompanyReport.reportYear wins).',
+          'One reporting period per data year (highest CompanyReport.reportYear wins).',
         tags: getTags('Internal'),
         params: wikidataIdParamSchema,
         response: {

--- a/src/api/routes/internal/internal.company.read.ts
+++ b/src/api/routes/internal/internal.company.read.ts
@@ -26,9 +26,9 @@ export async function internalCompanyReadRoutes(app: FastifyInstance) {
     '/',
     {
       schema: {
-        summary: 'Get all companies',
+        summary: 'Get all companies (latest reporting period per data year)',
         description:
-          'Retrieve a list of all companies with their emissions, economic data, industry classification, goals, and initiatives',
+          'Retrieve companies with their latest reporting period per data year.',
         tags: getTags('Internal'),
 
         response: {
@@ -42,28 +42,35 @@ export async function internalCompanyReadRoutes(app: FastifyInstance) {
 
       let currentEtag: string = await redisCache.get(cacheKey)
 
-      // Check for database changes by looking at record counts across relevant tables
       const [
         companyCount,
         reportingPeriodCount,
+        companyReportCount,
         emissionsCount,
         latestMetadata,
+        latestCompanyReport,
       ] = await prisma.$transaction([
         prisma.company.count(),
         prisma.reportingPeriod.count(),
+        prisma.companyReport.count(),
         prisma.emissions.count(),
         prisma.metadata.findFirst({
           select: { updatedAt: true },
           orderBy: { updatedAt: 'desc' },
         }),
+        prisma.companyReport.findFirst({
+          select: { createdAt: true },
+          orderBy: { createdAt: 'desc' },
+        }),
       ])
 
-      // Create a unique fingerprint based on company data
       const databaseFingerprint = [
         companyCount,
         reportingPeriodCount,
+        companyReportCount,
         emissionsCount,
         latestMetadata?.updatedAt?.toISOString() || '',
+        latestCompanyReport?.createdAt?.toISOString() || '',
       ].join('|')
 
       if (!currentEtag || !currentEtag.startsWith(databaseFingerprint)) {
@@ -76,7 +83,7 @@ export async function internalCompanyReadRoutes(app: FastifyInstance) {
       let companies = await redisCache.get(dataCacheKey)
 
       if (!companies) {
-        companies = await companyService.getAllCompaniesWithMetadata()
+        companies = await companyService.getAllCompaniesForPublicRead()
         await redisCache.set(dataCacheKey, JSON.stringify(companies))
       }
 
@@ -105,7 +112,9 @@ export async function internalCompanyReadRoutes(app: FastifyInstance) {
       reply
     ) => {
       const { q } = request.query
-      const companies = await companyService.getAllCompaniesBySearchTerm(q)
+      const companies = await companyService.getAllCompaniesBySearchTerm(q, {
+        onePeriodPerDataYear: true,
+      })
       reply.send(companies)
     }
   )
@@ -162,9 +171,9 @@ export async function internalCompanyReadRoutes(app: FastifyInstance) {
     '/:wikidataId',
     {
       schema: {
-        summary: 'Get detailed company',
+        summary: 'Get detailed company (first-party client)',
         description:
-          'Retrieve a company with its emissions, economic data, industry classification, goals, and initiatives',
+          'Retrieve a company for Bolt and other first-party clients. One reporting period per data year (highest CompanyReport.reportYear wins).',
         tags: getTags('Internal'),
         params: wikidataIdParamSchema,
         response: {
@@ -175,7 +184,7 @@ export async function internalCompanyReadRoutes(app: FastifyInstance) {
     },
     async (request: FastifyRequest<{ Params: WikidataIdParams }>, reply) => {
       const { wikidataId } = request.params
-      const company = await companyService.getCompanyWithMetadata(wikidataId)
+      const company = await companyService.getCompanyForPublicRead(wikidataId)
       reply.send({
         ...company,
         // Add translations for GICS data

--- a/src/api/schemas/request.ts
+++ b/src/api/schemas/request.ts
@@ -260,6 +260,7 @@ export const reportingPeriodSchema = z
   .object({
     startDate: z.coerce.date(),
     endDate: z.coerce.date(),
+    companyReportId: z.string().optional(),
     reportURL: z.string().optional().nullable(),
     reportS3Url: z.preprocess(
       (val) => (val === '' ? null : val),
@@ -277,6 +278,13 @@ export const postReportingPeriodsSchema = z
   .object({
     reportingPeriods: z.array(reportingPeriodSchema),
     replaceAllEmissions: z.boolean().optional(),
+    /// When set, all periods in the request attach to this document shell (overrides per-period id).
+    companyReportId: z.string().optional(),
+    /// Pipeline/job-level URLs used to resolve CompanyReport when companyReportId is omitted.
+    reportUrl: z.string().optional(),
+    reportSourceUrl: z.string().optional(),
+    reportS3Url: z.string().optional(),
+    reportSha256: z.string().optional(),
   })
   .merge(createMetadataSchema)
 

--- a/src/api/schemas/request.ts
+++ b/src/api/schemas/request.ts
@@ -278,13 +278,15 @@ export const postReportingPeriodsSchema = z
   .object({
     reportingPeriods: z.array(reportingPeriodSchema),
     replaceAllEmissions: z.boolean().optional(),
-    /// When set, all periods in the request attach to this document shell (overrides per-period id).
+    /// Default CompanyReport for all periods (overrides per-period companyReportId).
     companyReportId: z.string().optional(),
-    /// Pipeline/job-level URLs used to resolve CompanyReport when companyReportId is omitted.
+    /// Report URLs at job level; used to find or create CompanyReport when companyReportId is omitted.
     reportUrl: z.string().optional(),
     reportSourceUrl: z.string().optional(),
     reportS3Url: z.string().optional(),
     reportSha256: z.string().optional(),
+    /// PDF year label (e.g. 2025 annual report), stored on Report and CompanyReport.
+    documentReportYear: z.string().optional(),
   })
   .merge(createMetadataSchema)
 

--- a/src/api/schemas/response.ts
+++ b/src/api/schemas/response.ts
@@ -281,6 +281,10 @@ export const ReportingPeriodSchema = z.object({
     .nullable()
     .optional()
     .openapi({ description: 'SHA-256 hash for cached/uploaded report PDF' }),
+  companyReportId: z
+    .string()
+    .optional()
+    .openapi({ description: 'CompanyReport (processed PDF) this period belongs to' }),
   emissions: EmissionsSchema.nullable(),
   economy: EconomySchema.nullable(),
   emissionsChangeLastTwoYears: z

--- a/src/api/schemas/response.ts
+++ b/src/api/schemas/response.ts
@@ -281,12 +281,9 @@ export const ReportingPeriodSchema = z.object({
     .nullable()
     .optional()
     .openapi({ description: 'SHA-256 hash for cached/uploaded report PDF' }),
-  companyReportId: z
-    .string()
-    .optional()
-    .openapi({
-      description: 'CompanyReport (processed PDF) this period belongs to',
-    }),
+  companyReportId: z.string().optional().openapi({
+    description: 'CompanyReport (processed PDF) this period belongs to',
+  }),
   emissions: EmissionsSchema.nullable(),
   economy: EconomySchema.nullable(),
   emissionsChangeLastTwoYears: z

--- a/src/api/schemas/response.ts
+++ b/src/api/schemas/response.ts
@@ -284,7 +284,9 @@ export const ReportingPeriodSchema = z.object({
   companyReportId: z
     .string()
     .optional()
-    .openapi({ description: 'CompanyReport (processed PDF) this period belongs to' }),
+    .openapi({
+      description: 'CompanyReport (processed PDF) this period belongs to',
+    }),
   emissions: EmissionsSchema.nullable(),
   economy: EconomySchema.nullable(),
   emissionsChangeLastTwoYears: z

--- a/src/api/services/companyReportService.ts
+++ b/src/api/services/companyReportService.ts
@@ -1,14 +1,27 @@
 import { Company } from '@prisma/client'
 
 import { prisma } from '../../lib/prisma'
-import { buildRegistryPayload } from '../../workers/saveToAPI.utils'
+import {
+  buildRegistryPayload,
+  resolveDocumentReportYear,
+} from '../../workers/saveToAPI.utils'
 import { registryService } from './registryService'
 
-export type ReportingPeriodReportIdentity = {
+export type ReportingPeriodIdentity = {
   year?: number | string
+  companyReportId?: string
   reportURL?: string | null
   reportS3Url?: string | null
   reportSha256?: string | null
+}
+
+export type PrepareCompanyReportForPeriodSaveInput = {
+  bodyCompanyReportId?: string
+  documentReportYear?: string
+  reportUrl?: string
+  reportSourceUrl?: string
+  reportS3Url?: string
+  reportSha256?: string
 }
 
 export type SaveReportIdentity = {
@@ -59,7 +72,28 @@ class CompanyReportService {
     }
   }
 
-  async defaultCompanyReportIdForCompany(companyId: string): Promise<string> {
+  async setCompanyReportYear(
+    companyReportId: string,
+    documentReportYear: string | undefined
+  ): Promise<void> {
+    const year = documentReportYear?.trim()
+    if (!year || !/^\d{4}$/.test(year)) return
+
+    const companyReport = await prisma.companyReport.update({
+      where: { id: companyReportId },
+      data: { reportYear: year },
+      select: { registryReportId: true },
+    })
+
+    if (companyReport.registryReportId) {
+      await prisma.report.update({
+        where: { id: companyReport.registryReportId },
+        data: { reportYear: year },
+      })
+    }
+  }
+
+  async getOrCreateFallbackCompanyReportId(companyId: string): Promise<string> {
     const existing = await prisma.companyReport.findFirst({
       where: { companyId },
       orderBy: { createdAt: 'desc' },
@@ -73,7 +107,7 @@ class CompanyReportService {
 
   async resolveCompanyReportIdForSave(
     company: Pick<Company, 'wikidataId' | 'name'>,
-    reportingPeriods: ReportingPeriodReportIdentity[],
+    reportingPeriods: ReportingPeriodIdentity[],
     options?: {
       companyReportId?: string
       reportIdentity?: SaveReportIdentity
@@ -118,14 +152,79 @@ class CompanyReportService {
       return { companyReportId, inferred: true }
     }
 
-    const companyReportId = await this.defaultCompanyReportIdForCompany(
+    const companyReportId = await this.getOrCreateFallbackCompanyReportId(
       company.wikidataId
     )
     console.warn(
-      '[companyReportService] Inferred companyReportId from company default shell',
+      '[companyReportService] Inferred companyReportId from latest CompanyReport for company',
       { companyId: company.wikidataId, companyReportId }
     )
     return { companyReportId, inferred: true }
+  }
+
+  async prepareCompanyReportForPeriodSave(
+    company: Pick<Company, 'wikidataId' | 'name'>,
+    reportingPeriods: ReportingPeriodIdentity[],
+    input: PrepareCompanyReportForPeriodSaveInput
+  ): Promise<{ companyReportId: string; documentReportYear: string | undefined }> {
+    const perPeriodCompanyReportId = reportingPeriods.find(
+      (period) => period.companyReportId
+    )?.companyReportId
+
+    const { companyReportId } = await this.resolveCompanyReportIdForSave(
+      company,
+      reportingPeriods,
+      {
+        companyReportId:
+          input.bodyCompanyReportId ?? perPeriodCompanyReportId,
+        reportIdentity: {
+          url: input.reportUrl,
+          sourceUrl: input.reportSourceUrl,
+          pdfCache:
+            input.reportS3Url || input.reportSha256
+              ? {
+                  publicUrl: input.reportS3Url,
+                  sha256: input.reportSha256,
+                }
+              : undefined,
+        },
+      }
+    )
+
+    const documentReportYear = resolveDocumentReportYear(reportingPeriods, {
+      documentReportYear: input.documentReportYear,
+      reportUrl: input.reportUrl,
+      sourceUrl: input.reportSourceUrl,
+    })
+
+    await this.setCompanyReportYear(companyReportId, documentReportYear)
+
+    return { companyReportId, documentReportYear }
+  }
+
+  async companyReportIdForPeriodSave(
+    companyId: string,
+    defaultCompanyReportId: string,
+    periodCompanyReportId: string | undefined,
+    documentReportYear: string | undefined
+  ): Promise<string> {
+    if (!periodCompanyReportId) {
+      return defaultCompanyReportId
+    }
+
+    await this.assertCompanyReportBelongsToCompany(
+      periodCompanyReportId,
+      companyId
+    )
+
+    if (periodCompanyReportId !== defaultCompanyReportId) {
+      await this.setCompanyReportYear(
+        periodCompanyReportId,
+        documentReportYear
+      )
+    }
+
+    return periodCompanyReportId
   }
 }
 

--- a/src/api/services/companyReportService.ts
+++ b/src/api/services/companyReportService.ts
@@ -36,21 +36,35 @@ class CompanyReportService {
     companyId: string,
     registryReportId: string | null
   ): Promise<string> {
+    if (registryReportId !== null) {
+      const row = await prisma.companyReport.upsert({
+        where: {
+          companyId_registryReportId: {
+            companyId,
+            registryReportId,
+          },
+        },
+        create: {
+          companyId,
+          registryReportId,
+        },
+        update: {},
+        select: { id: true },
+      })
+
+      return row.id
+    }
+
     const existing = await prisma.companyReport.findFirst({
-      where: {
-        companyId,
-        registryReportId: registryReportId ?? null,
-      },
+      where: { companyId, registryReportId: null },
+      orderBy: { createdAt: 'desc' },
       select: { id: true },
     })
 
     if (existing) return existing.id
 
     const created = await prisma.companyReport.create({
-      data: {
-        companyId,
-        registryReportId: registryReportId ?? null,
-      },
+      data: { companyId, registryReportId: null },
       select: { id: true },
     })
 
@@ -118,7 +132,7 @@ class CompanyReportService {
   async getOrCreateFallbackCompanyReportId(companyId: string): Promise<string> {
     const existing = await prisma.companyReport.findFirst({
       where: { companyId },
-      orderBy: { reportingPeriods: { _count: 'desc' } },
+      orderBy: [{ reportYear: 'desc' }, { createdAt: 'desc' }],
       select: { id: true },
     })
 

--- a/src/api/services/companyReportService.ts
+++ b/src/api/services/companyReportService.ts
@@ -134,9 +134,8 @@ class CompanyReportService {
     })
 
     if (registryPayload) {
-      const report = await registryService.upsertReportInRegistry(
-        registryPayload
-      )
+      const report =
+        await registryService.upsertReportInRegistry(registryPayload)
       const companyReportId = await this.findOrCreateCompanyReport(
         company.wikidataId,
         report.id
@@ -166,7 +165,10 @@ class CompanyReportService {
     company: Pick<Company, 'wikidataId' | 'name'>,
     reportingPeriods: ReportingPeriodIdentity[],
     input: PrepareCompanyReportForPeriodSaveInput
-  ): Promise<{ companyReportId: string; documentReportYear: string | undefined }> {
+  ): Promise<{
+    companyReportId: string
+    documentReportYear: string | undefined
+  }> {
     const perPeriodCompanyReportId = reportingPeriods.find(
       (period) => period.companyReportId
     )?.companyReportId
@@ -175,8 +177,7 @@ class CompanyReportService {
       company,
       reportingPeriods,
       {
-        companyReportId:
-          input.bodyCompanyReportId ?? perPeriodCompanyReportId,
+        companyReportId: input.bodyCompanyReportId ?? perPeriodCompanyReportId,
         reportIdentity: {
           url: input.reportUrl,
           sourceUrl: input.reportSourceUrl,
@@ -218,10 +219,7 @@ class CompanyReportService {
     )
 
     if (periodCompanyReportId !== defaultCompanyReportId) {
-      await this.setCompanyReportYear(
-        periodCompanyReportId,
-        documentReportYear
-      )
+      await this.setCompanyReportYear(periodCompanyReportId, documentReportYear)
     }
 
     return periodCompanyReportId

--- a/src/api/services/companyReportService.ts
+++ b/src/api/services/companyReportService.ts
@@ -1,0 +1,141 @@
+import { Company } from '@prisma/client'
+
+import { prisma } from '../../lib/prisma'
+import { buildRegistryPayload } from '../../workers/saveToAPI.utils'
+import { registryService } from './registryService'
+
+export type ReportingPeriodReportIdentity = {
+  year?: number | string
+  reportURL?: string | null
+  reportS3Url?: string | null
+  reportSha256?: string | null
+}
+
+export type SaveReportIdentity = {
+  url?: string
+  sourceUrl?: string
+  pdfCache?: { publicUrl?: string; sha256?: string }
+}
+
+class CompanyReportService {
+  async findOrCreateCompanyReport(
+    companyId: string,
+    registryReportId: string | null
+  ): Promise<string> {
+    const existing = await prisma.companyReport.findFirst({
+      where: {
+        companyId,
+        registryReportId: registryReportId ?? null,
+      },
+      select: { id: true },
+    })
+
+    if (existing) return existing.id
+
+    const created = await prisma.companyReport.create({
+      data: {
+        companyId,
+        registryReportId: registryReportId ?? null,
+      },
+      select: { id: true },
+    })
+
+    return created.id
+  }
+
+  async assertCompanyReportBelongsToCompany(
+    companyReportId: string,
+    companyId: string
+  ): Promise<void> {
+    const row = await prisma.companyReport.findFirst({
+      where: { id: companyReportId, companyId },
+      select: { id: true },
+    })
+
+    if (!row) {
+      throw new CompanyReportScopeError(
+        `companyReportId ${companyReportId} does not belong to company ${companyId}`
+      )
+    }
+  }
+
+  async defaultCompanyReportIdForCompany(companyId: string): Promise<string> {
+    const existing = await prisma.companyReport.findFirst({
+      where: { companyId },
+      orderBy: { createdAt: 'desc' },
+      select: { id: true },
+    })
+
+    if (existing) return existing.id
+
+    return this.findOrCreateCompanyReport(companyId, null)
+  }
+
+  async resolveCompanyReportIdForSave(
+    company: Pick<Company, 'wikidataId' | 'name'>,
+    reportingPeriods: ReportingPeriodReportIdentity[],
+    options?: {
+      companyReportId?: string
+      reportIdentity?: SaveReportIdentity
+    }
+  ): Promise<{ companyReportId: string; inferred: boolean }> {
+    const explicitId = options?.companyReportId?.trim()
+    if (explicitId) {
+      await this.assertCompanyReportBelongsToCompany(
+        explicitId,
+        company.wikidataId
+      )
+      return { companyReportId: explicitId, inferred: false }
+    }
+
+    const registryPayload = buildRegistryPayload({
+      data: {
+        companyName: company.name,
+        wikidata: { node: company.wikidataId },
+        url: options?.reportIdentity?.url?.trim() ?? '',
+        sourceUrl: options?.reportIdentity?.sourceUrl,
+        pdfCache: options?.reportIdentity?.pdfCache,
+        body: { reportingPeriods },
+      },
+    })
+
+    if (registryPayload) {
+      const report = await registryService.upsertReportInRegistry(
+        registryPayload
+      )
+      const companyReportId = await this.findOrCreateCompanyReport(
+        company.wikidataId,
+        report.id
+      )
+      console.warn(
+        '[companyReportService] Inferred companyReportId from report identity',
+        {
+          companyId: company.wikidataId,
+          companyReportId,
+          registryReportId: report.id,
+        }
+      )
+      return { companyReportId, inferred: true }
+    }
+
+    const companyReportId = await this.defaultCompanyReportIdForCompany(
+      company.wikidataId
+    )
+    console.warn(
+      '[companyReportService] Inferred companyReportId from company default shell',
+      { companyId: company.wikidataId, companyReportId }
+    )
+    return { companyReportId, inferred: true }
+  }
+}
+
+export class CompanyReportScopeError extends Error {
+  readonly statusCode = 400
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'CompanyReportScopeError'
+  }
+}
+
+export const companyReportService = new CompanyReportService()

--- a/src/api/services/companyReportService.ts
+++ b/src/api/services/companyReportService.ts
@@ -5,6 +5,7 @@ import {
   buildRegistryPayload,
   resolveDocumentReportYear,
 } from '../../workers/saveToAPI.utils'
+import { mergeReportYearFromPipeline } from './registryReportIdentity'
 import { registryService } from './registryService'
 
 export type ReportingPeriodIdentity = {
@@ -76,27 +77,48 @@ class CompanyReportService {
     companyReportId: string,
     documentReportYear: string | undefined
   ): Promise<void> {
-    const year = documentReportYear?.trim()
-    if (!year || !/^\d{4}$/.test(year)) return
+    const incoming = documentReportYear?.trim()
+    if (!incoming || !/^\d{4}$/.test(incoming)) return
 
-    const companyReport = await prisma.companyReport.update({
+    const existing = await prisma.companyReport.findUnique({
       where: { id: companyReportId },
-      data: { reportYear: year },
-      select: { registryReportId: true },
+      select: { reportYear: true, registryReportId: true },
+    })
+    if (!existing) return
+
+    const mergedYear = mergeReportYearFromPipeline(
+      existing.reportYear,
+      incoming
+    )
+    if (!mergedYear) return
+
+    await prisma.companyReport.update({
+      where: { id: companyReportId },
+      data: { reportYear: mergedYear },
     })
 
-    if (companyReport.registryReportId) {
-      await prisma.report.update({
-        where: { id: companyReport.registryReportId },
-        data: { reportYear: year },
+    if (existing.registryReportId) {
+      const registryRow = await prisma.report.findUnique({
+        where: { id: existing.registryReportId },
+        select: { reportYear: true },
       })
+      const registryYear = mergeReportYearFromPipeline(
+        registryRow?.reportYear,
+        mergedYear
+      )
+      if (registryYear) {
+        await prisma.report.update({
+          where: { id: existing.registryReportId },
+          data: { reportYear: registryYear },
+        })
+      }
     }
   }
 
   async getOrCreateFallbackCompanyReportId(companyId: string): Promise<string> {
     const existing = await prisma.companyReport.findFirst({
       where: { companyId },
-      orderBy: { createdAt: 'desc' },
+      orderBy: { reportingPeriods: { _count: 'desc' } },
       select: { id: true },
     })
 
@@ -169,15 +191,11 @@ class CompanyReportService {
     companyReportId: string
     documentReportYear: string | undefined
   }> {
-    const perPeriodCompanyReportId = reportingPeriods.find(
-      (period) => period.companyReportId
-    )?.companyReportId
-
     const { companyReportId } = await this.resolveCompanyReportIdForSave(
       company,
       reportingPeriods,
       {
-        companyReportId: input.bodyCompanyReportId ?? perPeriodCompanyReportId,
+        companyReportId: input.bodyCompanyReportId,
         reportIdentity: {
           url: input.reportUrl,
           sourceUrl: input.reportSourceUrl,

--- a/src/api/services/companyService.ts
+++ b/src/api/services/companyService.ts
@@ -24,6 +24,7 @@ import sharp from 'sharp'
 import { ReportsListResponseSchema } from '../schemas/response'
 import { z } from 'zod'
 import { registryService } from './registryService'
+import { pickOnePeriodPerDataYear } from './reportingPeriodPublicRead'
 import type { ReportingPeriod } from '@/types'
 
 const API_KEY = process.env.FIRECRAWL_API_KEY
@@ -32,10 +33,22 @@ const API_KEY = process.env.FIRECRAWL_API_KEY
 type ReportsListResponse = z.infer<typeof ReportsListResponseSchema>
 
 class CompanyService {
-  async getAllCompaniesWithMetadata() {
-    const companies = await prisma.company.findMany(companyListArgs)
+  private enrichCompaniesWithMetadata(
+    companies: Array<{ reportingPeriods: unknown[] } & Record<string, unknown>>,
+    onePeriodPerDataYear: boolean
+  ) {
+    const withPeriods = onePeriodPerDataYear
+      ? companies.map((company) => ({
+          ...company,
+          reportingPeriods: pickOnePeriodPerDataYear(
+            company.reportingPeriods as Parameters<
+              typeof pickOnePeriodPerDataYear
+            >[0]
+          ),
+        }))
+      : companies
 
-    const transformedCompanies = companies.map(transformMetadata)
+    const transformedCompanies = withPeriods.map(transformMetadata)
 
     const companiesWithCalculatedTotalEmissions =
       addCalculatedTotalEmissions(transformedCompanies)
@@ -44,14 +57,25 @@ class CompanyService {
       companiesWithCalculatedTotalEmissions
     )
 
-    const companiesWithFutureEmissionsTrendSlope = addFutureEmissionsTrendSlope(
-      companiesWithEmissionsChange
-    )
-
-    return companiesWithFutureEmissionsTrendSlope
+    return addFutureEmissionsTrendSlope(companiesWithEmissionsChange)
   }
 
-  async getAllCompaniesBySearchTerm(searchTerm: string) {
+  /** All reporting period rows (internal / editor). */
+  async getAllCompaniesWithMetadata() {
+    const companies = await prisma.company.findMany(companyListArgs)
+    return this.enrichCompaniesWithMetadata(companies, false)
+  }
+
+  /** Public API: one period per data year (highest CompanyReport.reportYear wins). */
+  async getAllCompaniesForPublicRead() {
+    const companies = await prisma.company.findMany(companyListArgs)
+    return this.enrichCompaniesWithMetadata(companies, true)
+  }
+
+  async getAllCompaniesBySearchTerm(
+    searchTerm: string,
+    options?: { onePeriodPerDataYear?: boolean }
+  ) {
     const normalizedSearchTerm = searchTerm.trim().toLocaleLowerCase('sv-SE')
     const likePattern = normalizedSearchTerm + '%'
 
@@ -81,19 +105,12 @@ class CompanyService {
 
     const sorted = orderedIds
       .map((wikidataId) => companies.find((c) => c.wikidataId === wikidataId))
-      .filter(Boolean)
+      .filter((c) => c !== undefined)
 
-    const transformedCompanies = sorted.map(transformMetadata)
-    const companiesWithCalculatedTotalEmissions =
-      addCalculatedTotalEmissions(transformedCompanies)
-    const companiesWithEmissionsChange = addCompanyEmissionChange(
-      companiesWithCalculatedTotalEmissions
+    return this.enrichCompaniesWithMetadata(
+      sorted,
+      options?.onePeriodPerDataYear ?? false
     )
-    const companiesWithFutureEmissionsTrendSlope = addFutureEmissionsTrendSlope(
-      companiesWithEmissionsChange
-    )
-
-    return companiesWithFutureEmissionsTrendSlope
   }
 
   async getCompanyWithMetadata(wikidataId: string) {
@@ -103,12 +120,18 @@ class CompanyService {
         wikidataId,
       },
     })
-    const [transformedCompany] = addFutureEmissionsTrendSlope(
-      addCompanyEmissionChange(
-        addCalculatedTotalEmissions([transformMetadata(company)])
-      )
-    )
+    const [transformedCompany] = this.enrichCompaniesWithMetadata([company], false)
+    return transformedCompany
+  }
 
+  async getCompanyForPublicRead(wikidataId: string) {
+    const company = await prisma.company.findFirstOrThrow({
+      ...detailedCompanyArgs,
+      where: {
+        wikidataId,
+      },
+    })
+    const [transformedCompany] = this.enrichCompaniesWithMetadata([company], true)
     return transformedCompany
   }
 

--- a/src/api/services/companyService.ts
+++ b/src/api/services/companyService.ts
@@ -120,7 +120,10 @@ class CompanyService {
         wikidataId,
       },
     })
-    const [transformedCompany] = this.enrichCompaniesWithMetadata([company], false)
+    const [transformedCompany] = this.enrichCompaniesWithMetadata(
+      [company],
+      false
+    )
     return transformedCompany
   }
 
@@ -131,7 +134,10 @@ class CompanyService {
         wikidataId,
       },
     })
-    const [transformedCompany] = this.enrichCompaniesWithMetadata([company], true)
+    const [transformedCompany] = this.enrichCompaniesWithMetadata(
+      [company],
+      true
+    )
     return transformedCompany
   }
 

--- a/src/api/services/registryReportIdentity.ts
+++ b/src/api/services/registryReportIdentity.ts
@@ -38,6 +38,18 @@ export function isValidReportCatalogYear(year: string): boolean {
   return n >= REPORT_CATALOG_YEAR_MIN && n <= REPORT_CATALOG_YEAR_MAX
 }
 
+/** Registry upsert: use incoming reportYear when it is a valid year. */
+export function mergeReportYearFromPipeline(
+  existing: string | null | undefined,
+  incoming: string | null | undefined
+): string | undefined {
+  const inc = trimStr(incoming ?? null)
+  if (!inc || !isValidReportCatalogYear(inc)) {
+    return trimStr(existing ?? null) ?? undefined
+  }
+  return inc
+}
+
 /** Last path segment of a report URL, lowercased (e.g. `annual-report-2024.pdf`). */
 export function pdfBasenameFromUrl(
   raw: string | null | undefined

--- a/src/api/services/registryService.ts
+++ b/src/api/services/registryService.ts
@@ -9,6 +9,7 @@ import {
   buildReportMatchConditions,
   copyMissingFields,
   pickRowToKeep,
+  mergeReportYearFromPipeline,
   type RegistryReportIdentityRow,
   trimStr,
   isStorageUrl,
@@ -53,7 +54,10 @@ function patchRow(
   const update: Prisma.ReportUpdateInput = {
     companyName: existing.companyName ?? input.companyName,
     wikidataId: existing.wikidataId ?? input.wikidataId ?? undefined,
-    reportYear: existing.reportYear ?? input.reportYear ?? undefined,
+    reportYear: mergeReportYearFromPipeline(
+      existing.reportYear,
+      input.reportYear
+    ),
   }
 
   // Only assign when explicitly provided — omitting keeps Prisma from clearing the field.
@@ -79,7 +83,10 @@ function applyMergedRows(
   return {
     companyName: merged.companyName ?? input.companyName,
     wikidataId: merged.wikidataId ?? input.wikidataId ?? undefined,
-    reportYear: merged.reportYear ?? input.reportYear ?? undefined,
+    reportYear: mergeReportYearFromPipeline(
+      merged.reportYear,
+      input.reportYear
+    ),
     url: webUrl ?? baseUrl,
     sourceUrl:
       input.sourceUrl !== undefined ? input.sourceUrl : merged.sourceUrl,

--- a/src/api/services/reportingPeriodPublicRead.ts
+++ b/src/api/services/reportingPeriodPublicRead.ts
@@ -7,7 +7,9 @@ export type PeriodWithCompanyReport = {
   } | null
 }
 
-function parseCompanyReportYear(reportYear: string | null | undefined): number | null {
+function parseCompanyReportYear(
+  reportYear: string | null | undefined
+): number | null {
   const trimmed = reportYear?.trim()
   if (!trimmed || !/^\d{4}$/.test(trimmed)) return null
   return Number(trimmed)

--- a/src/api/services/reportingPeriodPublicRead.ts
+++ b/src/api/services/reportingPeriodPublicRead.ts
@@ -1,0 +1,57 @@
+export type PeriodWithCompanyReport = {
+  year: string
+  companyReport?: {
+    id: string
+    reportYear: string | null
+    reportPublicationDate: Date | null
+  } | null
+}
+
+function parseCompanyReportYear(reportYear: string | null | undefined): number | null {
+  const trimmed = reportYear?.trim()
+  if (!trimmed || !/^\d{4}$/.test(trimmed)) return null
+  return Number(trimmed)
+}
+
+/** Negative = prefer `a` over `b` (higher CompanyReport.reportYear wins). */
+function preferPeriodFromNewerReport(
+  a: PeriodWithCompanyReport,
+  b: PeriodWithCompanyReport
+): number {
+  const yearA = parseCompanyReportYear(a.companyReport?.reportYear)
+  const yearB = parseCompanyReportYear(b.companyReport?.reportYear)
+
+  if (yearA !== yearB) {
+    if (yearA === null) return 1
+    if (yearB === null) return -1
+    return yearB - yearA
+  }
+
+  const pubA = a.companyReport?.reportPublicationDate?.getTime() ?? 0
+  const pubB = b.companyReport?.reportPublicationDate?.getTime() ?? 0
+  if (pubA !== pubB) return pubB - pubA
+
+  const idA = a.companyReport?.id ?? ''
+  const idB = b.companyReport?.id ?? ''
+  return idB.localeCompare(idA)
+}
+
+export function pickOnePeriodPerDataYear<T extends PeriodWithCompanyReport>(
+  periods: T[]
+): Omit<T, 'companyReport'>[] {
+  const byDataYear = new Map<string, T>()
+
+  for (const period of periods) {
+    const dataYear = period.year?.trim()
+    if (!dataYear) continue
+
+    const existing = byDataYear.get(dataYear)
+    if (!existing || preferPeriodFromNewerReport(period, existing) < 0) {
+      byDataYear.set(dataYear, period)
+    }
+  }
+
+  return Array.from(byDataYear.values()).map(
+    ({ companyReport: _companyReport, ...period }) => period
+  )
+}

--- a/src/api/services/reportingPeriodService.ts
+++ b/src/api/services/reportingPeriodService.ts
@@ -67,6 +67,7 @@ class ReportingPeriodService {
     })
   }
 
+  // ToDo: after delete, remove CompanyReport when no periods remain; add bulk delete-by-companyReportId.
   async deleteReportingPeriod(id: string) {
     return await prisma.reportingPeriod.delete({ where: { id } })
   }

--- a/src/api/services/reportingPeriodService.ts
+++ b/src/api/services/reportingPeriodService.ts
@@ -1,4 +1,5 @@
-import { Company, ReportingPeriod } from '@prisma/client'
+import { Company } from '@prisma/client'
+
 import { prisma } from '../../lib/prisma'
 import { reportingPeriodArgs } from '../args'
 
@@ -13,6 +14,7 @@ class ReportingPeriodService {
       reportS3Url,
       reportSha256,
       year,
+      companyReportId,
     }: {
       startDate: Date
       endDate: Date
@@ -20,12 +22,13 @@ class ReportingPeriodService {
       reportS3Url?: string | null
       reportSha256?: string | null
       year: string
+      companyReportId: string
     }
   ) {
     return prisma.reportingPeriod.upsert({
       where: {
-        companyId_year: {
-          companyId: company.wikidataId,
+        companyReportId_year: {
+          companyReportId,
           year,
         },
       },
@@ -48,9 +51,16 @@ class ReportingPeriodService {
         reportS3Url,
         reportSha256,
         year,
+        companyId: company.wikidataId,
+        companyReportId,
         company: {
           connect: {
             wikidataId: company.wikidataId,
+          },
+        },
+        companyReport: {
+          connect: {
+            id: companyReportId,
           },
         },
         metadata: {
@@ -63,7 +73,7 @@ class ReportingPeriodService {
     })
   }
 
-  async deleteReportingPeriod(id: ReportingPeriod['id']) {
+  async deleteReportingPeriod(id: string) {
     return await prisma.reportingPeriod.delete({ where: { id } })
   }
 }

--- a/src/api/services/reportingPeriodService.ts
+++ b/src/api/services/reportingPeriodService.ts
@@ -1,7 +1,11 @@
-import { Company } from '@prisma/client'
+import { Company, Prisma } from '@prisma/client'
 
 import { prisma } from '../../lib/prisma'
 import { reportingPeriodArgs } from '../args'
+
+type UpsertedReportingPeriod = Prisma.ReportingPeriodGetPayload<
+  typeof reportingPeriodArgs
+>
 
 class ReportingPeriodService {
   async upsertReportingPeriod(
@@ -24,7 +28,7 @@ class ReportingPeriodService {
       year: string
       companyReportId: string
     }
-  ) {
+  ): Promise<UpsertedReportingPeriod> {
     return prisma.reportingPeriod.upsert({
       where: {
         companyReportId_year: {
@@ -53,16 +57,6 @@ class ReportingPeriodService {
         year,
         companyId: company.wikidataId,
         companyReportId,
-        company: {
-          connect: {
-            wikidataId: company.wikidataId,
-          },
-        },
-        companyReport: {
-          connect: {
-            id: companyReportId,
-          },
-        },
         metadata: {
           connect: {
             id: metadata.id,

--- a/src/app.ts
+++ b/src/app.ts
@@ -20,6 +20,7 @@ import authPlugin from './api/plugins/auth'
 import { companyIndustryRoutes } from './api/routes/internal/company.industry'
 import { companyInitiativesRoutes } from './api/routes/internal/company.initiatives'
 import { companyReportingPeriodsRoutes } from './api/routes/internal/company.reportingPeriods'
+import { pipelineCompanyReadRoutes } from './api/routes/internal/company.pipelineRead'
 import { companyUpdateRoutes } from './api/routes/internal/company.update'
 import { companyDeleteRoutes } from './api/routes/internal/company.delete'
 import { errorHandler } from './api/plugins/errorhandler'
@@ -130,6 +131,9 @@ async function authenticatedContext(app: FastifyInstance) {
   app.register(companyUpdateRoutes, { prefix: 'api/companies' })
   app.register(companyIndustryRoutes, { prefix: 'api/companies' })
   app.register(companyReportingPeriodsRoutes, { prefix: 'api/companies' })
+  app.register(pipelineCompanyReadRoutes, {
+    prefix: 'api/pipeline/companies',
+  })
   app.register(companyGoalsRoutes, { prefix: 'api/companies' })
   app.register(companyBaseYearRoutes, { prefix: 'api/companies' })
   app.register(companyInitiativesRoutes, { prefix: 'api/companies' })

--- a/src/workers/checkDB.ts
+++ b/src/workers/checkDB.ts
@@ -84,9 +84,9 @@ const checkDB = new DiscordWorker(
 
     job.sendMessage(`🤖 Checking if ${companyName} already exists in API...`)
     const wikidataId = wikidata.node
-    const existingCompany = await apiFetch(`/companies/${wikidataId}`).catch(
-      () => null
-    )
+    const existingCompany = await apiFetch(
+      `/pipeline/companies/${wikidataId}`
+    ).catch(() => null)
     job.log(existingCompany)
 
     if (!existingCompany) {

--- a/src/workers/diffReportingPeriods.ts
+++ b/src/workers/diffReportingPeriods.ts
@@ -57,9 +57,22 @@ const diffReportingPeriods = new DiffWorker<DiffReportingPeriodsJob>(
         : undefined)
 
     if (job.isDataApproved()) {
+      const approvedBody = job.getApprovedBody() ?? {}
+      const periods = approvedBody.reportingPeriods ?? []
+      const years = periods
+        .map((p: { year?: number | string }) => Number(p?.year))
+        .filter((y: number) => Number.isFinite(y))
+      const documentReportYear =
+        years.length > 0 ? String(Math.max(...years)) : undefined
+
       await job.enqueueSaveToAPI('reporting-periods', companyName, wikidata, {
-        ...job.getApprovedBody(),
+        ...approvedBody,
         ...(job.data.replaceAllEmissions && { replaceAllEmissions: true }),
+        documentReportYear,
+        reportUrl: reportURLForPeriod,
+        reportSourceUrl: trimmedSourceUrl,
+        reportS3Url: reportS3UrlForPeriod,
+        reportSha256: pdfCache?.sha256,
       })
       return
     }

--- a/src/workers/diffReportingPeriods.ts
+++ b/src/workers/diffReportingPeriods.ts
@@ -1,5 +1,6 @@
 import { canonicalPublicReportUrl, diffChanges } from '../lib/saveUtils'
 import { getReportingPeriodDates } from '../lib/reportingPeriodDates'
+import { resolveDocumentReportYear } from './saveToAPI.utils'
 import { QUEUE_NAMES } from '../queues'
 import { ChangeDescription, DiffWorker, DiffJob } from '../lib/DiffWorker'
 import apiConfig from '../config/api'
@@ -22,6 +23,8 @@ export class DiffReportingPeriodsJob extends DiffJob {
     biogenic?: any[]
     economy?: any[]
     replaceAllEmissions?: boolean
+    /** PDF year from pipeline parse when set on the job. */
+    documentReportYear?: string | number
   }
 }
 
@@ -59,11 +62,12 @@ const diffReportingPeriods = new DiffWorker<DiffReportingPeriodsJob>(
     if (job.isDataApproved()) {
       const approvedBody = job.getApprovedBody() ?? {}
       const periods = approvedBody.reportingPeriods ?? []
-      const years = periods
-        .map((p: { year?: number | string }) => Number(p?.year))
-        .filter((y: number) => Number.isFinite(y))
-      const documentReportYear =
-        years.length > 0 ? String(Math.max(...years)) : undefined
+      const documentReportYear = resolveDocumentReportYear(periods, {
+        documentReportYear:
+          approvedBody.documentReportYear ?? job.data.documentReportYear,
+        reportUrl: reportURLForPeriod,
+        sourceUrl: trimmedSourceUrl,
+      })
 
       await job.enqueueSaveToAPI('reporting-periods', companyName, wikidata, {
         ...approvedBody,

--- a/src/workers/saveToAPI.ts
+++ b/src/workers/saveToAPI.ts
@@ -124,8 +124,7 @@ export const saveToAPI = new DiscordWorker<SaveToApiJob>(
           data: {
             ...job.data,
             documentReportYear:
-              job.data.documentReportYear ??
-              sanitizedBody?.documentReportYear,
+              job.data.documentReportYear ?? sanitizedBody?.documentReportYear,
             body: sanitizedBody,
           },
         })

--- a/src/workers/saveToAPI.ts
+++ b/src/workers/saveToAPI.ts
@@ -21,6 +21,7 @@ export interface SaveToApiJob extends DiscordJob {
       publicUrl?: string
       sha256?: string
     }
+    documentReportYear?: string | number
   }
 }
 
@@ -119,7 +120,15 @@ export const saveToAPI = new DiscordWorker<SaveToApiJob>(
       }
 
       if (apiSubEndpoint === 'reporting-periods') {
-        const registryPayload = buildRegistryPayload(job)
+        const registryPayload = buildRegistryPayload({
+          data: {
+            ...job.data,
+            documentReportYear:
+              job.data.documentReportYear ??
+              sanitizedBody?.documentReportYear,
+            body: sanitizedBody,
+          },
+        })
         if (registryPayload) {
           try {
             await registryService.upsertReportInRegistry(registryPayload)

--- a/src/workers/saveToAPI.utils.ts
+++ b/src/workers/saveToAPI.utils.ts
@@ -1,5 +1,10 @@
 import { canonicalPublicReportUrl } from '../lib/canonicalPublicReportUrl'
-import { isStorageUrl, trimStr } from '../api/services/registryReportIdentity'
+import {
+  isStorageUrl,
+  parseReportYearFromUrl,
+  trimStr,
+  isValidReportCatalogYear,
+} from '../api/services/registryReportIdentity'
 
 export interface RegistrySaveJobData {
   companyName?: string
@@ -7,6 +12,8 @@ export interface RegistrySaveJobData {
   url: string
   sourceUrl?: string
   pdfCache?: { publicUrl?: string; sha256?: string }
+  /** PDF year label from pipeline (explicit field or max extracted data year). */
+  documentReportYear?: string | number
   body: { reportingPeriods: any[] }
 }
 
@@ -74,25 +81,38 @@ function resolveStorageUrl(
   )
 }
 
-// Returns the year from the chosen period, or falls back to the highest year across all periods.
-function resolveReportYear(
-  chosenPeriod: any,
-  reportingPeriods: any[]
+function maxDataYearAmongPeriods(reportingPeriods: any[]): number | null {
+  let max: number | null = null
+  for (const period of reportingPeriods) {
+    const y = Number(period?.year)
+    if (!Number.isFinite(y)) continue
+    max = max === null ? y : Math.max(max, y)
+  }
+  return max
+}
+
+/** PDF year for Report / CompanyReport (not a single comparison-period row). */
+export function resolveDocumentReportYear(
+  reportingPeriods: any[],
+  options?: {
+    documentReportYear?: string | number | null
+    reportUrl?: string | null
+    sourceUrl?: string | null
+  }
 ): string | undefined {
-  const year = chosenPeriod?.year
-  if (typeof year === 'number') return year.toString()
-  if (typeof year === 'string') return year
+  const explicit = options?.documentReportYear
+  if (explicit !== undefined && explicit !== null) {
+    const y = String(explicit).trim()
+    if (isValidReportCatalogYear(y)) return y
+  }
 
-  const maxYear = reportingPeriods.reduce(
-    (max: number | null, rp: any) => {
-      const y = Number(rp?.year)
-      if (!Number.isFinite(y)) return max
-      return max === null ? y : Math.max(max, y)
-    },
-    null as number | null
-  )
+  for (const url of [options?.reportUrl, options?.sourceUrl]) {
+    const fromUrl = parseReportYearFromUrl(url)
+    if (fromUrl && isValidReportCatalogYear(fromUrl)) return fromUrl
+  }
 
-  return maxYear !== null ? maxYear.toString() : undefined
+  const maxYear = maxDataYearAmongPeriods(reportingPeriods)
+  return maxYear !== null ? String(maxYear) : undefined
 }
 
 export function buildRegistryPayload(job: {
@@ -168,7 +188,14 @@ export function buildRegistryPayload(job: {
   return {
     companyName,
     wikidataId,
-    reportYear: resolveReportYear(chosenPeriod, reportingPeriods),
+    reportYear: resolveDocumentReportYear(reportingPeriods, {
+      documentReportYear: job.data.documentReportYear,
+      reportUrl: primaryUrl,
+      sourceUrl:
+        sourceUrlIsHttp && sourceUrl && !isStorageUrl(sourceUrl)
+          ? sourceUrl
+          : undefined,
+    }),
     url: primaryUrl,
     sourceUrl:
       sourceUrlIsHttp && sourceUrl && !isStorageUrl(sourceUrl)

--- a/src/workers/saveToAPI.utils.ts
+++ b/src/workers/saveToAPI.utils.ts
@@ -91,7 +91,10 @@ function maxDataYearAmongPeriods(reportingPeriods: any[]): number | null {
   return max
 }
 
-/** PDF year for Report / CompanyReport (not a single comparison-period row). */
+/**
+ * PDF year label for Report / CompanyReport.
+ * Priority: pipeline/job field → max extracted data year → URL parse (least trusted).
+ */
 export function resolveDocumentReportYear(
   reportingPeriods: any[],
   options?: {
@@ -106,13 +109,15 @@ export function resolveDocumentReportYear(
     if (isValidReportCatalogYear(y)) return y
   }
 
+  const maxYear = maxDataYearAmongPeriods(reportingPeriods)
+  if (maxYear !== null) return String(maxYear)
+
   for (const url of [options?.reportUrl, options?.sourceUrl]) {
     const fromUrl = parseReportYearFromUrl(url)
     if (fromUrl && isValidReportCatalogYear(fromUrl)) return fromUrl
   }
 
-  const maxYear = maxDataYearAmongPeriods(reportingPeriods)
-  return maxYear !== null ? String(maxYear) : undefined
+  return undefined
 }
 
 export function buildRegistryPayload(job: {

--- a/tests/companyReportService.test.ts
+++ b/tests/companyReportService.test.ts
@@ -42,9 +42,7 @@ describe('companyReportService', () => {
     jest
       .spyOn(registryService, 'upsertReportInRegistry')
       .mockResolvedValueOnce({ id: 'report-1' } as never)
-    jest
-      .spyOn(prisma.companyReport, 'findFirst')
-      .mockResolvedValueOnce(null)
+    jest.spyOn(prisma.companyReport, 'findFirst').mockResolvedValueOnce(null)
     jest
       .spyOn(prisma.companyReport, 'create')
       .mockResolvedValueOnce({ id: 'cr-new' } as never)

--- a/tests/companyReportService.test.ts
+++ b/tests/companyReportService.test.ts
@@ -38,13 +38,12 @@ describe('companyReportService', () => {
     ).rejects.toBeInstanceOf(CompanyReportScopeError)
   })
 
-  it('creates CompanyReport from registry upsert when identity is present', async () => {
+  it('upserts CompanyReport from registry when identity is present', async () => {
     jest
       .spyOn(registryService, 'upsertReportInRegistry')
       .mockResolvedValueOnce({ id: 'report-1' } as never)
-    jest.spyOn(prisma.companyReport, 'findFirst').mockResolvedValueOnce(null)
     jest
-      .spyOn(prisma.companyReport, 'create')
+      .spyOn(prisma.companyReport, 'upsert')
       .mockResolvedValueOnce({ id: 'cr-new' } as never)
 
     const result = await companyReportService.resolveCompanyReportIdForSave(
@@ -59,17 +58,26 @@ describe('companyReportService', () => {
 
     expect(result).toEqual({ companyReportId: 'cr-new', inferred: true })
     expect(registryService.upsertReportInRegistry).toHaveBeenCalled()
-    expect(prisma.companyReport.create).toHaveBeenCalledWith(
+    expect(prisma.companyReport.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: { companyId: 'Q1', registryReportId: 'report-1' },
+        where: {
+          companyId_registryReportId: {
+            companyId: 'Q1',
+            registryReportId: 'report-1',
+          },
+        },
+        create: { companyId: 'Q1', registryReportId: 'report-1' },
+        update: {},
       })
     )
   })
 
   it('falls back to the latest CompanyReport when no report identity', async () => {
-    jest.spyOn(prisma.companyReport, 'findFirst').mockResolvedValueOnce({
-      id: 'cr-legacy',
-    } as never)
+    const findFirst = jest
+      .spyOn(prisma.companyReport, 'findFirst')
+      .mockResolvedValueOnce({
+        id: 'cr-legacy',
+      } as never)
 
     const result = await companyReportService.resolveCompanyReportIdForSave(
       { wikidataId: 'Q1', name: 'Acme' },
@@ -77,6 +85,11 @@ describe('companyReportService', () => {
     )
 
     expect(result).toEqual({ companyReportId: 'cr-legacy', inferred: true })
+    expect(findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ reportYear: 'desc' }, { createdAt: 'desc' }],
+      })
+    )
   })
 
   it('prepareCompanyReportForPeriodSave resolves id, pdf year, and updates reportYear', async () => {

--- a/tests/companyReportService.test.ts
+++ b/tests/companyReportService.test.ts
@@ -68,7 +68,7 @@ describe('companyReportService', () => {
     )
   })
 
-  it('falls back to the newest company shell when no report identity', async () => {
+  it('falls back to the latest CompanyReport when no report identity', async () => {
     jest.spyOn(prisma.companyReport, 'findFirst').mockResolvedValueOnce({
       id: 'cr-legacy',
     } as never)
@@ -79,5 +79,59 @@ describe('companyReportService', () => {
     )
 
     expect(result).toEqual({ companyReportId: 'cr-legacy', inferred: true })
+  })
+
+  it('prepareCompanyReportForPeriodSave resolves id, pdf year, and updates reportYear', async () => {
+    jest
+      .spyOn(companyReportService, 'resolveCompanyReportIdForSave')
+      .mockResolvedValueOnce({ companyReportId: 'cr-1', inferred: false })
+    const setYear = jest
+      .spyOn(companyReportService, 'setCompanyReportYear')
+      .mockResolvedValueOnce(undefined)
+
+    const result = await companyReportService.prepareCompanyReportForPeriodSave(
+      { wikidataId: 'Q1', name: 'Acme' },
+      [{ year: '2024', reportURL: 'https://example.com/2024.pdf' }],
+      {
+        bodyCompanyReportId: 'cr-1',
+        documentReportYear: '2024',
+        reportUrl: 'https://example.com/2024.pdf',
+      }
+    )
+
+    expect(result).toEqual({
+      companyReportId: 'cr-1',
+      documentReportYear: '2024',
+    })
+    expect(setYear).toHaveBeenCalledWith('cr-1', '2024')
+  })
+
+  it('companyReportIdForPeriodSave returns default when period has no override', async () => {
+    const result = await companyReportService.companyReportIdForPeriodSave(
+      'Q1',
+      'cr-default',
+      undefined,
+      '2024'
+    )
+    expect(result).toBe('cr-default')
+  })
+
+  it('companyReportIdForPeriodSave uses period override and sets year when different', async () => {
+    jest.spyOn(prisma.companyReport, 'findFirst').mockResolvedValueOnce({
+      id: 'cr-other',
+    } as never)
+    const setYear = jest
+      .spyOn(companyReportService, 'setCompanyReportYear')
+      .mockResolvedValueOnce(undefined)
+
+    const result = await companyReportService.companyReportIdForPeriodSave(
+      'Q1',
+      'cr-default',
+      'cr-other',
+      '2025'
+    )
+
+    expect(result).toBe('cr-other')
+    expect(setYear).toHaveBeenCalledWith('cr-other', '2025')
   })
 })

--- a/tests/companyReportService.test.ts
+++ b/tests/companyReportService.test.ts
@@ -1,0 +1,83 @@
+import { jest } from '@jest/globals'
+
+import { prisma } from '../src/lib/prisma'
+import {
+  companyReportService,
+  CompanyReportScopeError,
+} from '../src/api/services/companyReportService'
+import { registryService } from '../src/api/services/registryService'
+
+describe('companyReportService', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('returns explicit companyReportId when it belongs to the company', async () => {
+    jest.spyOn(prisma.companyReport, 'findFirst').mockResolvedValueOnce({
+      id: 'cr-1',
+    } as never)
+
+    const result = await companyReportService.resolveCompanyReportIdForSave(
+      { wikidataId: 'Q1', name: 'Acme' },
+      [{ reportURL: 'https://example.com/2024.pdf', year: '2024' }],
+      { companyReportId: 'cr-1' }
+    )
+
+    expect(result).toEqual({ companyReportId: 'cr-1', inferred: false })
+  })
+
+  it('throws when explicit companyReportId is out of scope', async () => {
+    jest.spyOn(prisma.companyReport, 'findFirst').mockResolvedValueOnce(null)
+
+    await expect(
+      companyReportService.resolveCompanyReportIdForSave(
+        { wikidataId: 'Q1', name: 'Acme' },
+        [{ year: '2024' }],
+        { companyReportId: 'cr-other' }
+      )
+    ).rejects.toBeInstanceOf(CompanyReportScopeError)
+  })
+
+  it('creates CompanyReport from registry upsert when identity is present', async () => {
+    jest
+      .spyOn(registryService, 'upsertReportInRegistry')
+      .mockResolvedValueOnce({ id: 'report-1' } as never)
+    jest
+      .spyOn(prisma.companyReport, 'findFirst')
+      .mockResolvedValueOnce(null)
+    jest
+      .spyOn(prisma.companyReport, 'create')
+      .mockResolvedValueOnce({ id: 'cr-new' } as never)
+
+    const result = await companyReportService.resolveCompanyReportIdForSave(
+      { wikidataId: 'Q1', name: 'Acme' },
+      [
+        {
+          reportURL: 'https://example.com/sustainability-2024.pdf',
+          year: '2024',
+        },
+      ]
+    )
+
+    expect(result).toEqual({ companyReportId: 'cr-new', inferred: true })
+    expect(registryService.upsertReportInRegistry).toHaveBeenCalled()
+    expect(prisma.companyReport.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { companyId: 'Q1', registryReportId: 'report-1' },
+      })
+    )
+  })
+
+  it('falls back to the newest company shell when no report identity', async () => {
+    jest.spyOn(prisma.companyReport, 'findFirst').mockResolvedValueOnce({
+      id: 'cr-legacy',
+    } as never)
+
+    const result = await companyReportService.resolveCompanyReportIdForSave(
+      { wikidataId: 'Q1', name: 'Acme' },
+      [{ year: '2024' }]
+    )
+
+    expect(result).toEqual({ companyReportId: 'cr-legacy', inferred: true })
+  })
+})

--- a/tests/reportingPeriodPublicRead.test.ts
+++ b/tests/reportingPeriodPublicRead.test.ts
@@ -42,11 +42,15 @@ describe('pickOnePeriodPerDataYear', () => {
       period('2025', '2025', 'report-new'),
     ])
     expect(result.map((p) => p.year).sort()).toEqual(['2024', '2025'])
-    expect(result.find((p) => p.year === '2024')?.id).toBe('period-2024-report-old')
+    expect(result.find((p) => p.year === '2024')?.id).toBe(
+      'period-2024-report-old'
+    )
   })
 
   it('strips companyReport from the result', () => {
-    const result = pickOnePeriodPerDataYear([period('2024', '2024', 'report-a')])
+    const result = pickOnePeriodPerDataYear([
+      period('2024', '2024', 'report-a'),
+    ])
     expect(result[0]).not.toHaveProperty('companyReport')
   })
 })

--- a/tests/reportingPeriodPublicRead.test.ts
+++ b/tests/reportingPeriodPublicRead.test.ts
@@ -1,0 +1,52 @@
+import { pickOnePeriodPerDataYear } from '../src/api/services/reportingPeriodPublicRead'
+
+function period(
+  year: string,
+  companyReportYear: string | null,
+  companyReportId: string
+) {
+  return {
+    year,
+    id: `period-${year}-${companyReportId}`,
+    companyReport: {
+      id: companyReportId,
+      reportYear: companyReportYear,
+      reportPublicationDate: null,
+    },
+  }
+}
+
+describe('pickOnePeriodPerDataYear', () => {
+  it('returns one period per data year', () => {
+    const result = pickOnePeriodPerDataYear([
+      period('2024', '2024', 'report-a'),
+      period('2025', '2024', 'report-a'),
+    ])
+    expect(result).toHaveLength(2)
+    expect(result.map((p) => p.year).sort()).toEqual(['2024', '2025'])
+  })
+
+  it('prefers the period from the higher CompanyReport.reportYear for the same data year', () => {
+    const result = pickOnePeriodPerDataYear([
+      period('2024', '2024', 'report-old'),
+      period('2024', '2025', 'report-new'),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('period-2024-report-new')
+    expect(result[0]).not.toHaveProperty('companyReport')
+  })
+
+  it('keeps older report data when newer report has no row for that year', () => {
+    const result = pickOnePeriodPerDataYear([
+      period('2024', '2024', 'report-old'),
+      period('2025', '2025', 'report-new'),
+    ])
+    expect(result.map((p) => p.year).sort()).toEqual(['2024', '2025'])
+    expect(result.find((p) => p.year === '2024')?.id).toBe('period-2024-report-old')
+  })
+
+  it('strips companyReport from the result', () => {
+    const result = pickOnePeriodPerDataYear([period('2024', '2024', 'report-a')])
+    expect(result[0]).not.toHaveProperty('companyReport')
+  })
+})

--- a/tests/saveToAPI.test.ts
+++ b/tests/saveToAPI.test.ts
@@ -1,4 +1,7 @@
-import { buildRegistryPayload } from '../src/workers/saveToAPI.utils'
+import {
+  buildRegistryPayload,
+  resolveDocumentReportYear,
+} from '../src/workers/saveToAPI.utils'
 import type { RegistrySaveJobData } from '../src/workers/saveToAPI.utils'
 
 function makeJob(overrides: Partial<RegistrySaveJobData> & { url: string }): {
@@ -108,14 +111,14 @@ describe('buildRegistryPayload', () => {
 
   // ── reportYear derived from period ──────────────────────────────────────────
 
-  it('uses the year of the chosen (first) period when no identity match', () => {
+  it('uses max data year among periods when no explicit documentReportYear', () => {
     const result = buildRegistryPayload(
       makeJob({
         url: 'https://company.com/report',
         body: { reportingPeriods: [{ year: 2022 }, { year: 2024 }] },
       })
     )
-    expect(result!.reportYear).toBe('2022')
+    expect(result!.reportYear).toBe('2024')
   })
 
   it('falls back to max year when chosen period has no year', () => {
@@ -150,5 +153,41 @@ describe('buildRegistryPayload', () => {
     )
     expect(result!.url).toBe('https://company.com/annual')
     expect(result!.sha256).toBe('b'.repeat(64))
+  })
+
+  it('uses documentReportYear from job over a single comparison period year', () => {
+    const result = buildRegistryPayload(
+      makeJob({
+        url: 'https://company.com/annual-report-2025.pdf',
+        documentReportYear: '2025',
+        body: {
+          reportingPeriods: [
+            { year: 2024 },
+            { year: 2025 },
+          ],
+        },
+      })
+    )
+    expect(result!.reportYear).toBe('2025')
+  })
+})
+
+describe('resolveDocumentReportYear', () => {
+  it('prefers explicit documentReportYear', () => {
+    expect(
+      resolveDocumentReportYear([{ year: 2023 }], {
+        documentReportYear: '2025',
+      })
+    ).toBe('2025')
+  })
+
+  it('falls back to max data year among periods', () => {
+    expect(
+      resolveDocumentReportYear([
+        { year: 2023 },
+        { year: 2025 },
+        { year: 2024 },
+      ])
+    ).toBe('2025')
   })
 })

--- a/tests/saveToAPI.test.ts
+++ b/tests/saveToAPI.test.ts
@@ -161,10 +161,7 @@ describe('buildRegistryPayload', () => {
         url: 'https://company.com/annual-report-2025.pdf',
         documentReportYear: '2025',
         body: {
-          reportingPeriods: [
-            { year: 2024 },
-            { year: 2025 },
-          ],
+          reportingPeriods: [{ year: 2024 }, { year: 2025 }],
         },
       })
     )

--- a/tests/saveToAPI.test.ts
+++ b/tests/saveToAPI.test.ts
@@ -187,4 +187,20 @@ describe('resolveDocumentReportYear', () => {
       ])
     ).toBe('2025')
   })
+
+  it('prefers max data year over a misleading year in the report URL', () => {
+    expect(
+      resolveDocumentReportYear([{ year: 2023 }, { year: 2024 }], {
+        reportUrl: 'https://company.com/annual-report-2017.pdf',
+      })
+    ).toBe('2024')
+  })
+
+  it('uses URL year only when periods have no usable data years', () => {
+    expect(
+      resolveDocumentReportYear([{}], {
+        reportUrl: 'https://company.com/sustainability-report-2022.pdf',
+      })
+    ).toBe('2022')
+  })
 })


### PR DESCRIPTION
## Summary

Scopes reporting periods to a **CompanyReport** (processed PDF) instead of one row per company per data year. Public and first-party clients still see **one period per data year**; staff tooling sees **all period rows** per report.

Depends on **PR 1** (link job) having run in the target environment — no `ReportingPeriod.companyReportId IS NULL`.

### Schema & migration

- `ReportingPeriod.companyReportId` **NOT NULL**
- Unique **`(companyReportId, year)`** replaces **`(companyId, year)`**
- `companyReportId` → `CompanyReport`: **ON DELETE RESTRICT**
- Migration: `20260602120000_reporting_period_per_company_report`

### Writes 

- `companyReportService` resolves/creates shells from `companyReportId`, report identity, or company default
- `POST /api/companies/:wikidataId/reporting-periods` upserts on `(companyReportId, year)`
- Optional body fields: `companyReportId`, job-level report URLs, `documentReportYear`

### Public read

- `reportingPeriodPublicRead` — one period per data year; highest `CompanyReport.reportYear` wins
- **`GET /api/companies`** (+ search, detail): effective read
- **`GET /api/internal-companies`** (+ search, detail): same effective read (Bolt / first-party)
- ETag fingerprint includes `CompanyReport` count and latest shell

### Staff read (validate / workers)

- **`GET /api/pipeline/companies`** — list, all period rows (`getAllCompaniesWithMetadata`)
- **`GET /api/pipeline/companies/:wikidataId`** — detail, all period rows (`getCompanyWithMetadata`)
- Workers (`checkDB`, diff/save) use pipeline company read

### Pipeline 

- `documentReportYear` on save (explicit → URL parse → max period year)
- Registry upsert syncs `Report.reportYear` and `CompanyReport.reportYear`
- Approved diff passes report identity + `documentReportYear` to Garbo POST

### API surface (after merge)

| Audience | Endpoint | Periods returned |
|----------|----------|------------------|
| External | `GET /api/companies` | One per data year |
| First-party | `GET /api/internal-companies` | One per data year |
| Staff JWT | `GET /api/pipeline/companies` | All rows per report |

Mutations under `POST/PATCH/DELETE /api/companies/...` unchanged in shape; upsert key is `(companyReportId, year)`.

### Deploy (per environment)

1. Confirm link job completed (`companyReportId` populated).
2. Deploy app + run `npm run migrate` (`20260602120000_...`).
3. Deploy **unearth-api** mirror + **validate** in the same train (validate uses `pipeline/companies` on unearth-api).

See `k8s/jobs/README.md` for job manifests and ordering.

### Follow-up ToDos

- Delete whole `CompanyReport` + all periods (staff endpoint + validate UI)
- Remove empty `CompanyReport` when last period is deleted
- See `reportingPeriodService.deleteReportingPeriod` TODO

### Out of scope

- Bolt editor round-trip `companyReportId` (separate PR)
- Export / Wikidata / drop period URL columns on `ReportingPeriod`


### 📋 Checklist

- [x] PR title starts with `[#issue-number]`; if no issue is applicable use: `[fix]`, `[feat]`, `[ops]`, or `[prod]`
- [x] I’ve added/updated tests (or noted why they’re not needed)
- [x] I’ve verified the change runs locally (and in Docker/k8s if relevant)
- [x] If this changes the API contract, I’ve called that out clearly (and considered backward compatibility)
- [x] If this includes a DB change, I’ve included a migration + rollout/rollback notes
- [ ] I’ve considered observability (logs/metrics/traces) and added what’s needed
- [x] I’ve set labels, linked issue, and milestone (if applicable)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->
