### PR TITLE
Change docker-compose command to docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ For local development, uncomment the `docling` service in `docker-compose.yaml`,
 The simplest way to start the containers is to run the following docker command.
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
 ```


### PR DESCRIPTION
### ✨ What’s Changed?

Updated the command to start containers from 'docker-compose' to 'docker compose'.