### PR TITLE
Add unit tests for cumulative emissions KPI helpers

### DIFF
--- a/src/lib/company-emissions/companyKpiCalculator.ts
+++ b/src/lib/company-emissions/companyKpiCalculator.ts
@@ -65,7 +65,7 @@ function get2025Emissions(
   return slope * 2025 + intercept
 }
 
-function calculateCumulativeEmissions(
+export function calculateCumulativeEmissions(
   startEmissions: number,
   slope: number,
   startYear: number,
@@ -79,7 +79,7 @@ function calculateCumulativeEmissions(
   return cumulative
 }
 
-function calculateCarbonLawCumulativeEmissions(
+export function calculateCarbonLawCumulativeEmissions(
   startEmissions: number,
   startYear: number,
   endYear: number

--- a/tests/companyKpiCalculator.spec.ts
+++ b/tests/companyKpiCalculator.spec.ts
@@ -1,10 +1,46 @@
 import {
+  calculateCarbonLawCumulativeEmissions,
   calculateCompanyKpi,
+  calculateCumulativeEmissions,
   calculateEmissionsChangeFromBaseYear,
   calculateMeetsParis,
 } from '../src/lib/company-emissions/companyKpiCalculator'
 
+const CARBON_LAW_REDUCTION_RATE = 0.1172
+
 describe('companyKpiCalculator', () => {
+  describe('calculateCumulativeEmissions', () => {
+    it('sums constant emissions when the trend slope is zero', () => {
+      expect(calculateCumulativeEmissions(100, 0, 2025, 2027)).toBe(300)
+    })
+
+    it('sums declining linear emissions and floors negative years at zero', () => {
+      expect(calculateCumulativeEmissions(100, -10, 2025, 2035)).toBe(550)
+    })
+
+    it('sums increasing linear emissions across the range', () => {
+      expect(calculateCumulativeEmissions(100, 10, 2025, 2027)).toBe(330)
+    })
+  })
+
+  describe('calculateCarbonLawCumulativeEmissions', () => {
+    it('returns the starting emissions for a single-year range', () => {
+      expect(calculateCarbonLawCumulativeEmissions(100, 2025, 2025)).toBe(100)
+    })
+
+    it('applies the carbon law reduction rate each year', () => {
+      const startEmissions = 100
+      const expected =
+        startEmissions +
+        startEmissions * (1 - CARBON_LAW_REDUCTION_RATE) +
+        startEmissions * Math.pow(1 - CARBON_LAW_REDUCTION_RATE, 2)
+
+      expect(
+        calculateCarbonLawCumulativeEmissions(startEmissions, 2025, 2027)
+      ).toBeCloseTo(expected, 5)
+    })
+  })
+
   describe('calculateMeetsParis', () => {
     it('returns null when future emissions trend slope is unavailable', () => {
       expect(
@@ -71,6 +107,70 @@ describe('companyKpiCalculator', () => {
           ],
         })
       ).toBe(false)
+    })
+
+    it('compares projected cumulative emissions against the carbon law budget', () => {
+      const slope = -10000
+      const company = {
+        wikidataId: 'Q1',
+        name: 'Test Co',
+        futureEmissionsTrendSlope: slope,
+        reportingPeriods: [
+          {
+            startDate: '2024-01-01',
+            endDate: '2024-12-31',
+            emissions: { calculatedTotalEmissions: 100000 },
+          },
+        ],
+      }
+
+      const emissions2025 = 90000
+      const companyCumulative = calculateCumulativeEmissions(
+        emissions2025,
+        slope,
+        2025,
+        2050
+      )
+      const carbonLawCumulative = calculateCarbonLawCumulativeEmissions(
+        emissions2025,
+        2025,
+        2050
+      )
+
+      expect(companyCumulative).toBeLessThanOrEqual(carbonLawCumulative)
+      expect(calculateMeetsParis(company)).toBe(true)
+    })
+
+    it('returns false when projected cumulative emissions exceed the carbon law budget', () => {
+      const slope = 5000
+      const company = {
+        wikidataId: 'Q1',
+        name: 'Test Co',
+        futureEmissionsTrendSlope: slope,
+        reportingPeriods: [
+          {
+            startDate: '2024-01-01',
+            endDate: '2024-12-31',
+            emissions: { calculatedTotalEmissions: 100000 },
+          },
+        ],
+      }
+
+      const emissions2025 = 105000
+      const companyCumulative = calculateCumulativeEmissions(
+        emissions2025,
+        slope,
+        2025,
+        2050
+      )
+      const carbonLawCumulative = calculateCarbonLawCumulativeEmissions(
+        emissions2025,
+        2025,
+        2050
+      )
+
+      expect(companyCumulative).toBeGreaterThan(carbonLawCumulative)
+      expect(calculateMeetsParis(company)).toBe(false)
     })
   })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends `companyKpiCalculator` test coverage to directly exercise the cumulative emissions helpers used by `calculateMeetsParis`.

## Changes

- Export `calculateCumulativeEmissions` and `calculateCarbonLawCumulativeEmissions` for direct unit testing
- Add unit tests for constant, declining (with zero floor), and increasing linear trend cases
- Add unit tests for carbon law cumulative compounding over multiple years
- Add `calculateMeetsParis` tests that explicitly assert the cumulative budget comparison using the exported helpers

## Test plan

- [x] `npm test -- tests/companyKpiCalculator.spec.ts` (15 tests passing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b437b3f-d1cd-42fd-bdad-030c2a0d3f65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b437b3f-d1cd-42fd-bdad-030c2a0d3f65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

