### PR TITLE
[Fix]  issue of running multiple reports for a company partly in parallel

### DIFF
--- a/src/api/routes/internal/company.reportingPeriods.ts
+++ b/src/api/routes/internal/company.reportingPeriods.ts
@@ -237,7 +237,7 @@ export async function companyReportingPeriodsRoutes(app: FastifyInstance) {
         throw error
       }
 
-      // If replaceAllEmissions is set, purge existing emissions for ALL reporting periods for the company before upserting
+      // Purge emissions only on the CompanyReport shell being saved (not the whole company).
       if (replaceAllEmissions) {
         if (process.env.NODE_ENV === 'production') {
           return reply.status(403).send({
@@ -246,7 +246,10 @@ export async function companyReportingPeriodsRoutes(app: FastifyInstance) {
           })
         }
         const existingPeriods = await prisma.reportingPeriod.findMany({
-          where: { companyId: company.wikidataId },
+          where: {
+            companyId: company.wikidataId,
+            companyReportId: resolvedCompanyReportId,
+          },
           include: {
             emissions: {
               include: {

--- a/src/api/schemas/response.ts
+++ b/src/api/schemas/response.ts
@@ -263,6 +263,12 @@ export const InitiativeSchema = z.object({
   metadata: MetadataSchema,
 })
 
+export const CompanyReportSummarySchema = z.object({
+  id: z.string().optional(),
+  reportYear: z.string().nullable().optional(),
+  reportPublicationDate: dateStringSchema.nullable().optional(),
+})
+
 export const ReportingPeriodSchema = z.object({
   id: z.string(),
   startDate: dateStringSchema.openapi({
@@ -271,6 +277,10 @@ export const ReportingPeriodSchema = z.object({
   endDate: dateStringSchema.openapi({
     description: 'End date of reporting period',
   }),
+  year: z
+    .string()
+    .optional()
+    .openapi({ description: 'Data year for this reporting period' }),
   reportURL: z
     .string()
     .nullable()
@@ -289,6 +299,7 @@ export const ReportingPeriodSchema = z.object({
   companyReportId: z.string().optional().openapi({
     description: 'CompanyReport (processed PDF) this period belongs to',
   }),
+  companyReport: CompanyReportSummarySchema.nullable().optional(),
   emissions: EmissionsSchema.nullable(),
   economy: EconomySchema.nullable(),
   emissionsChangeLastTwoYears: z

--- a/src/lib/DiffWorker.ts
+++ b/src/lib/DiffWorker.ts
@@ -64,7 +64,11 @@ export class DiffJob extends DiscordJob {
     apiSubEndpoint: string,
     diff: string,
     change: ChangeDescription,
-    requiresApproval: boolean
+    requiresApproval: boolean,
+    options?: {
+      forceSave?: boolean
+      saveBodyExtras?: Record<string, unknown>
+    }
   ) => Promise<void>
 }
 
@@ -87,7 +91,13 @@ function addCustomMethods(job: DiffJob) {
     await enqueueSaveToAPIWithParentFallback(job, name, data)
   }
 
-  job.handleDiff = async (apiSubEndpoint, diff, change, requiresApproval) => {
+  job.handleDiff = async (
+    apiSubEndpoint,
+    diff,
+    change,
+    requiresApproval,
+    options
+  ) => {
     if (diff && requiresApproval && !job.data.autoApprove) {
       job.log('The data needs approval before saving to API.')
 
@@ -112,13 +122,19 @@ function addCustomMethods(job: DiffJob) {
         ),
         `Updates to the company's ${apiSubEndpoint}`
       )
-    } else if (diff) {
+    } else if (diff || options?.forceSave) {
+      if (options?.forceSave && !diff) {
+        job.log(
+          'Forcing save to API: new report PDF identity is not in the database yet.'
+        )
+      }
       await job.enqueueSaveToAPI(
         apiSubEndpoint,
         job.data.companyName,
         job.data.wikidata,
         {
           ...change.newValue,
+          ...options?.saveBodyExtras,
           metadata: defaultMetadata(
             canonicalPublicReportUrl(
               job.data as { url: string; sourceUrl?: string }

--- a/src/lib/companySaveLock.ts
+++ b/src/lib/companySaveLock.ts
@@ -1,0 +1,76 @@
+import { randomUUID } from 'node:crypto'
+import { createClient, type RedisClientType } from 'redis'
+import redisConfig from '../config/redis'
+
+const LOCK_KEY_PREFIX = 'garbo:company-save-lock:'
+const LOCK_TTL_MS = 10 * 60 * 1000
+const POLL_INTERVAL_MS = 500
+const MAX_WAIT_MS = 15 * 60 * 1000
+
+const redisUrl = `redis://default:${redisConfig.password}@${redisConfig.host}:${redisConfig.port}`
+
+let client: RedisClientType | null = null
+
+async function getRedis(): Promise<RedisClientType> {
+  if (!client || !client.isOpen) {
+    client = createClient({
+      url: redisUrl,
+      socket: {
+        connectTimeout: 2000,
+        reconnectStrategy: false,
+      },
+    })
+    client.on('error', (err) => {
+      console.warn('companySaveLock Redis error:', err.message)
+      client = null
+    })
+    client.on('end', () => {
+      client = null
+    })
+    await client.connect()
+  }
+  return client
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Serialize API saves per company so concurrent pipeline runs for the same
+ * wikidataId do not interleave registry / CompanyReport / period writes.
+ */
+export async function withCompanySaveLock<T>(
+  wikidataId: string,
+  run: () => Promise<T>
+): Promise<T> {
+  const key = `${LOCK_KEY_PREFIX}${wikidataId.trim()}`
+  const token = randomUUID()
+  const redis = await getRedis()
+  const waitStartedAt = Date.now()
+
+  while (true) {
+    const acquired = await redis.set(key, token, { NX: true, PX: LOCK_TTL_MS })
+    if (acquired) break
+
+    if (Date.now() - waitStartedAt > MAX_WAIT_MS) {
+      throw new Error(
+        `Timed out waiting for company save lock (${wikidataId}) after ${MAX_WAIT_MS}ms`
+      )
+    }
+    await sleep(POLL_INTERVAL_MS)
+  }
+
+  try {
+    return await run()
+  } finally {
+    try {
+      const current = await redis.get(key)
+      if (current === token) {
+        await redis.del(key)
+      }
+    } catch (err) {
+      console.warn('companySaveLock release failed:', err)
+    }
+  }
+}

--- a/src/lib/reportSaveIdentity.ts
+++ b/src/lib/reportSaveIdentity.ts
@@ -1,0 +1,117 @@
+import { canonicalPublicReportUrl } from './canonicalPublicReportUrl'
+import { resolveDocumentReportYear } from '../workers/saveToAPI.utils'
+
+export type PipelineReportIdentity = {
+  reportURL: string
+  reportS3Url?: string
+  reportSha256?: string
+}
+
+type JobReportFields = {
+  url: string
+  sourceUrl?: string
+  pdfCache?: { publicUrl?: string; sha256?: string }
+  documentReportYear?: string | number
+  replaceAllEmissions?: boolean
+}
+
+function trimOptional(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+/** Identity fields for the PDF this pipeline job is processing. */
+export function buildPipelineReportIdentity(jobData: {
+  url: string
+  sourceUrl?: string
+  pdfCache?: { publicUrl?: string; sha256?: string }
+}): PipelineReportIdentity {
+  const trimmedUrl = trimOptional(jobData.url) ?? ''
+  const trimmedSourceUrl = trimOptional(jobData.sourceUrl)
+  const sourceIsHttp =
+    typeof trimmedSourceUrl === 'string' &&
+    /^https?:\/\//i.test(trimmedSourceUrl)
+
+  const reportS3Url =
+    trimOptional(jobData.pdfCache?.publicUrl) ||
+    (trimmedUrl && (!sourceIsHttp || trimmedUrl !== trimmedSourceUrl)
+      ? trimmedUrl
+      : undefined)
+
+  return {
+    reportURL: canonicalPublicReportUrl({
+      url: jobData.url,
+      sourceUrl: jobData.sourceUrl,
+    }),
+    reportS3Url,
+    reportSha256: trimOptional(jobData.pdfCache?.sha256),
+  }
+}
+
+export function periodMatchesReportIdentity(
+  period: {
+    reportURL?: string | null
+    reportS3Url?: string | null
+    reportSha256?: string | null
+  },
+  identity: PipelineReportIdentity
+): boolean {
+  const periodSha = trimOptional(period.reportSha256)
+  const periodS3 = trimOptional(period.reportS3Url)
+  const periodUrl = trimOptional(period.reportURL)
+
+  if (identity.reportSha256 && periodSha === identity.reportSha256) return true
+  if (identity.reportS3Url && periodS3 === identity.reportS3Url) return true
+  if (identity.reportURL && periodUrl === identity.reportURL) return true
+
+  return false
+}
+
+/** True when any reporting period already stores this PDF identity. */
+export function isReportIdentityKnownInCompany(
+  company: { reportingPeriods?: unknown } | null | undefined,
+  identity: PipelineReportIdentity
+): boolean {
+  const periods = Array.isArray(company?.reportingPeriods)
+    ? company.reportingPeriods
+    : []
+  return periods.some((period) =>
+    periodMatchesReportIdentity(period as PipelineReportIdentity, identity)
+  )
+}
+
+/** Period rows already linked to this PDF — used as the diff "before" baseline. */
+export function reportingPeriodsForReportIdentity(
+  company: { reportingPeriods?: unknown } | null | undefined,
+  identity: PipelineReportIdentity
+): unknown[] {
+  const periods = Array.isArray(company?.reportingPeriods)
+    ? company.reportingPeriods
+    : []
+  const matched = periods.filter((period) =>
+    periodMatchesReportIdentity(period as PipelineReportIdentity, identity)
+  )
+  return matched
+}
+
+/** Top-level POST fields for reporting-periods save (registry + CompanyReport resolution). */
+export function buildReportingPeriodsApiBodyExtras(
+  jobData: JobReportFields,
+  reportingPeriods: unknown[]
+): Record<string, unknown> {
+  const identity = buildPipelineReportIdentity(jobData)
+  const trimmedSourceUrl = trimOptional(jobData.sourceUrl)
+  const documentReportYear = resolveDocumentReportYear(reportingPeriods, {
+    documentReportYear: jobData.documentReportYear,
+    reportUrl: identity.reportURL,
+    sourceUrl: trimmedSourceUrl,
+  })
+
+  return {
+    ...(jobData.replaceAllEmissions && { replaceAllEmissions: true }),
+    documentReportYear,
+    reportUrl: identity.reportURL,
+    reportSourceUrl: trimmedSourceUrl,
+    reportS3Url: identity.reportS3Url,
+    reportSha256: identity.reportSha256,
+  }
+}

--- a/src/workers/diffReportingPeriods.ts
+++ b/src/workers/diffReportingPeriods.ts
@@ -91,7 +91,8 @@ const diffReportingPeriods = new DiffWorker<DiffReportingPeriodsJob>(
     if (!job.hasApproval()) {
       const wikidataId = wikidata.node
       const freshCompany =
-        (await fetchFreshExistingCompany(wikidataId)) ?? existingCompanyFromCheckDb
+        (await fetchFreshExistingCompany(wikidataId)) ??
+        existingCompanyFromCheckDb
       const reportIdentity = buildPipelineReportIdentity(job.data)
       const isNewReportIdentity = !isReportIdentityKnownInCompany(
         freshCompany,
@@ -105,10 +106,10 @@ const diffReportingPeriods = new DiffWorker<DiffReportingPeriodsJob>(
       }
 
       const years = new Set([
-        ...job.data.scope12?.map((d) => d.year) ?? [],
-        ...job.data.scope3?.map((d) => d.year) ?? [],
-        ...job.data.biogenic?.map((d) => d.year) ?? [],
-        ...job.data.economy?.map((d) => d.year) ?? [],
+        ...(job.data.scope12?.map((d) => d.year) ?? []),
+        ...(job.data.scope3?.map((d) => d.year) ?? []),
+        ...(job.data.biogenic?.map((d) => d.year) ?? []),
+        ...(job.data.economy?.map((d) => d.year) ?? []),
       ])
 
       const reportYear = years.size > 0 ? Math.max(...Array.from(years)) : null

--- a/src/workers/diffReportingPeriods.ts
+++ b/src/workers/diffReportingPeriods.ts
@@ -4,6 +4,13 @@ import { resolveDocumentReportYear } from './saveToAPI.utils'
 import { QUEUE_NAMES } from '../queues'
 import { ChangeDescription, DiffWorker, DiffJob } from '../lib/DiffWorker'
 import apiConfig from '../config/api'
+import { apiFetch } from '../lib/api'
+import {
+  buildPipelineReportIdentity,
+  buildReportingPeriodsApiBodyExtras,
+  isReportIdentityKnownInCompany,
+  reportingPeriodsForReportIdentity,
+} from '../lib/reportSaveIdentity'
 
 export class DiffReportingPeriodsJob extends DiffJob {
   declare data: DiffJob['data'] & {
@@ -28,6 +35,10 @@ export class DiffReportingPeriodsJob extends DiffJob {
   }
 }
 
+async function fetchFreshExistingCompany(wikidataId: string) {
+  return apiFetch(`/pipeline/companies/${wikidataId}`).catch(() => null)
+}
+
 const diffReportingPeriods = new DiffWorker<DiffReportingPeriodsJob>(
   QUEUE_NAMES.DIFF_REPORTING_PERIODS,
   async (job) => {
@@ -38,11 +49,7 @@ const diffReportingPeriods = new DiffWorker<DiffReportingPeriodsJob>(
       wikidata,
       fiscalYear,
       companyName,
-      existingCompany,
-      scope12 = [],
-      scope3 = [],
-      biogenic = [],
-      economy = [],
+      existingCompany: existingCompanyFromCheckDb,
     } = job.data
 
     const reportURLForPeriod = canonicalPublicReportUrl({ url, sourceUrl })
@@ -82,19 +89,35 @@ const diffReportingPeriods = new DiffWorker<DiffReportingPeriodsJob>(
     }
 
     if (!job.hasApproval()) {
-      // Get all unique years from all sources
+      const wikidataId = wikidata.node
+      const freshCompany =
+        (await fetchFreshExistingCompany(wikidataId)) ?? existingCompanyFromCheckDb
+      const reportIdentity = buildPipelineReportIdentity(job.data)
+      const isNewReportIdentity = !isReportIdentityKnownInCompany(
+        freshCompany,
+        reportIdentity
+      )
+
+      if (isNewReportIdentity) {
+        job.log(
+          `New report identity for ${wikidataId}: ${reportIdentity.reportURL}`
+        )
+      }
+
       const years = new Set([
-        ...scope12.map((d) => d.year),
-        ...scope3.map((d) => d.year),
-        ...biogenic.map((d) => d.year),
-        ...economy.map((d) => d.year),
+        ...job.data.scope12?.map((d) => d.year) ?? [],
+        ...job.data.scope3?.map((d) => d.year) ?? [],
+        ...job.data.biogenic?.map((d) => d.year) ?? [],
+        ...job.data.economy?.map((d) => d.year) ?? [],
       ])
 
-      // Determine the report year - use the most recent year found in the data
-      // This represents the year the current report actually covers
       const reportYear = years.size > 0 ? Math.max(...Array.from(years)) : null
 
-      // Create base reporting periods
+      const scope12 = job.data.scope12 ?? []
+      const scope3 = job.data.scope3 ?? []
+      const biogenic = job.data.biogenic ?? []
+      const economy = job.data.economy ?? []
+
       const reportingPeriods = Array.from(years).map((year) => {
         const [startDate, endDate] = getReportingPeriodDates(
           year,
@@ -105,7 +128,6 @@ const diffReportingPeriods = new DiffWorker<DiffReportingPeriodsJob>(
           year,
           startDate,
           endDate,
-          // Only assign reportURL to the reporting period that matches the report year
           reportURL:
             reportYear !== null && year === reportYear
               ? reportURLForPeriod
@@ -121,7 +143,6 @@ const diffReportingPeriods = new DiffWorker<DiffReportingPeriodsJob>(
         }
       })
 
-      // Fill in data from each source, only keeping data that was changed.
       const updatedReportingPeriods = reportingPeriods.map(
         ({ year, ...period }) => {
           const emissions = {
@@ -145,9 +166,8 @@ const diffReportingPeriods = new DiffWorker<DiffReportingPeriodsJob>(
             reportingPeriod.economy = economyData
           }
 
-          // Preserve existing reportURL for years that don't match the current report year
           if (reportYear !== null && year !== reportYear) {
-            const existingPeriod = existingCompany?.reportingPeriods?.find(
+            const existingPeriod = freshCompany?.reportingPeriods?.find(
               (rp: any) => rp.year === year.toString()
             )
             if (existingPeriod?.reportURL) {
@@ -165,27 +185,39 @@ const diffReportingPeriods = new DiffWorker<DiffReportingPeriodsJob>(
         }
       )
 
-      // NOTE: Maybe only keep properties in existingCompany.reportingPeriods, e.g. the relevant economy properties, or the relevant emissions properties
-      // This could improve accuracy of the diff
+      const periodsBefore = reportingPeriodsForReportIdentity(
+        freshCompany,
+        reportIdentity
+      )
+
       const { diff, requiresApproval } = await diffChanges({
-        existingCompany,
-        before: existingCompany?.reportingPeriods || [],
+        existingCompany: freshCompany,
+        before: periodsBefore,
         after: updatedReportingPeriods,
       })
 
       const change: ChangeDescription = {
         type: 'reportingPeriods',
         oldValue: {
-          reportingPeriods: existingCompany?.reportingPeriods || [],
+          reportingPeriods: periodsBefore,
         },
         newValue: { reportingPeriods: updatedReportingPeriods },
       }
+
+      const saveBodyExtras = buildReportingPeriodsApiBodyExtras(
+        job.data,
+        updatedReportingPeriods
+      )
+
+      const forceSave =
+        isNewReportIdentity && updatedReportingPeriods.length > 0
 
       await job.handleDiff(
         'reporting-periods',
         diff,
         change,
-        typeof requiresApproval == 'boolean' ? requiresApproval : false
+        typeof requiresApproval == 'boolean' ? requiresApproval : false,
+        { forceSave, saveBodyExtras }
       )
     }
 

--- a/src/workers/saveToAPI.ts
+++ b/src/workers/saveToAPI.ts
@@ -5,6 +5,7 @@ import { registryService } from '../api/services/registryService'
 import { createServerCache } from '../createCache'
 import { invalidateRegistryCache } from '../api/services/registryCache'
 import { buildRegistryPayload } from './saveToAPI.utils'
+import { withCompanySaveLock } from '../lib/companySaveLock'
 
 const registryCache = createServerCache({ maxAge: 24 * 60 * 60 * 1000 })
 
@@ -107,39 +108,45 @@ export const saveToAPI = new DiscordWorker<SaveToApiJob>(
         typeof apiSubEndpoint === 'string' && apiSubEndpoint.trim().length > 0
           ? apiSubEndpoint.trim()
           : 'company'
-      const result = await apiFetch(endpoint, {
-        body: sanitizedBody,
-        ...(method && { method }),
-        headers: {
-          'X-Garbo-Chunk': chunk,
-        },
-      })
-
-      if (result === null) {
-        throw new Error(`API endpoint not found: ${endpoint}`)
-      }
-
-      if (apiSubEndpoint === 'reporting-periods') {
-        const registryPayload = buildRegistryPayload({
-          data: {
-            ...job.data,
-            documentReportYear:
-              job.data.documentReportYear ?? sanitizedBody?.documentReportYear,
-            body: sanitizedBody,
+      await withCompanySaveLock(wikidataId, async () => {
+        const saved = await apiFetch(endpoint, {
+          body: sanitizedBody,
+          ...(method && { method }),
+          headers: {
+            'X-Garbo-Chunk': chunk,
           },
         })
-        if (registryPayload) {
-          try {
-            await registryService.upsertReportInRegistry(registryPayload)
-            await invalidateRegistryCache(registryCache, {
-              warn: (msg: string, ...args: unknown[]) =>
-                job.log([msg, ...args.map((a) => JSON.stringify(a))].join(' ')),
-            })
-          } catch (e: any) {
-            job.log(`Registry upsert failed after save: ${e?.message ?? e}`)
+
+        if (saved === null) {
+          throw new Error(`API endpoint not found: ${endpoint}`)
+        }
+
+        if (apiSubEndpoint === 'reporting-periods') {
+          const registryPayload = buildRegistryPayload({
+            data: {
+              ...job.data,
+              documentReportYear:
+                job.data.documentReportYear ??
+                sanitizedBody?.documentReportYear,
+              body: sanitizedBody,
+            },
+          })
+          if (registryPayload) {
+            try {
+              await registryService.upsertReportInRegistry(registryPayload)
+              await invalidateRegistryCache(registryCache, {
+                warn: (msg: string, ...args: unknown[]) =>
+                  job.log(
+                    [msg, ...args.map((a) => JSON.stringify(a))].join(' ')
+                  ),
+              })
+            } catch (e: any) {
+              job.log(`Registry upsert failed after save: ${e?.message ?? e}`)
+            }
           }
         }
-      }
+
+      })
 
       return { success: true }
     } catch (error) {

--- a/src/workers/saveToAPI.ts
+++ b/src/workers/saveToAPI.ts
@@ -145,7 +145,6 @@ export const saveToAPI = new DiscordWorker<SaveToApiJob>(
             }
           }
         }
-
       })
 
       return { success: true }

--- a/tests/reportSaveIdentity.test.ts
+++ b/tests/reportSaveIdentity.test.ts
@@ -1,0 +1,86 @@
+import {
+  buildPipelineReportIdentity,
+  buildReportingPeriodsApiBodyExtras,
+  isReportIdentityKnownInCompany,
+  periodMatchesReportIdentity,
+  reportingPeriodsForReportIdentity,
+} from '../src/lib/reportSaveIdentity'
+
+describe('reportSaveIdentity', () => {
+  const identity = {
+    reportURL: 'https://storage.googleapis.com/garbo/abc.pdf',
+    reportS3Url: 'https://storage.googleapis.com/garbo/abc.pdf',
+    reportSha256: 'a'.repeat(64),
+  }
+
+  it('matches period by sha256', () => {
+    expect(
+      periodMatchesReportIdentity(
+        { reportSha256: identity.reportSha256 },
+        identity
+      )
+    ).toBe(true)
+  })
+
+  it('detects unknown identity on company', () => {
+    expect(isReportIdentityKnownInCompany({ reportingPeriods: [] }, identity)).toBe(
+      false
+    )
+  })
+
+  it('detects known identity on company', () => {
+    expect(
+      isReportIdentityKnownInCompany(
+        {
+          reportingPeriods: [
+            { year: '2025', reportSha256: identity.reportSha256 },
+          ],
+        },
+        identity
+      )
+    ).toBe(true)
+  })
+
+  it('filters before-periods to this report shell only', () => {
+    const company = {
+      reportingPeriods: [
+        { year: '2022', reportSha256: 'old' },
+        { year: '2025', reportSha256: identity.reportSha256 },
+      ],
+    }
+    expect(reportingPeriodsForReportIdentity(company, identity)).toHaveLength(1)
+  })
+
+  it('builds API body extras from job pdfCache', () => {
+    const extras = buildReportingPeriodsApiBodyExtras(
+      {
+        url: 'https://storage.googleapis.com/garbo/abc.pdf',
+        sourceUrl: 'uploaded:tele2-2025.pdf',
+        pdfCache: {
+          publicUrl: 'https://storage.googleapis.com/garbo/abc.pdf',
+          sha256: identity.reportSha256,
+        },
+        replaceAllEmissions: true,
+      },
+      [{ year: 2025, startDate: '2025-01-01', endDate: '2025-12-31' }]
+    )
+    expect(extras.replaceAllEmissions).toBe(true)
+    expect(extras.reportSha256).toBe(identity.reportSha256)
+    expect(extras.documentReportYear).toBe('2025')
+  })
+
+  it('buildPipelineReportIdentity uses S3 url when source is upload placeholder', () => {
+    const built = buildPipelineReportIdentity({
+      url: 'https://storage.googleapis.com/garbo/abc.pdf',
+      sourceUrl: 'uploaded:file.pdf',
+      pdfCache: {
+        publicUrl: 'https://storage.googleapis.com/garbo/abc.pdf',
+        sha256: 'b'.repeat(64),
+      },
+    })
+    expect(built.reportURL).toBe(
+      'https://storage.googleapis.com/garbo/abc.pdf'
+    )
+    expect(built.reportSha256).toBe('b'.repeat(64))
+  })
+})

--- a/tests/reportSaveIdentity.test.ts
+++ b/tests/reportSaveIdentity.test.ts
@@ -23,9 +23,9 @@ describe('reportSaveIdentity', () => {
   })
 
   it('detects unknown identity on company', () => {
-    expect(isReportIdentityKnownInCompany({ reportingPeriods: [] }, identity)).toBe(
-      false
-    )
+    expect(
+      isReportIdentityKnownInCompany({ reportingPeriods: [] }, identity)
+    ).toBe(false)
   })
 
   it('detects known identity on company', () => {
@@ -78,9 +78,7 @@ describe('reportSaveIdentity', () => {
         sha256: 'b'.repeat(64),
       },
     })
-    expect(built.reportURL).toBe(
-      'https://storage.googleapis.com/garbo/abc.pdf'
-    )
+    expect(built.reportURL).toBe('https://storage.googleapis.com/garbo/abc.pdf')
     expect(built.reportSha256).toBe('b'.repeat(64))
   })
 })


### PR DESCRIPTION
### ✨ What’s Changed?

Fixes to help with running multiple reports for the same company in parallel but forcing new reports to always save, checking for matching reports, and apisave lock per wikidataid so we only save data one report at a time for a company.

### 🔍 How to Review / Test

<!-- Include relevant commands, curl examples, or steps in staging -->

### 📋 Checklist

- [x] PR title starts with `[#issue-number]`; if no issue is applicable use: `[fix]`, `[feat]`, `[ops]`, or `[prod]`
- [ ] I’ve added/updated tests (or noted why they’re not needed)
- [ ] I’ve verified the change runs locally (and in Docker/k8s if relevant)
- [ ] If this changes the API contract, I’ve called that out clearly (and considered backward compatibility)
- [ ] If this includes a DB change, I’ve included a migration + rollout/rollback notes
- [ ] I’ve considered observability (logs/metrics/traces) and added what’s needed
- [x] I’ve set labels, linked issue, and milestone (if applicable)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->
