### PR TITLE
[#1267] Improve error handling on LEI worker

### DIFF
--- a/src/prompts/lei.ts
+++ b/src/prompts/lei.ts
@@ -19,3 +19,32 @@ export const leiSchema = z.object({
 })
 
 export type LEI = z.infer<typeof leiSchema>['lei']
+
+export type ParseLeiLlmResponseResult =
+  | { success: true; data: z.infer<typeof leiSchema> }
+  | { success: false; error: string }
+
+export function parseLeiLlmResponse(
+  response: string
+): ParseLeiLlmResponseResult {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(response)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      success: false,
+      error: `Invalid JSON response: ${message}`,
+    }
+  }
+
+  const result = leiSchema.safeParse(parsed)
+  if (!result.success) {
+    return {
+      success: false,
+      error: result.error.message,
+    }
+  }
+
+  return { success: true, data: result.data }
+}

--- a/src/workers/extractLEI.ts
+++ b/src/workers/extractLEI.ts
@@ -3,7 +3,7 @@ import { PipelineJob, PipelineWorker } from '../lib/PipelineWorker'
 import { QUEUE_NAMES } from '../queues'
 import { getLEINumbersFromGLEIF } from '../lib/gleif'
 import { ask } from '../lib/openai'
-import { leiPrompt, leiSchema } from '../prompts/lei'
+import { leiPrompt, leiSchema, parseLeiLlmResponse } from '../prompts/lei'
 import { zodResponseFormat } from 'openai/helpers/zod'
 import { ChatCompletionMessageParam } from 'openai/resources'
 import { getLEINumber } from '@/lib/wikidata/read'
@@ -35,40 +35,53 @@ const extractLEI = new PipelineWorker<LEIJob>(
         job.log(`❌ Could not find a valid LEI for '${companyName}' in GLEIF.`)
         return { lei: undefined, wikidataId: wikidataId }
       } else {
-        const response = await ask(
-          [
-            {
-              role: 'system',
-              content: `I have a company named ${companyName} and I am looking for the wikidata entry related to this company. Be helpful and try to be accurate.`,
-            },
-            { role: 'user', content: leiPrompt },
-            {
-              role: 'assistant',
-              content: 'OK. Just send me the wikidata search results?',
-            },
-            {
-              role: 'user',
-              content: JSON.stringify(searchResults, null, 2),
-            },
-            Array.isArray(job.stacktrace)
-              ? { role: 'user', content: job.stacktrace.join('\n') }
-              : undefined,
-          ].filter(
-            (m) => m && m.content?.length > 0
-          ) as ChatCompletionMessageParam[],
-          { response_format: zodResponseFormat(leiSchema, 'lei') }
-        )
+        let response: string
+        try {
+          response = await ask(
+            [
+              {
+                role: 'system',
+                content: `I have a company named ${companyName} and I am looking for the wikidata entry related to this company. Be helpful and try to be accurate.`,
+              },
+              { role: 'user', content: leiPrompt },
+              {
+                role: 'assistant',
+                content: 'OK. Just send me the wikidata search results?',
+              },
+              {
+                role: 'user',
+                content: JSON.stringify(searchResults, null, 2),
+              },
+              Array.isArray(job.stacktrace)
+                ? { role: 'user', content: job.stacktrace.join('\n') }
+                : undefined,
+            ].filter(
+              (m) => m && m.content?.length > 0
+            ) as ChatCompletionMessageParam[],
+            { response_format: zodResponseFormat(leiSchema, 'lei') }
+          )
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          job.log(`❌ LLM request failed for '${companyName}': ${message}`)
+          await job.sendMessage(
+            `❌ Failed to look up LEI for ${companyName}: ${message}`
+          )
+          return { lei: undefined, wikidataId: wikidataId }
+        }
 
         job.log('Response: ' + response)
 
-        const { success, error, data } = leiSchema.safeParse(
-          JSON.parse(response)
-        )
-
-        if (error || !success) {
-          job.log('Failed to parse GLEIF response: ' + error.message)
+        const parsed = parseLeiLlmResponse(response)
+        if (!parsed.success) {
+          job.log(`Failed to parse GLEIF response: ${parsed.error}`)
+          job.log(`Raw response: ${response}`)
+          await job.sendMessage(
+            `❌ Could not parse LEI selection for ${companyName}. The AI service returned an unexpected response.`
+          )
+          return { lei: undefined, wikidataId: wikidataId }
         }
-        return { lei: data?.lei, wikidataId: wikidataId }
+
+        return { lei: parsed.data.lei, wikidataId: wikidataId }
       }
     }
     job.log(`✅ Found LEI for '${companyName}': ${lei}`)

--- a/tests/parseLeiLlmResponse.test.ts
+++ b/tests/parseLeiLlmResponse.test.ts
@@ -1,0 +1,40 @@
+import { parseLeiLlmResponse } from '../src/prompts/lei'
+
+describe('parseLeiLlmResponse', () => {
+  it('parses valid LEI JSON', () => {
+    const result = parseLeiLlmResponse(
+      JSON.stringify({
+        lei: '12345678901234567890',
+        legalName: 'Example AB',
+      })
+    )
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        lei: '12345678901234567890',
+        legalName: 'Example AB',
+      },
+    })
+  })
+
+  it('returns an error for non-JSON LLM responses', () => {
+    const result = parseLeiLlmResponse(
+      'You are sending too many requests. Please try again later.'
+    )
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toMatch(/Invalid JSON response/)
+    }
+  })
+
+  it('returns an error when required fields are missing', () => {
+    const result = parseLeiLlmResponse(JSON.stringify({ lei: '123' }))
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.length).toBeGreaterThan(0)
+    }
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### ✨ What's Changed?

The LEI worker (`extractLEI`) previously called `JSON.parse` directly on the LLM response. When the model or API returned a plain-text error (e.g. rate limit messages like "You are sending too many requests"), parsing threw and crashed the worker.

This PR:
- Wraps the OpenAI `ask()` call in try/catch to handle API-level failures gracefully
- Adds `parseLeiLlmResponse()` to safely parse and validate LLM output without throwing
- Logs the raw response on parse failure and returns `{ lei: undefined }` instead of crashing
- Sends a Discord message when LEI lookup fails due to LLM/API issues

### 🔍 How to Review / Test

```bash
npm test -- tests/parseLeiLlmResponse.test.ts
```

Manual verification: trigger the LEI worker when the OpenAI API is rate-limited or returns non-JSON content — the job should complete with `lei: undefined` and log the error instead of crashing.

### 📋 Checklist

- [x] PR title starts with `[#issue-number]`; if no issue is applicable use: `[fix]`, `[feat]`, `[ops]`, or `[prod]`
- [x] I've added/updated tests (or noted why they're not needed)
- [x] I've verified the change runs locally (and in Docker/k8s if relevant)
- [ ] If this changes the API contract, I've called that out clearly (and considered backward compatibility)
- [ ] If this includes a DB change, I've included a migration + rollout/rollback notes
- [x] I've considered observability (logs/metrics/traces) and added what's needed
- [ ] I've set labels, linked issue, and milestone (if applicable)

### 🛠 Related Issue

Closes #1267 
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KLI-61](https://linear.app/klimatkollen/issue/KLI-61/change-request-improve-error-handling-on-lei-worker)

<div><a href="https://cursor.com/agents/bc-402875bd-647b-4e9d-87db-c86dc98e5ae3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-402875bd-647b-4e9d-87db-c86dc98e5ae3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

