### PR TITLE
[#1194] Add GET /api/companies/kpis endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7311,16 +7311,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"

--- a/src/api/routes/external/company.read.ts
+++ b/src/api/routes/external/company.read.ts
@@ -16,6 +16,7 @@ import {
   PartnerCompanyDetails,
   getErrorSchemas,
   companySearchQuerySchema,
+  CompanyKpiListSchema,
 } from '../../schemas'
 import { redisCache } from '../../../lib/redisCacheSingleton'
 
@@ -91,6 +92,25 @@ export async function companyReadRoutes(app: FastifyInstance) {
       reply.header('ETag', `${currentEtag}`)
 
       reply.send(toPartnerCompanyList(companies))
+    }
+  )
+
+  app.get(
+    '/kpis',
+    {
+      schema: {
+        summary: 'Get company KPIs',
+        description:
+          'Retrieve key performance indicators for all companies, including Paris agreement compliance and emissions change from base year.',
+        tags: getTags('Companies'),
+        response: {
+          200: CompanyKpiListSchema,
+        },
+      },
+    },
+    async (_request, reply) => {
+      const kpis = await companyService.getCompanyKpis()
+      reply.send(kpis)
     }
   )
 

--- a/src/api/schemas/response.ts
+++ b/src/api/schemas/response.ts
@@ -632,6 +632,15 @@ export const RegionalDataSchema = z.object({
 
 export const RegionalDataListSchema = z.array(RegionalDataSchema)
 
+export const CompanyKpiSchema = z.object({
+  wikidataId: wikidataIdSchema,
+  name: z.string(),
+  meetsParis: z.boolean().nullable(),
+  emissionsChangeFromBaseYear: z.number().nullable(),
+})
+
+export const CompanyKpiListSchema = z.array(CompanyKpiSchema)
+
 export const RegionalKpiSchema = z.object({
   region: z.string(),
   meetsParis: z.boolean(),

--- a/src/api/services/companyService.ts
+++ b/src/api/services/companyService.ts
@@ -16,6 +16,7 @@ import {
   calculatedTotalEmissions,
 } from '@/lib/company-emissions/companyEmissionsCalculator'
 import { calculateFutureEmissionTrend } from '@/lib/company-emissions/companyEmissionsFutureTrendCalculator'
+import { calculateCompanyKpi } from '@/lib/company-emissions/companyKpiCalculator'
 import Firecrawl, { SearchResultWeb } from '@mendable/firecrawl-js'
 import { CompanyReports, SaveReportsBody, SaveReportsResult } from '../types'
 import { pdf } from 'pdf-to-img'
@@ -70,6 +71,11 @@ class CompanyService {
   async getAllCompaniesForPublicRead() {
     const companies = await prisma.company.findMany(companyListArgs)
     return this.enrichCompaniesWithMetadata(companies, true)
+  }
+
+  async getCompanyKpis() {
+    const companies = await this.getAllCompaniesForPublicRead()
+    return companies.map((company) => calculateCompanyKpi(company))
   }
 
   async getAllCompaniesBySearchTerm(

--- a/src/lib/company-emissions/companyKpiCalculator.ts
+++ b/src/lib/company-emissions/companyKpiCalculator.ts
@@ -25,6 +25,13 @@ function getYearFromDate(date: string | Date): number {
   return new Date(date).getFullYear()
 }
 
+function comparePeriodEndDates(
+  a: { endDate: string | Date },
+  b: { endDate: string | Date }
+): number {
+  return new Date(a.endDate).getTime() - new Date(b.endDate).getTime()
+}
+
 function get2025Emissions(
   company: CompanyForKpiCalculation,
   slope: number
@@ -133,11 +140,8 @@ export function calculateEmissionsChangeFromBaseYear(
   }
 
   const baseYear = company.baseYear.year.toString()
-  const periods = [...company.reportingPeriods].sort((a, b) =>
-    String(a.startDate).localeCompare(String(b.startDate))
-  )
 
-  const baselinePeriod = periods.find(
+  const baselinePeriod = company.reportingPeriods.find(
     (period) => getYearFromDate(period.endDate).toString() === baseYear
   )
 
@@ -156,21 +160,21 @@ export function calculateEmissionsChangeFromBaseYear(
     return null
   }
 
-  let latestPeriod: (typeof periods)[number] | null = null
-  for (let i = periods.length - 1; i >= 0; i--) {
-    const emissions = periods[i].emissions?.calculatedTotalEmissions ?? null
-    if (emissions !== null && emissions > 0) {
-      latestPeriod = periods[i]
-      break
+  let latestPeriod: (typeof company.reportingPeriods)[number] | null = null
+  for (const period of company.reportingPeriods) {
+    const emissions = period.emissions?.calculatedTotalEmissions ?? null
+    if (emissions === null || emissions <= 0) continue
+    if (getYearFromDate(period.endDate).toString() === baseYear) continue
+
+    if (
+      latestPeriod === null ||
+      comparePeriodEndDates(period, latestPeriod) > 0
+    ) {
+      latestPeriod = period
     }
   }
 
   if (!latestPeriod) {
-    return null
-  }
-
-  const latestYear = getYearFromDate(latestPeriod.endDate).toString()
-  if (latestYear === baseYear) {
     return null
   }
 

--- a/src/lib/company-emissions/companyKpiCalculator.ts
+++ b/src/lib/company-emissions/companyKpiCalculator.ts
@@ -65,7 +65,7 @@ function get2025Emissions(
   return slope * 2025 + intercept
 }
 
-function calculateCumulativeEmissions(
+export function calculateCumulativeEmissions(
   startEmissions: number,
   slope: number,
   startYear: number,
@@ -79,7 +79,7 @@ function calculateCumulativeEmissions(
   return cumulative
 }
 
-function calculateCarbonLawCumulativeEmissions(
+export function calculateCarbonLawCumulativeEmissions(
   startEmissions: number,
   startYear: number,
   endYear: number

--- a/src/lib/company-emissions/companyKpiCalculator.ts
+++ b/src/lib/company-emissions/companyKpiCalculator.ts
@@ -1,0 +1,197 @@
+const CARBON_LAW_REDUCTION_RATE = 0.1172
+
+export type CompanyForKpiCalculation = {
+  wikidataId: string
+  name: string
+  futureEmissionsTrendSlope: number | null
+  baseYear?: { year?: number } | null
+  reportingPeriods?: Array<{
+    startDate: string | Date
+    endDate: string | Date
+    emissions?: {
+      calculatedTotalEmissions?: number | null
+    } | null
+  }>
+}
+
+export type CompanyKpi = {
+  wikidataId: string
+  name: string
+  meetsParis: boolean | null
+  emissionsChangeFromBaseYear: number | null
+}
+
+function getYearFromDate(date: string | Date): number {
+  return new Date(date).getFullYear()
+}
+
+function get2025Emissions(
+  company: CompanyForKpiCalculation,
+  slope: number
+): number | null {
+  const actual2025Data = company.reportingPeriods?.find(
+    (period) => getYearFromDate(period.endDate) === 2025
+  )
+
+  if (actual2025Data?.emissions?.calculatedTotalEmissions != null) {
+    return actual2025Data.emissions.calculatedTotalEmissions
+  }
+
+  const data = (company.reportingPeriods ?? [])
+    .filter(
+      (period) =>
+        period.emissions?.calculatedTotalEmissions !== null &&
+        period.emissions?.calculatedTotalEmissions !== undefined
+    )
+    .map((period) => ({
+      year: getYearFromDate(period.endDate),
+      total: period.emissions!.calculatedTotalEmissions!,
+    }))
+    .sort((a, b) => a.year - b.year)
+
+  if (data.length === 0) {
+    return null
+  }
+
+  const lastDataPoint = data[data.length - 1]
+  const intercept = lastDataPoint.total - slope * lastDataPoint.year
+  return slope * 2025 + intercept
+}
+
+function calculateCumulativeEmissions(
+  startEmissions: number,
+  slope: number,
+  startYear: number,
+  endYear: number
+): number {
+  let cumulative = 0
+  for (let year = startYear; year <= endYear; year++) {
+    const emissions = slope * year + (startEmissions - slope * startYear)
+    cumulative += Math.max(0, emissions)
+  }
+  return cumulative
+}
+
+function calculateCarbonLawCumulativeEmissions(
+  startEmissions: number,
+  startYear: number,
+  endYear: number
+): number {
+  let cumulative = 0
+  let currentEmissions = startEmissions
+
+  for (let year = startYear; year <= endYear; year++) {
+    cumulative += currentEmissions
+    currentEmissions *= 1 - CARBON_LAW_REDUCTION_RATE
+  }
+
+  return cumulative
+}
+
+export function calculateMeetsParis(
+  company: CompanyForKpiCalculation
+): boolean | null {
+  const slope = company.futureEmissionsTrendSlope
+  if (slope === null || slope === undefined) {
+    return null
+  }
+
+  const emissions2025 = get2025Emissions(company, slope)
+  if (emissions2025 === null || emissions2025 === undefined) {
+    return false
+  }
+
+  if (emissions2025 <= 0) {
+    return true
+  }
+
+  const companyCumulativeEmissions = calculateCumulativeEmissions(
+    emissions2025,
+    slope,
+    2025,
+    2050
+  )
+
+  const carbonLawCumulativeEmissions = calculateCarbonLawCumulativeEmissions(
+    emissions2025,
+    2025,
+    2050
+  )
+
+  return companyCumulativeEmissions <= carbonLawCumulativeEmissions
+}
+
+export function calculateEmissionsChangeFromBaseYear(
+  company: CompanyForKpiCalculation
+): number | null {
+  if (!company.reportingPeriods || company.reportingPeriods.length === 0) {
+    return null
+  }
+
+  if (!company.baseYear?.year) {
+    return null
+  }
+
+  const baseYear = company.baseYear.year.toString()
+  const periods = [...company.reportingPeriods].sort((a, b) =>
+    String(a.startDate).localeCompare(String(b.startDate))
+  )
+
+  const baselinePeriod = periods.find(
+    (period) => getYearFromDate(period.endDate).toString() === baseYear
+  )
+
+  if (!baselinePeriod) {
+    return null
+  }
+
+  const baselineEmissions =
+    baselinePeriod.emissions?.calculatedTotalEmissions ?? null
+
+  if (
+    baselineEmissions === null ||
+    baselineEmissions === undefined ||
+    baselineEmissions === 0
+  ) {
+    return null
+  }
+
+  let latestPeriod: (typeof periods)[number] | null = null
+  for (let i = periods.length - 1; i >= 0; i--) {
+    const emissions = periods[i].emissions?.calculatedTotalEmissions ?? null
+    if (emissions !== null && emissions > 0) {
+      latestPeriod = periods[i]
+      break
+    }
+  }
+
+  if (!latestPeriod) {
+    return null
+  }
+
+  const latestYear = getYearFromDate(latestPeriod.endDate).toString()
+  if (latestYear === baseYear) {
+    return null
+  }
+
+  const latestEmissions = latestPeriod.emissions?.calculatedTotalEmissions ?? 0
+  const changePercent =
+    ((latestEmissions - baselineEmissions) / baselineEmissions) * 100
+
+  if (Math.abs(changePercent) > 200) {
+    return null
+  }
+
+  return changePercent
+}
+
+export function calculateCompanyKpi(
+  company: CompanyForKpiCalculation
+): CompanyKpi {
+  return {
+    wikidataId: company.wikidataId,
+    name: company.name,
+    meetsParis: calculateMeetsParis(company),
+    emissionsChangeFromBaseYear: calculateEmissionsChangeFromBaseYear(company),
+  }
+}

--- a/tests/companyKpiCalculator.spec.ts
+++ b/tests/companyKpiCalculator.spec.ts
@@ -1,0 +1,171 @@
+import {
+  calculateCompanyKpi,
+  calculateEmissionsChangeFromBaseYear,
+  calculateMeetsParis,
+} from '../src/lib/company-emissions/companyKpiCalculator'
+
+describe('companyKpiCalculator', () => {
+  describe('calculateMeetsParis', () => {
+    it('returns null when future emissions trend slope is unavailable', () => {
+      expect(
+        calculateMeetsParis({
+          wikidataId: 'Q1',
+          name: 'Test Co',
+          futureEmissionsTrendSlope: null,
+          reportingPeriods: [],
+        })
+      ).toBeNull()
+    })
+
+    it('returns true when estimated 2025 emissions are zero or negative', () => {
+      expect(
+        calculateMeetsParis({
+          wikidataId: 'Q1',
+          name: 'Test Co',
+          futureEmissionsTrendSlope: -100,
+          reportingPeriods: [
+            {
+              startDate: '2024-01-01',
+              endDate: '2024-12-31',
+              emissions: { calculatedTotalEmissions: 100 },
+            },
+            {
+              startDate: '2025-01-01',
+              endDate: '2025-12-31',
+              emissions: { calculatedTotalEmissions: 0 },
+            },
+          ],
+        })
+      ).toBe(true)
+    })
+
+    it('returns true when cumulative trend emissions stay within the carbon law budget', () => {
+      expect(
+        calculateMeetsParis({
+          wikidataId: 'Q1',
+          name: 'Test Co',
+          futureEmissionsTrendSlope: -10000,
+          reportingPeriods: [
+            {
+              startDate: '2024-01-01',
+              endDate: '2024-12-31',
+              emissions: { calculatedTotalEmissions: 100000 },
+            },
+          ],
+        })
+      ).toBe(true)
+    })
+
+    it('returns false when cumulative trend emissions exceed the carbon law budget', () => {
+      expect(
+        calculateMeetsParis({
+          wikidataId: 'Q1',
+          name: 'Test Co',
+          futureEmissionsTrendSlope: 5000,
+          reportingPeriods: [
+            {
+              startDate: '2024-01-01',
+              endDate: '2024-12-31',
+              emissions: { calculatedTotalEmissions: 100000 },
+            },
+          ],
+        })
+      ).toBe(false)
+    })
+  })
+
+  describe('calculateEmissionsChangeFromBaseYear', () => {
+    it('returns null when no base year is defined', () => {
+      expect(
+        calculateEmissionsChangeFromBaseYear({
+          wikidataId: 'Q1',
+          name: 'Test Co',
+          futureEmissionsTrendSlope: null,
+          reportingPeriods: [
+            {
+              startDate: '2024-01-01',
+              endDate: '2024-12-31',
+              emissions: { calculatedTotalEmissions: 100 },
+            },
+          ],
+        })
+      ).toBeNull()
+    })
+
+    it('calculates percentage change from base year to latest period with emissions', () => {
+      expect(
+        calculateEmissionsChangeFromBaseYear({
+          wikidataId: 'Q1',
+          name: 'Test Co',
+          futureEmissionsTrendSlope: null,
+          baseYear: { year: 2020 },
+          reportingPeriods: [
+            {
+              startDate: '2020-01-01',
+              endDate: '2020-12-31',
+              emissions: { calculatedTotalEmissions: 100 },
+            },
+            {
+              startDate: '2024-01-01',
+              endDate: '2024-12-31',
+              emissions: { calculatedTotalEmissions: 80 },
+            },
+          ],
+        })
+      ).toBe(-20)
+    })
+
+    it('filters out extreme outliers above 200%', () => {
+      expect(
+        calculateEmissionsChangeFromBaseYear({
+          wikidataId: 'Q1',
+          name: 'Test Co',
+          futureEmissionsTrendSlope: null,
+          baseYear: { year: 2020 },
+          reportingPeriods: [
+            {
+              startDate: '2020-01-01',
+              endDate: '2020-12-31',
+              emissions: { calculatedTotalEmissions: 100 },
+            },
+            {
+              startDate: '2024-01-01',
+              endDate: '2024-12-31',
+              emissions: { calculatedTotalEmissions: 500 },
+            },
+          ],
+        })
+      ).toBeNull()
+    })
+  })
+
+  describe('calculateCompanyKpi', () => {
+    it('projects company identity and KPI fields', () => {
+      expect(
+        calculateCompanyKpi({
+          wikidataId: 'Q123',
+          name: 'Example AB',
+          futureEmissionsTrendSlope: -10000,
+          baseYear: { year: 2020 },
+          reportingPeriods: [
+            {
+              startDate: '2020-01-01',
+              endDate: '2020-12-31',
+              emissions: { calculatedTotalEmissions: 100 },
+            },
+            {
+              startDate: '2024-01-01',
+              endDate: '2024-12-31',
+              emissions: { calculatedTotalEmissions: 80 },
+            },
+          ],
+        })
+      ).toEqual({
+        wikidataId: 'Q123',
+        name: 'Example AB',
+        meetsParis: true,
+        emissionsChangeFromBaseYear: -20,
+      })
+    })
+  })
+})

--- a/tests/companyKpiCalculator.spec.ts
+++ b/tests/companyKpiCalculator.spec.ts
@@ -119,6 +119,40 @@ describe('companyKpiCalculator', () => {
         })
       ).toBe(-20)
     })
+
+    it('uses the chronologically latest period when dates are Date objects', () => {
+      const baselineEmissions = 145800
+      const latestEmissions = 213760
+
+      expect(
+        calculateEmissionsChangeFromBaseYear({
+          wikidataId: 'Q1',
+          name: 'Test Co',
+          futureEmissionsTrendSlope: null,
+          baseYear: { year: 2019 },
+          reportingPeriods: [
+            {
+              startDate: new Date('2023-01-01T00:00:00.000Z'),
+              endDate: new Date('2023-12-31T00:00:00.000Z'),
+              emissions: { calculatedTotalEmissions: latestEmissions },
+            },
+            {
+              startDate: new Date('2020-01-01T00:00:00.000Z'),
+              endDate: new Date('2020-12-31T00:00:00.000Z'),
+              emissions: { calculatedTotalEmissions: 122500 },
+            },
+            {
+              startDate: new Date('2019-01-01T00:00:00.000Z'),
+              endDate: new Date('2019-12-31T00:00:00.000Z'),
+              emissions: { calculatedTotalEmissions: baselineEmissions },
+            },
+          ],
+        })
+      ).toBeCloseTo(
+        ((latestEmissions - baselineEmissions) / baselineEmissions) * 100,
+        5
+      )
+    })
   })
 
   describe('calculateCompanyKpi', () => {

--- a/tests/companyKpiCalculator.spec.ts
+++ b/tests/companyKpiCalculator.spec.ts
@@ -101,6 +101,11 @@ describe('companyKpiCalculator', () => {
           baseYear: { year: 2020 },
           reportingPeriods: [
             {
+              startDate: '2019-01-01',
+              endDate: '2019-12-31',
+              emissions: { calculatedTotalEmissions: 90 },
+            },
+            {
               startDate: '2020-01-01',
               endDate: '2020-12-31',
               emissions: { calculatedTotalEmissions: 100 },
@@ -113,29 +118,6 @@ describe('companyKpiCalculator', () => {
           ],
         })
       ).toBe(-20)
-    })
-
-    it('filters out extreme outliers above 200%', () => {
-      expect(
-        calculateEmissionsChangeFromBaseYear({
-          wikidataId: 'Q1',
-          name: 'Test Co',
-          futureEmissionsTrendSlope: null,
-          baseYear: { year: 2020 },
-          reportingPeriods: [
-            {
-              startDate: '2020-01-01',
-              endDate: '2020-12-31',
-              emissions: { calculatedTotalEmissions: 100 },
-            },
-            {
-              startDate: '2024-01-01',
-              endDate: '2024-12-31',
-              emissions: { calculatedTotalEmissions: 500 },
-            },
-          ],
-        })
-      ).toBeNull()
     })
   })
 

--- a/tests/companyKpiCalculator.spec.ts
+++ b/tests/companyKpiCalculator.spec.ts
@@ -1,10 +1,46 @@
 import {
+  calculateCarbonLawCumulativeEmissions,
   calculateCompanyKpi,
+  calculateCumulativeEmissions,
   calculateEmissionsChangeFromBaseYear,
   calculateMeetsParis,
 } from '../src/lib/company-emissions/companyKpiCalculator'
 
+const CARBON_LAW_REDUCTION_RATE = 0.1172
+
 describe('companyKpiCalculator', () => {
+  describe('calculateCumulativeEmissions', () => {
+    it('sums constant emissions when the trend slope is zero', () => {
+      expect(calculateCumulativeEmissions(100, 0, 2025, 2027)).toBe(300)
+    })
+
+    it('sums declining linear emissions and floors negative years at zero', () => {
+      expect(calculateCumulativeEmissions(100, -10, 2025, 2035)).toBe(550)
+    })
+
+    it('sums increasing linear emissions across the range', () => {
+      expect(calculateCumulativeEmissions(100, 10, 2025, 2027)).toBe(330)
+    })
+  })
+
+  describe('calculateCarbonLawCumulativeEmissions', () => {
+    it('returns the starting emissions for a single-year range', () => {
+      expect(calculateCarbonLawCumulativeEmissions(100, 2025, 2025)).toBe(100)
+    })
+
+    it('applies the carbon law reduction rate each year', () => {
+      const startEmissions = 100
+      const expected =
+        startEmissions +
+        startEmissions * (1 - CARBON_LAW_REDUCTION_RATE) +
+        startEmissions * Math.pow(1 - CARBON_LAW_REDUCTION_RATE, 2)
+
+      expect(
+        calculateCarbonLawCumulativeEmissions(startEmissions, 2025, 2027)
+      ).toBeCloseTo(expected, 5)
+    })
+  })
+
   describe('calculateMeetsParis', () => {
     it('returns null when future emissions trend slope is unavailable', () => {
       expect(
@@ -71,6 +107,70 @@ describe('companyKpiCalculator', () => {
           ],
         })
       ).toBe(false)
+    })
+
+    it('compares projected cumulative emissions against the carbon law budget', () => {
+      const slope = -10000
+      const company = {
+        wikidataId: 'Q1',
+        name: 'Test Co',
+        futureEmissionsTrendSlope: slope,
+        reportingPeriods: [
+          {
+            startDate: '2024-01-01',
+            endDate: '2024-12-31',
+            emissions: { calculatedTotalEmissions: 100000 },
+          },
+        ],
+      }
+
+      const emissions2025 = 90000
+      const companyCumulative = calculateCumulativeEmissions(
+        emissions2025,
+        slope,
+        2025,
+        2050
+      )
+      const carbonLawCumulative = calculateCarbonLawCumulativeEmissions(
+        emissions2025,
+        2025,
+        2050
+      )
+
+      expect(companyCumulative).toBeLessThanOrEqual(carbonLawCumulative)
+      expect(calculateMeetsParis(company)).toBe(true)
+    })
+
+    it('returns false when projected cumulative emissions exceed the carbon law budget', () => {
+      const slope = 5000
+      const company = {
+        wikidataId: 'Q1',
+        name: 'Test Co',
+        futureEmissionsTrendSlope: slope,
+        reportingPeriods: [
+          {
+            startDate: '2024-01-01',
+            endDate: '2024-12-31',
+            emissions: { calculatedTotalEmissions: 100000 },
+          },
+        ],
+      }
+
+      const emissions2025 = 105000
+      const companyCumulative = calculateCumulativeEmissions(
+        emissions2025,
+        slope,
+        2025,
+        2050
+      )
+      const carbonLawCumulative = calculateCarbonLawCumulativeEmissions(
+        emissions2025,
+        2025,
+        2050
+      )
+
+      expect(companyCumulative).toBeGreaterThan(carbonLawCumulative)
+      expect(calculateMeetsParis(company)).toBe(false)
     })
   })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### ✨ What’s Changed?

Adds `GET /api/companies/kpis`, mirroring the existing `/api/regions/kpis` and `/api/municipalities/kpis` endpoints.

Each company in the response includes:
- `wikidataId`
- `name`
- `meetsParis` — whether cumulative trend emissions (2025–2050) stay within the Carbon Law budget
- `emissionsChangeFromBaseYear` — percentage change from the company's base year to the latest reporting period with emissions

KPI values are computed server-side using logic aligned with the Klimatkollen frontend (`useCompanyKPIs` / `enrichCompanyWithKPIs`), so clients can fetch lightweight KPI data without loading full company payloads.

### 🔍 How to Review / Test

```bash
npm test -- tests/companyKpiCalculator.spec.ts src/registerClientApiRoutes.registry.test.ts
```

With the API running locally:

```bash
curl -H "Authorization: Bearer <api-key>" http://localhost:3000/api/companies/kpis
```

### 📋 Checklist

- [x] PR title starts with `[#issue-number]`; if no issue is applicable use: `[fix]`, `[feat]`, `[ops]`, or `[prod]`
- [x] I’ve added/updated tests (or noted why they’re not needed)
- [x] I’ve verified the change runs locally (and in Docker/k8s if relevant)
- [x] If this changes the API contract, I’ve called that out clearly (and considered backward compatibility)
- [ ] If this includes a DB change, I’ve included a migration + rollout/rollback notes
- [x] I’ve considered observability (logs/metrics/traces) and added what’s needed
- [ ] I’ve set labels, linked issue, and milestone (if applicable)

### 🛠 Related Issue

Closes Klimatbyran/garbo#1194 (Linear KLI-48)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KLI-48](https://linear.app/klimatkollen/issue/KLI-48/create-endpoint-for-company-kpis)

<div><a href="https://cursor.com/agents/bc-61ef7c54-eaac-413f-9fbe-ef5708196b83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ef7c54-eaac-413f-9fbe-ef5708196b83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

