### PR TITLE
1235 additional reporting periods updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -786,9 +786,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -802,9 +802,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -818,9 +818,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -834,9 +834,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -850,9 +850,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -866,9 +866,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -882,9 +882,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -898,9 +898,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -914,9 +914,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -930,9 +930,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -946,9 +946,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -962,9 +962,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -978,9 +978,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -994,9 +994,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1010,9 +1010,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1026,9 +1026,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -1042,9 +1042,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -1058,9 +1058,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -1074,9 +1074,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -1090,9 +1090,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -1106,9 +1106,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -1122,9 +1122,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -1138,9 +1138,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -1154,9 +1154,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -1170,9 +1170,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -1186,9 +1186,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -6442,9 +6442,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -6454,32 +6454,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -7372,18 +7372,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-tsconfig": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/giget": {
@@ -11597,15 +11585,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
@@ -12584,13 +12563,12 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"

--- a/src/api/args.ts
+++ b/src/api/args.ts
@@ -27,6 +27,18 @@ export const reportingPeriodCompanyReportSelect = {
       id: true,
       reportYear: true,
       reportPublicationDate: true,
+      registryReportId: true,
+      createdAt: true,
+      report: {
+        select: {
+          id: true,
+          url: true,
+          sourceUrl: true,
+          s3Url: true,
+          reportYear: true,
+          sha256: true,
+        },
+      },
     },
   },
 } as const

--- a/src/api/routes/internal/company.reportingPeriods.ts
+++ b/src/api/routes/internal/company.reportingPeriods.ts
@@ -453,7 +453,26 @@ export async function companyReportingPeriodsRoutes(app: FastifyInstance) {
         }
       }
 
-      return reply.send({ ok: true })
+      const registryReportId =
+        await companyReportService.ensureCompanyReportRegistryLink(
+          resolvedCompanyReportId,
+          company,
+          reportingPeriods,
+          {
+            bodyCompanyReportId,
+            documentReportYear,
+            reportUrl,
+            reportSourceUrl,
+            reportS3Url,
+            reportSha256,
+          },
+        )
+
+      return reply.send({
+        ok: true,
+        companyReportId: resolvedCompanyReportId,
+        registryReportId,
+      })
     }
   )
 }

--- a/src/api/routes/internal/company.reportingPeriods.ts
+++ b/src/api/routes/internal/company.reportingPeriods.ts
@@ -465,7 +465,7 @@ export async function companyReportingPeriodsRoutes(app: FastifyInstance) {
             reportSourceUrl,
             reportS3Url,
             reportSha256,
-          },
+          }
         )
 
       return reply.send({

--- a/src/api/routes/internal/company.reportingPeriods.ts
+++ b/src/api/routes/internal/company.reportingPeriods.ts
@@ -195,6 +195,7 @@ export async function companyReportingPeriodsRoutes(app: FastifyInstance) {
         reportS3Url,
         reportSha256,
         documentReportYear: bodyDocumentReportYear,
+        registryReportId: bodyRegistryReportId,
       } = request.body
       const user = request.user
       let company
@@ -218,6 +219,7 @@ export async function companyReportingPeriodsRoutes(app: FastifyInstance) {
             reportingPeriods,
             {
               bodyCompanyReportId,
+              registryReportId: bodyRegistryReportId,
               documentReportYear: bodyDocumentReportYear,
               reportUrl,
               reportSourceUrl,
@@ -453,13 +455,14 @@ export async function companyReportingPeriodsRoutes(app: FastifyInstance) {
         }
       }
 
-      const registryReportId =
+      const linkResult =
         await companyReportService.ensureCompanyReportRegistryLink(
           resolvedCompanyReportId,
           company,
           reportingPeriods,
           {
             bodyCompanyReportId,
+            registryReportId: bodyRegistryReportId,
             documentReportYear,
             reportUrl,
             reportSourceUrl,
@@ -470,8 +473,8 @@ export async function companyReportingPeriodsRoutes(app: FastifyInstance) {
 
       return reply.send({
         ok: true,
-        companyReportId: resolvedCompanyReportId,
-        registryReportId,
+        companyReportId: linkResult?.companyReportId ?? resolvedCompanyReportId,
+        registryReportId: linkResult?.registryReportId ?? null,
       })
     }
   )

--- a/src/api/schemas/request.ts
+++ b/src/api/schemas/request.ts
@@ -287,6 +287,8 @@ export const postReportingPeriodsSchema = z
     reportSha256: z.string().optional(),
     /// PDF year label (e.g. 2025 annual report), stored on Report and CompanyReport.
     documentReportYear: z.string().optional(),
+    /// Registry report id from early pipeline upsert (checkDB).
+    registryReportId: z.string().optional(),
   })
   .merge(createMetadataSchema)
 

--- a/src/api/services/companyReportService.ts
+++ b/src/api/services/companyReportService.ts
@@ -31,6 +31,67 @@ export type SaveReportIdentity = {
   pdfCache?: { publicUrl?: string; sha256?: string }
 }
 
+function trimOptional(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function mergeReportIdentityFromPeriods(
+  reportingPeriods: ReportingPeriodIdentity[],
+  identity?: SaveReportIdentity,
+): SaveReportIdentity {
+  const periodWithUrl = reportingPeriods.find((period) =>
+    trimOptional(period.reportURL),
+  )
+  const periodWithS3 = reportingPeriods.find((period) =>
+    trimOptional(period.reportS3Url),
+  )
+  const periodWithSha = reportingPeriods.find((period) =>
+    trimOptional(period.reportSha256),
+  )
+
+  const publicUrl =
+    trimOptional(identity?.pdfCache?.publicUrl) ??
+    trimOptional(periodWithS3?.reportS3Url)
+  const sha256 =
+    trimOptional(identity?.pdfCache?.sha256) ??
+    trimOptional(periodWithSha?.reportSha256)
+
+  return {
+    url:
+      trimOptional(identity?.url) ??
+      trimOptional(periodWithUrl?.reportURL) ??
+      trimOptional(periodWithS3?.reportS3Url) ??
+      '',
+    sourceUrl: trimOptional(identity?.sourceUrl),
+    pdfCache:
+      publicUrl || sha256 ? { publicUrl, sha256 } : identity?.pdfCache,
+  }
+}
+
+function buildRegistryPayloadForCompanySave(
+  company: Pick<Company, 'wikidataId' | 'name'>,
+  reportingPeriods: ReportingPeriodIdentity[],
+  identity?: SaveReportIdentity,
+  documentReportYear?: string,
+) {
+  const mergedIdentity = mergeReportIdentityFromPeriods(
+    reportingPeriods,
+    identity,
+  )
+
+  return buildRegistryPayload({
+    data: {
+      companyName: company.name,
+      wikidata: { node: company.wikidataId },
+      url: mergedIdentity.url ?? '',
+      sourceUrl: mergedIdentity.sourceUrl,
+      pdfCache: mergedIdentity.pdfCache,
+      documentReportYear,
+      body: { reportingPeriods },
+    },
+  })
+}
+
 class CompanyReportService {
   async findOrCreateCompanyReport(
     companyId: string,
@@ -158,16 +219,11 @@ class CompanyReportService {
       return { companyReportId: explicitId, inferred: false }
     }
 
-    const registryPayload = buildRegistryPayload({
-      data: {
-        companyName: company.name,
-        wikidata: { node: company.wikidataId },
-        url: options?.reportIdentity?.url?.trim() ?? '',
-        sourceUrl: options?.reportIdentity?.sourceUrl,
-        pdfCache: options?.reportIdentity?.pdfCache,
-        body: { reportingPeriods },
-      },
-    })
+    const registryPayload = buildRegistryPayloadForCompanySave(
+      company,
+      reportingPeriods,
+      options?.reportIdentity,
+    )
 
     if (registryPayload) {
       const report =
@@ -233,6 +289,118 @@ class CompanyReportService {
     await this.setCompanyReportYear(companyReportId, documentReportYear)
 
     return { companyReportId, documentReportYear }
+  }
+
+  /**
+   * Link CompanyReport.registryReportId when prepare used a fallback shell but
+   * report identity is available (common when top-level reportUrl was missing).
+   */
+  async ensureCompanyReportRegistryLink(
+    companyReportId: string,
+    company: Pick<Company, 'wikidataId' | 'name'>,
+    reportingPeriods: ReportingPeriodIdentity[],
+    input: PrepareCompanyReportForPeriodSaveInput,
+  ): Promise<string | null> {
+    const existing = await prisma.companyReport.findUnique({
+      where: { id: companyReportId },
+      select: { registryReportId: true, companyId: true },
+    })
+    if (!existing) return null
+    if (existing.registryReportId) return existing.registryReportId
+
+    const registryPayload = buildRegistryPayloadForCompanySave(
+      company,
+      reportingPeriods,
+      {
+        url: input.reportUrl,
+        sourceUrl: input.reportSourceUrl,
+        pdfCache:
+          input.reportS3Url || input.reportSha256
+            ? {
+                publicUrl: input.reportS3Url,
+                sha256: input.reportSha256,
+              }
+            : undefined,
+      },
+      input.documentReportYear,
+    )
+    if (!registryPayload) return null
+
+    const report =
+      await registryService.upsertReportInRegistry(registryPayload)
+
+    const alreadyLinked = await prisma.companyReport.findFirst({
+      where: {
+        companyId: existing.companyId,
+        registryReportId: report.id,
+      },
+      select: { id: true },
+    })
+    if (alreadyLinked && alreadyLinked.id !== companyReportId) {
+      console.warn(
+        '[companyReportService] Registry report already linked to another CompanyReport',
+        {
+          companyId: existing.companyId,
+          companyReportId,
+          linkedShellId: alreadyLinked.id,
+          registryReportId: report.id,
+        },
+      )
+      return report.id
+    }
+
+    await prisma.companyReport.update({
+      where: { id: companyReportId },
+      data: { registryReportId: report.id },
+    })
+
+    return report.id
+  }
+
+  async setCompanyReportRegistryLink(
+    companyReportId: string,
+    companyWikidataId: string,
+    registryReportId: string,
+  ): Promise<void> {
+    await this.assertCompanyReportBelongsToCompany(
+      companyReportId,
+      companyWikidataId,
+    )
+
+    const report = await prisma.report.findUnique({
+      where: { id: registryReportId },
+      select: { id: true, wikidataId: true },
+    })
+    if (!report) {
+      throw new CompanyReportScopeError(
+        `Registry report ${registryReportId} not found`,
+      )
+    }
+
+    if (report.wikidataId && report.wikidataId !== companyWikidataId) {
+      throw new CompanyReportScopeError(
+        `Registry report ${registryReportId} belongs to ${report.wikidataId}, not ${companyWikidataId}`,
+      )
+    }
+
+    const conflicting = await prisma.companyReport.findFirst({
+      where: {
+        companyId: companyWikidataId,
+        registryReportId,
+        NOT: { id: companyReportId },
+      },
+      select: { id: true },
+    })
+    if (conflicting) {
+      throw new CompanyReportScopeError(
+        `Registry report already linked to CompanyReport ${conflicting.id}`,
+      )
+    }
+
+    await prisma.companyReport.update({
+      where: { id: companyReportId },
+      data: { registryReportId },
+    })
   }
 
   async companyReportIdForPeriodSave(

--- a/src/api/services/companyReportService.ts
+++ b/src/api/services/companyReportService.ts
@@ -37,16 +37,16 @@ function trimOptional(value: unknown): string | undefined {
 
 function mergeReportIdentityFromPeriods(
   reportingPeriods: ReportingPeriodIdentity[],
-  identity?: SaveReportIdentity,
+  identity?: SaveReportIdentity
 ): SaveReportIdentity {
   const periodWithUrl = reportingPeriods.find((period) =>
-    trimOptional(period.reportURL),
+    trimOptional(period.reportURL)
   )
   const periodWithS3 = reportingPeriods.find((period) =>
-    trimOptional(period.reportS3Url),
+    trimOptional(period.reportS3Url)
   )
   const periodWithSha = reportingPeriods.find((period) =>
-    trimOptional(period.reportSha256),
+    trimOptional(period.reportSha256)
   )
 
   const publicUrl =
@@ -63,8 +63,7 @@ function mergeReportIdentityFromPeriods(
       trimOptional(periodWithS3?.reportS3Url) ??
       '',
     sourceUrl: trimOptional(identity?.sourceUrl),
-    pdfCache:
-      publicUrl || sha256 ? { publicUrl, sha256 } : identity?.pdfCache,
+    pdfCache: publicUrl || sha256 ? { publicUrl, sha256 } : identity?.pdfCache,
   }
 }
 
@@ -72,11 +71,11 @@ function buildRegistryPayloadForCompanySave(
   company: Pick<Company, 'wikidataId' | 'name'>,
   reportingPeriods: ReportingPeriodIdentity[],
   identity?: SaveReportIdentity,
-  documentReportYear?: string,
+  documentReportYear?: string
 ) {
   const mergedIdentity = mergeReportIdentityFromPeriods(
     reportingPeriods,
-    identity,
+    identity
   )
 
   return buildRegistryPayload({
@@ -222,7 +221,7 @@ class CompanyReportService {
     const registryPayload = buildRegistryPayloadForCompanySave(
       company,
       reportingPeriods,
-      options?.reportIdentity,
+      options?.reportIdentity
     )
 
     if (registryPayload) {
@@ -299,7 +298,7 @@ class CompanyReportService {
     companyReportId: string,
     company: Pick<Company, 'wikidataId' | 'name'>,
     reportingPeriods: ReportingPeriodIdentity[],
-    input: PrepareCompanyReportForPeriodSaveInput,
+    input: PrepareCompanyReportForPeriodSaveInput
   ): Promise<string | null> {
     const existing = await prisma.companyReport.findUnique({
       where: { id: companyReportId },
@@ -322,12 +321,11 @@ class CompanyReportService {
               }
             : undefined,
       },
-      input.documentReportYear,
+      input.documentReportYear
     )
     if (!registryPayload) return null
 
-    const report =
-      await registryService.upsertReportInRegistry(registryPayload)
+    const report = await registryService.upsertReportInRegistry(registryPayload)
 
     const alreadyLinked = await prisma.companyReport.findFirst({
       where: {
@@ -344,7 +342,7 @@ class CompanyReportService {
           companyReportId,
           linkedShellId: alreadyLinked.id,
           registryReportId: report.id,
-        },
+        }
       )
       return report.id
     }
@@ -360,11 +358,11 @@ class CompanyReportService {
   async setCompanyReportRegistryLink(
     companyReportId: string,
     companyWikidataId: string,
-    registryReportId: string,
+    registryReportId: string
   ): Promise<void> {
     await this.assertCompanyReportBelongsToCompany(
       companyReportId,
-      companyWikidataId,
+      companyWikidataId
     )
 
     const report = await prisma.report.findUnique({
@@ -373,13 +371,13 @@ class CompanyReportService {
     })
     if (!report) {
       throw new CompanyReportScopeError(
-        `Registry report ${registryReportId} not found`,
+        `Registry report ${registryReportId} not found`
       )
     }
 
     if (report.wikidataId && report.wikidataId !== companyWikidataId) {
       throw new CompanyReportScopeError(
-        `Registry report ${registryReportId} belongs to ${report.wikidataId}, not ${companyWikidataId}`,
+        `Registry report ${registryReportId} belongs to ${report.wikidataId}, not ${companyWikidataId}`
       )
     }
 
@@ -393,7 +391,7 @@ class CompanyReportService {
     })
     if (conflicting) {
       throw new CompanyReportScopeError(
-        `Registry report already linked to CompanyReport ${conflicting.id}`,
+        `Registry report already linked to CompanyReport ${conflicting.id}`
       )
     }
 

--- a/src/api/services/companyReportService.ts
+++ b/src/api/services/companyReportService.ts
@@ -18,11 +18,17 @@ export type ReportingPeriodIdentity = {
 
 export type PrepareCompanyReportForPeriodSaveInput = {
   bodyCompanyReportId?: string
+  registryReportId?: string
   documentReportYear?: string
   reportUrl?: string
   reportSourceUrl?: string
   reportS3Url?: string
   reportSha256?: string
+}
+
+export type EnsureCompanyReportRegistryLinkResult = {
+  registryReportId: string
+  companyReportId: string
 }
 
 export type SaveReportIdentity = {
@@ -91,6 +97,60 @@ function buildRegistryPayloadForCompanySave(
   })
 }
 
+async function reassignPeriodsToCanonicalShell(
+  companyId: string,
+  fromShellId: string,
+  toShellId: string,
+  reportingPeriods: ReportingPeriodIdentity[]
+): Promise<void> {
+  const years = reportingPeriods
+    .map((period) => {
+      if (period.year === undefined || period.year === null) return null
+      return String(period.year)
+    })
+    .filter((year): year is string => year !== null)
+
+  if (years.length === 0) return
+
+  for (const year of years) {
+    const onWrongShell = await prisma.reportingPeriod.findFirst({
+      where: { companyReportId: fromShellId, companyId, year },
+      select: { id: true },
+    })
+    if (!onWrongShell) continue
+
+    const onCanonical = await prisma.reportingPeriod.findFirst({
+      where: { companyReportId: toShellId, companyId, year },
+      select: { id: true },
+    })
+
+    if (onCanonical) {
+      await prisma.reportingPeriod.delete({ where: { id: onWrongShell.id } })
+    } else {
+      await prisma.reportingPeriod.update({
+        where: { id: onWrongShell.id },
+        data: { companyReportId: toShellId },
+      })
+    }
+  }
+
+  const wrongShell = await prisma.companyReport.findUnique({
+    where: { id: fromShellId },
+    select: {
+      registryReportId: true,
+      _count: { select: { reportingPeriods: true } },
+    },
+  })
+
+  if (
+    wrongShell &&
+    !wrongShell.registryReportId &&
+    wrongShell._count.reportingPeriods === 0
+  ) {
+    await prisma.companyReport.delete({ where: { id: fromShellId } })
+  }
+}
+
 class CompanyReportService {
   async findOrCreateCompanyReport(
     companyId: string,
@@ -151,6 +211,9 @@ class CompanyReportService {
     companyReportId: string,
     documentReportYear: string | undefined
   ): Promise<void> {
+    // TODO: After a pipeline run for a report year, keep CompanyReport and its linked Report
+    // row fully in sync (reportYear, urls, sha256, publication date). setCompanyReportYear
+    // only merges reportYear today; identity fields can drift across re-runs and manual edits.
     const incoming = documentReportYear?.trim()
     if (!incoming || !/^\d{4}$/.test(incoming)) return
 
@@ -206,6 +269,7 @@ class CompanyReportService {
     reportingPeriods: ReportingPeriodIdentity[],
     options?: {
       companyReportId?: string
+      registryReportId?: string
       reportIdentity?: SaveReportIdentity
     }
   ): Promise<{ companyReportId: string; inferred: boolean }> {
@@ -216,6 +280,15 @@ class CompanyReportService {
         company.wikidataId
       )
       return { companyReportId: explicitId, inferred: false }
+    }
+
+    const pipelineRegistryId = options?.registryReportId?.trim()
+    if (pipelineRegistryId) {
+      const companyReportId = await this.findOrCreateCompanyReport(
+        company.wikidataId,
+        pipelineRegistryId
+      )
+      return { companyReportId, inferred: true }
     }
 
     const registryPayload = buildRegistryPayloadForCompanySave(
@@ -265,6 +338,7 @@ class CompanyReportService {
       reportingPeriods,
       {
         companyReportId: input.bodyCompanyReportId,
+        registryReportId: input.registryReportId,
         reportIdentity: {
           url: input.reportUrl,
           sourceUrl: input.reportSourceUrl,
@@ -299,13 +373,18 @@ class CompanyReportService {
     company: Pick<Company, 'wikidataId' | 'name'>,
     reportingPeriods: ReportingPeriodIdentity[],
     input: PrepareCompanyReportForPeriodSaveInput
-  ): Promise<string | null> {
+  ): Promise<EnsureCompanyReportRegistryLinkResult | null> {
     const existing = await prisma.companyReport.findUnique({
       where: { id: companyReportId },
       select: { registryReportId: true, companyId: true },
     })
     if (!existing) return null
-    if (existing.registryReportId) return existing.registryReportId
+    if (existing.registryReportId) {
+      return {
+        registryReportId: existing.registryReportId,
+        companyReportId,
+      }
+    }
 
     const registryPayload = buildRegistryPayloadForCompanySave(
       company,
@@ -335,16 +414,16 @@ class CompanyReportService {
       select: { id: true },
     })
     if (alreadyLinked && alreadyLinked.id !== companyReportId) {
-      console.warn(
-        '[companyReportService] Registry report already linked to another CompanyReport',
-        {
-          companyId: existing.companyId,
-          companyReportId,
-          linkedShellId: alreadyLinked.id,
-          registryReportId: report.id,
-        }
+      await reassignPeriodsToCanonicalShell(
+        existing.companyId,
+        companyReportId,
+        alreadyLinked.id,
+        reportingPeriods
       )
-      return report.id
+      return {
+        registryReportId: report.id,
+        companyReportId: alreadyLinked.id,
+      }
     }
 
     await prisma.companyReport.update({
@@ -352,7 +431,10 @@ class CompanyReportService {
       data: { registryReportId: report.id },
     })
 
-    return report.id
+    return {
+      registryReportId: report.id,
+      companyReportId,
+    }
   }
 
   async setCompanyReportRegistryLink(

--- a/src/lib/reportSaveIdentity.ts
+++ b/src/lib/reportSaveIdentity.ts
@@ -12,6 +12,7 @@ type JobReportFields = {
   sourceUrl?: string
   pdfCache?: { publicUrl?: string; sha256?: string }
   documentReportYear?: string | number
+  registryReportId?: string
   replaceAllEmissions?: boolean
 }
 
@@ -98,6 +99,8 @@ export function buildReportingPeriodsApiBodyExtras(
   jobData: JobReportFields,
   reportingPeriods: unknown[]
 ): Record<string, unknown> {
+  // TODO(pipeline): registryReportId from checkDB is forwarded here so period save can resolve
+  // the CompanyReport shell without falling back to "latest shell for company".
   const identity = buildPipelineReportIdentity(jobData)
   const trimmedSourceUrl = trimOptional(jobData.sourceUrl)
   const documentReportYear = resolveDocumentReportYear(reportingPeriods, {
@@ -113,5 +116,8 @@ export function buildReportingPeriodsApiBodyExtras(
     reportSourceUrl: trimmedSourceUrl,
     reportS3Url: identity.reportS3Url,
     reportSha256: identity.reportSha256,
+    ...(trimOptional(jobData.registryReportId) && {
+      registryReportId: trimOptional(jobData.registryReportId),
+    }),
   }
 }

--- a/src/workers/checkDB.ts
+++ b/src/workers/checkDB.ts
@@ -8,6 +8,9 @@ import {
   extractScopeEntriesFromFollowUp,
   mergeScope1AndScope2Results,
 } from '../lib/mergeScopeResults'
+import { buildEarlyRegistryPayload } from './saveToAPI.utils'
+import { registryService } from '../api/services/registryService'
+import { companyReportService } from '../api/services/companyReportService'
 
 export class CheckDBJob extends DiscordJob {
   declare data: DiscordJob['data'] & {
@@ -117,6 +120,36 @@ const checkDB = new DiscordWorker(
       )
     }
 
+    // TODO(pipeline): Registry upsert and CompanyReport shell creation moved to checkDB;
+    // registryReportId is carried on the job through diff/save. Period save still re-resolves
+    // the shell and may reassign periods (ensureCompanyReportRegistryLink). Consider making
+    // registryReportId the single source of truth for the run instead of re-inferring at save.
+    let registryReportId: string | undefined
+    const earlyRegistryPayload = buildEarlyRegistryPayload({
+      companyName,
+      wikidata,
+      url,
+      sourceUrl,
+      pdfCache: job.data.pdfCache,
+      documentReportYear: job.data.documentReportYear,
+    })
+    if (earlyRegistryPayload) {
+      try {
+        const report =
+          await registryService.upsertReportInRegistry(earlyRegistryPayload)
+        registryReportId = report.id
+        await companyReportService.findOrCreateCompanyReport(
+          wikidataId,
+          report.id
+        )
+        job.log(`Early registry upsert: ${report.id}`)
+      } catch (error: any) {
+        job.log(
+          `Early registry upsert failed: ${error?.message ?? String(error)}`
+        )
+      }
+    }
+
     const base = {
       name: companyName,
       data: {
@@ -131,6 +164,9 @@ const checkDB = new DiscordWorker(
         autoApprove: job.data.autoApprove,
         replaceAllEmissions: job.data.replaceAllEmissions,
         batchId: job.data.batchId,
+        pdfCache: job.data.pdfCache,
+        documentReportYear: job.data.documentReportYear,
+        ...(registryReportId && { registryReportId }),
       },
       opts: {
         attempts: 3,

--- a/src/workers/checkDB.ts
+++ b/src/workers/checkDB.ts
@@ -17,6 +17,15 @@ export class CheckDBJob extends DiscordJob {
     companyName: string
     /** Original report URL when pipeline cached PDF to S3 (parsePdf). */
     sourceUrl?: string
+    /** Cached/uploaded PDF storage metadata from pipeline-api (when available). */
+    pdfCache?: {
+      publicUrl?: string
+      sha256?: string
+    }
+    /** PDF year from pipeline parse when set on the job. */
+    documentReportYear?: string | number
+    /** Registry report id from early upsert in this worker (passed to diff/save children). */
+    registryReportId?: string
     wikidata: { node: string }
     fiscalYear: {
       startMonth: number

--- a/src/workers/saveToAPI.ts
+++ b/src/workers/saveToAPI.ts
@@ -1,13 +1,7 @@
 import { DiscordJob, DiscordWorker } from '../lib/DiscordWorker'
 import { apiFetch } from '../lib/api'
 import { QUEUE_NAMES } from '../queues'
-import { registryService } from '../api/services/registryService'
-import { createServerCache } from '../createCache'
-import { invalidateRegistryCache } from '../api/services/registryCache'
-import { buildRegistryPayload } from './saveToAPI.utils'
 import { withCompanySaveLock } from '../lib/companySaveLock'
-
-const registryCache = createServerCache({ maxAge: 24 * 60 * 60 * 1000 })
 
 export interface SaveToApiJob extends DiscordJob {
   data: DiscordJob['data'] & {
@@ -121,30 +115,8 @@ export const saveToAPI = new DiscordWorker<SaveToApiJob>(
           throw new Error(`API endpoint not found: ${endpoint}`)
         }
 
-        if (apiSubEndpoint === 'reporting-periods') {
-          const registryPayload = buildRegistryPayload({
-            data: {
-              ...job.data,
-              documentReportYear:
-                job.data.documentReportYear ??
-                sanitizedBody?.documentReportYear,
-              body: sanitizedBody,
-            },
-          })
-          if (registryPayload) {
-            try {
-              await registryService.upsertReportInRegistry(registryPayload)
-              await invalidateRegistryCache(registryCache, {
-                warn: (msg: string, ...args: unknown[]) =>
-                  job.log(
-                    [msg, ...args.map((a) => JSON.stringify(a))].join(' ')
-                  ),
-              })
-            } catch (e: any) {
-              job.log(`Registry upsert failed after save: ${e?.message ?? e}`)
-            }
-          }
-        }
+        // TODO(pipeline): Registry upsert was removed here; see checkDB (early) and API period
+        // save prepare/ensure for registryReportId + CompanyReport shell resolution.
       })
 
       return { success: true }

--- a/src/workers/saveToAPI.utils.ts
+++ b/src/workers/saveToAPI.utils.ts
@@ -81,9 +81,28 @@ function resolveStorageUrl(
   )
 }
 
+function periodHasEmissionsOrEconomyData(period: any): boolean {
+  const economy = period?.economy
+  if (
+    economy &&
+    typeof economy === 'object' &&
+    Object.keys(economy).length > 0
+  ) {
+    return true
+  }
+
+  const emissions = period?.emissions
+  if (!emissions || typeof emissions !== 'object') return false
+
+  return Object.values(emissions).some(
+    (value) => value !== undefined && value !== null
+  )
+}
+
 function maxDataYearAmongPeriods(reportingPeriods: any[]): number | null {
   let max: number | null = null
   for (const period of reportingPeriods) {
+    if (!periodHasEmissionsOrEconomyData(period)) continue
     const y = Number(period?.year)
     if (!Number.isFinite(y)) continue
     max = max === null ? y : Math.max(max, y)
@@ -208,5 +227,86 @@ export function buildRegistryPayload(job: {
         : undefined,
     s3Url,
     sha256: pdfCacheSha256 ?? periodSha256,
+  }
+}
+
+export type EarlyRegistryJobData = {
+  companyName?: string
+  wikidata?: { node: string }
+  url?: string
+  sourceUrl?: string
+  pdfCache?: { publicUrl?: string; sha256?: string }
+  documentReportYear?: string | number
+}
+
+/** Registry upsert from PDF identity only (before reporting periods exist). */
+export function buildEarlyRegistryPayload(
+  jobData: EarlyRegistryJobData
+): null | {
+  companyName: string
+  wikidataId: string
+  reportYear?: string
+  url: string
+  sourceUrl?: string
+  s3Url?: string
+  sha256?: string
+} {
+  const companyName = jobData.companyName
+  if (!companyName) return null
+
+  const wikidataId = jobData.wikidata?.node?.trim() ?? ''
+  if (!isWikidataQId(wikidataId)) return null
+
+  const url = typeof jobData.url === 'string' ? jobData.url.trim() : ''
+  const sourceUrl =
+    typeof jobData.sourceUrl === 'string' ? jobData.sourceUrl.trim() : undefined
+
+  const pdfCacheSha256 = trimStr(jobData.pdfCache?.sha256) ?? undefined
+  const pdfCacheS3Url = trimStr(jobData.pdfCache?.publicUrl) ?? undefined
+
+  const sourceUrlIsHttp =
+    typeof sourceUrl === 'string' && /^https?:\/\//i.test(sourceUrl)
+  const jobS3Url =
+    url && (!sourceUrlIsHttp || url !== sourceUrl) ? url : undefined
+
+  const canonicalUrl = canonicalPublicReportUrl({ url, sourceUrl })
+  const resolvedWebUrl = resolveWebUrl(sourceUrl, canonicalUrl)
+  const resolvedStorageUrl = resolveStorageUrl(
+    undefined,
+    pdfCacheS3Url,
+    url,
+    jobS3Url
+  )
+
+  const primaryUrl = resolvedWebUrl || canonicalUrl.trim()
+  if (!primaryUrl) return null
+
+  let s3Url: string | undefined
+  if (resolvedStorageUrl) {
+    if (resolvedStorageUrl !== primaryUrl || isStorageUrl(primaryUrl)) {
+      s3Url = resolvedStorageUrl
+    }
+  } else if (isStorageUrl(primaryUrl)) {
+    s3Url = primaryUrl
+  }
+
+  return {
+    companyName,
+    wikidataId,
+    reportYear: resolveDocumentReportYear([], {
+      documentReportYear: jobData.documentReportYear,
+      reportUrl: primaryUrl,
+      sourceUrl:
+        sourceUrlIsHttp && sourceUrl && !isStorageUrl(sourceUrl)
+          ? sourceUrl
+          : undefined,
+    }),
+    url: primaryUrl,
+    sourceUrl:
+      sourceUrlIsHttp && sourceUrl && !isStorageUrl(sourceUrl)
+        ? sourceUrl
+        : undefined,
+    s3Url,
+    sha256: pdfCacheSha256,
   }
 }

--- a/tests/companyReportService.test.ts
+++ b/tests/companyReportService.test.ts
@@ -152,7 +152,7 @@ describe('companyReportService', () => {
       {
         reportUrl: 'https://example.com/sustainability-2024.pdf',
         documentReportYear: '2024',
-      },
+      }
     )
 
     expect(linked).toBe('report-1')
@@ -178,7 +178,7 @@ describe('companyReportService', () => {
     await companyReportService.setCompanyReportRegistryLink(
       'cr-1',
       'Q1',
-      'report-1',
+      'report-1'
     )
 
     expect(update).toHaveBeenCalledWith({
@@ -202,7 +202,7 @@ describe('companyReportService', () => {
           reportURL: 'https://example.com/sustainability-2024.pdf',
           year: '2024',
         },
-      ],
+      ]
     )
 
     expect(result).toEqual({ companyReportId: 'cr-new', inferred: true })

--- a/tests/companyReportService.test.ts
+++ b/tests/companyReportService.test.ts
@@ -127,6 +127,88 @@ describe('companyReportService', () => {
     expect(result).toBe('cr-default')
   })
 
+  it('ensureCompanyReportRegistryLink sets registryReportId on an unlinked shell', async () => {
+    jest.spyOn(prisma.companyReport, 'findUnique').mockResolvedValueOnce({
+      registryReportId: null,
+      companyId: 'Q1',
+    } as never)
+    jest
+      .spyOn(registryService, 'upsertReportInRegistry')
+      .mockResolvedValueOnce({ id: 'report-1' } as never)
+    jest.spyOn(prisma.companyReport, 'findFirst').mockResolvedValueOnce(null)
+    const update = jest
+      .spyOn(prisma.companyReport, 'update')
+      .mockResolvedValueOnce({} as never)
+
+    const linked = await companyReportService.ensureCompanyReportRegistryLink(
+      'cr-unlinked',
+      { wikidataId: 'Q1', name: 'Acme' },
+      [
+        {
+          reportURL: 'https://example.com/sustainability-2024.pdf',
+          year: '2024',
+        },
+      ],
+      {
+        reportUrl: 'https://example.com/sustainability-2024.pdf',
+        documentReportYear: '2024',
+      },
+    )
+
+    expect(linked).toBe('report-1')
+    expect(update).toHaveBeenCalledWith({
+      where: { id: 'cr-unlinked' },
+      data: { registryReportId: 'report-1' },
+    })
+  })
+
+  it('setCompanyReportRegistryLink updates registryReportId when report belongs to company', async () => {
+    jest.spyOn(prisma.companyReport, 'findFirst').mockResolvedValueOnce({
+      id: 'cr-1',
+    } as never)
+    jest.spyOn(prisma.report, 'findUnique').mockResolvedValueOnce({
+      id: 'report-1',
+      wikidataId: 'Q1',
+    } as never)
+    jest.spyOn(prisma.companyReport, 'findFirst').mockResolvedValueOnce(null)
+    const update = jest
+      .spyOn(prisma.companyReport, 'update')
+      .mockResolvedValueOnce({} as never)
+
+    await companyReportService.setCompanyReportRegistryLink(
+      'cr-1',
+      'Q1',
+      'report-1',
+    )
+
+    expect(update).toHaveBeenCalledWith({
+      where: { id: 'cr-1' },
+      data: { registryReportId: 'report-1' },
+    })
+  })
+
+  it('resolveCompanyReportIdForSave uses period reportURL when top-level url is missing', async () => {
+    jest
+      .spyOn(registryService, 'upsertReportInRegistry')
+      .mockResolvedValueOnce({ id: 'report-1' } as never)
+    jest
+      .spyOn(prisma.companyReport, 'upsert')
+      .mockResolvedValueOnce({ id: 'cr-new' } as never)
+
+    const result = await companyReportService.resolveCompanyReportIdForSave(
+      { wikidataId: 'Q1', name: 'Acme' },
+      [
+        {
+          reportURL: 'https://example.com/sustainability-2024.pdf',
+          year: '2024',
+        },
+      ],
+    )
+
+    expect(result).toEqual({ companyReportId: 'cr-new', inferred: true })
+    expect(registryService.upsertReportInRegistry).toHaveBeenCalled()
+  })
+
   it('companyReportIdForPeriodSave uses period override and sets year when different', async () => {
     jest.spyOn(prisma.companyReport, 'findFirst').mockResolvedValueOnce({
       id: 'cr-other',

--- a/tests/companyReportService.test.ts
+++ b/tests/companyReportService.test.ts
@@ -155,11 +155,66 @@ describe('companyReportService', () => {
       }
     )
 
-    expect(linked).toBe('report-1')
+    expect(linked).toEqual({
+      registryReportId: 'report-1',
+      companyReportId: 'cr-unlinked',
+    })
     expect(update).toHaveBeenCalledWith({
       where: { id: 'cr-unlinked' },
       data: { registryReportId: 'report-1' },
     })
+  })
+
+  it('ensureCompanyReportRegistryLink reassigns periods when registry is on another shell', async () => {
+    jest.spyOn(prisma.companyReport, 'findUnique').mockResolvedValueOnce({
+      registryReportId: null,
+      companyId: 'Q1',
+    } as never)
+    jest
+      .spyOn(registryService, 'upsertReportInRegistry')
+      .mockResolvedValueOnce({ id: 'report-1' } as never)
+    jest.spyOn(prisma.companyReport, 'findFirst').mockResolvedValueOnce({
+      id: 'cr-canonical',
+    } as never)
+    jest
+      .spyOn(prisma.reportingPeriod, 'findFirst')
+      .mockResolvedValueOnce({ id: 'period-1' } as never)
+      .mockResolvedValueOnce(null)
+    const updatePeriod = jest
+      .spyOn(prisma.reportingPeriod, 'update')
+      .mockResolvedValueOnce({} as never)
+    jest.spyOn(prisma.companyReport, 'findUnique').mockResolvedValueOnce({
+      registryReportId: null,
+      _count: { reportingPeriods: 0 },
+    } as never)
+    const deleteShell = jest
+      .spyOn(prisma.companyReport, 'delete')
+      .mockResolvedValueOnce({} as never)
+
+    const linked = await companyReportService.ensureCompanyReportRegistryLink(
+      'cr-wrong',
+      { wikidataId: 'Q1', name: 'Acme' },
+      [
+        {
+          year: '2024',
+          reportURL: 'https://example.com/sustainability-2024.pdf',
+        },
+      ],
+      {
+        reportUrl: 'https://example.com/sustainability-2024.pdf',
+        documentReportYear: '2024',
+      }
+    )
+
+    expect(linked).toEqual({
+      registryReportId: 'report-1',
+      companyReportId: 'cr-canonical',
+    })
+    expect(updatePeriod).toHaveBeenCalledWith({
+      where: { id: 'period-1' },
+      data: { companyReportId: 'cr-canonical' },
+    })
+    expect(deleteShell).toHaveBeenCalledWith({ where: { id: 'cr-wrong' } })
   })
 
   it('setCompanyReportRegistryLink updates registryReportId when report belongs to company', async () => {

--- a/tests/saveToAPI.test.ts
+++ b/tests/saveToAPI.test.ts
@@ -7,11 +7,15 @@ import type { RegistrySaveJobData } from '../src/workers/saveToAPI.utils'
 function makeJob(overrides: Partial<RegistrySaveJobData> & { url: string }): {
   data: RegistrySaveJobData
 } {
+  const defaultPeriod = {
+    year: 2024,
+    emissions: { scope1: { total: 1, unit: 'tCO2e' } },
+  }
   return {
     data: {
       wikidata: { node: 'Q123' },
       companyName: 'Acme Corp',
-      body: { reportingPeriods: [{ year: 2024 }] },
+      body: { reportingPeriods: [defaultPeriod] },
       ...overrides,
     },
   }
@@ -111,21 +115,47 @@ describe('buildRegistryPayload', () => {
 
   // ── reportYear derived from period ──────────────────────────────────────────
 
-  it('uses max data year among periods when no explicit documentReportYear', () => {
+  it('uses max emissions/economy year among periods when no explicit documentReportYear', () => {
     const result = buildRegistryPayload(
       makeJob({
         url: 'https://company.com/report',
-        body: { reportingPeriods: [{ year: 2022 }, { year: 2024 }] },
+        body: {
+          reportingPeriods: [
+            { year: 2022, emissions: { scope1: { total: 1, unit: 'tCO2e' } } },
+            { year: 2024, emissions: { scope1: { total: 1, unit: 'tCO2e' } } },
+          ],
+        },
       })
     )
     expect(result!.reportYear).toBe('2024')
   })
 
-  it('falls back to max year when chosen period has no year', () => {
+  it('ignores periods without emissions or economy when deriving report year', () => {
     const result = buildRegistryPayload(
       makeJob({
         url: 'https://company.com/report',
-        body: { reportingPeriods: [{}, { year: 2023 }, { year: 2024 }] },
+        body: {
+          reportingPeriods: [
+            { year: 2025, emissions: { scope1: { total: 1, unit: 'tCO2e' } } },
+            { year: 2026 },
+          ],
+        },
+      })
+    )
+    expect(result!.reportYear).toBe('2025')
+  })
+
+  it('falls back to max emissions year when chosen period has no year', () => {
+    const result = buildRegistryPayload(
+      makeJob({
+        url: 'https://company.com/report',
+        body: {
+          reportingPeriods: [
+            {},
+            { year: 2023, emissions: { scope1: { total: 1, unit: 'tCO2e' } } },
+            { year: 2024, emissions: { scope1: { total: 1, unit: 'tCO2e' } } },
+          ],
+        },
       })
     )
     expect(result!.reportYear).toBe('2024')
@@ -178,21 +208,36 @@ describe('resolveDocumentReportYear', () => {
     ).toBe('2025')
   })
 
-  it('falls back to max data year among periods', () => {
+  it('falls back to max emissions/economy year among periods', () => {
     expect(
       resolveDocumentReportYear([
-        { year: 2023 },
-        { year: 2025 },
-        { year: 2024 },
+        { year: 2023, emissions: { scope1: { total: 1 } } },
+        { year: 2025, emissions: { scope1: { total: 1 } } },
+        { year: 2024, economy: { turnover: { value: 1 } } },
       ])
     ).toBe('2025')
   })
 
-  it('prefers max data year over a misleading year in the report URL', () => {
+  it('ignores periods with only a year and no emissions or economy data', () => {
     expect(
-      resolveDocumentReportYear([{ year: 2023 }, { year: 2024 }], {
-        reportUrl: 'https://company.com/annual-report-2017.pdf',
-      })
+      resolveDocumentReportYear([
+        { year: 2025, emissions: { scope1: { total: 1 } } },
+        { year: 2026 },
+      ])
+    ).toBe('2025')
+  })
+
+  it('prefers max emissions year over a misleading year in the report URL', () => {
+    expect(
+      resolveDocumentReportYear(
+        [
+          { year: 2023, emissions: { scope1: { total: 1 } } },
+          { year: 2024, emissions: { scope1: { total: 1 } } },
+        ],
+        {
+          reportUrl: 'https://company.com/annual-report-2017.pdf',
+        }
+      )
     ).toBe('2024')
   })
 


### PR DESCRIPTION
### ✨ What’s Changed?

## Problem

Pipeline saves could leave **CompanyReport** shells unlinked from the **Report** registry, pick the wrong shell (fallback to “latest CompanyReport”), or set **wrong document years** (e.g. 2026 on a 2025 PDF when target/comparison years appeared in the payload). Validate needed staff APIs to inspect and fix shells manually.

## Data model (unchanged)

```
ReportingPeriod.companyReportId → CompanyReport.registryReportId → Report (registry)
```

Periods connect via **companyReportId** only. **registryReportId** is on the shell and on the registry row—not on each period.

---

## Garbo (pipeline workers + internal API)

### Registry earlier in the pipeline (`checkDB`)

- After company exists, **upsert Report** from PDF identity (`buildEarlyRegistryPayload`) and **find/create CompanyReport** shell.
- Pass `registryReportId`, `pdfCache`, and `documentReportYear` on job data to diff/save children (previously `pdfCache` was dropped at this step).

**Why:** Shell and registry row exist before period save, so prepare does not fall back to “latest CompanyReport for company” as often.

### Remove duplicate registry upsert (`saveToAPI` worker)

- Post-save `registryService.upsertReportInRegistry` removed from the worker.
- Registry is handled in **checkDB** (early) and **period-save API** (`prepare` / `ensureCompanyReportRegistryLink`).

**Why:** Same upsert ran twice; API save already links registry and shell.

### Period save: shell resolution + linking (`companyReportService`)

- **`prepareCompanyReportForPeriodSave`**: optional top-level `registryReportId` (from pipeline) resolves shell before URL inference; sets `reportYear` on shell (+ linked Report when linked).
- **`ensureCompanyReportRegistryLink`**: if registry already belongs to another shell, **reassign periods** to the canonical shell (or drop duplicates), delete empty orphan shells; returns canonical `companyReportId` + `registryReportId`.
- **`resolveDocumentReportYear`**: max data year uses **emissions/economy periods only**—not bare `{ year: 2026 }` rows without data.

### POST `reporting-periods` body

- Optional top-level **`registryReportId`** (pipeline hint for this run—not on `reportingPeriodSchema`).
- Response includes resolved `companyReportId` and `registryReportId`.

### TODOs left in code

- Pipeline: `registryReportId` as single source of truth end-to-end (see `checkDB`, `reportSaveIdentity`, `saveToAPI`).
- Post-run sync of **CompanyReport** and **Report** identity fields beyond `reportYear`.


### 📋 Checklist

- [x] PR title starts with `[#issue-number]`; if no issue is applicable use: `[fix]`, `[feat]`, `[ops]`, or `[prod]`
- [x] I’ve added/updated tests (or noted why they’re not needed)
- [ ] I’ve verified the change runs locally (and in Docker/k8s if relevant)
- [x] If this changes the API contract, I’ve called that out clearly (and considered backward compatibility)
- [x] If this includes a DB change, I’ve included a migration + rollout/rollback notes
- [ ] I’ve considered observability (logs/metrics/traces) and added what’s needed
- [x] I’ve set labels, linked issue, and milestone (if applicable)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->
