### PR TITLE
[FIX] Remove ReplaceAll From buildReportingPeriodApiBody

### DIFF
--- a/src/lib/reportSaveIdentity.ts
+++ b/src/lib/reportSaveIdentity.ts
@@ -13,7 +13,6 @@ type JobReportFields = {
   pdfCache?: { publicUrl?: string; sha256?: string }
   documentReportYear?: string | number
   registryReportId?: string
-  replaceAllEmissions?: boolean
 }
 
 function trimOptional(value: unknown): string | undefined {
@@ -110,7 +109,6 @@ export function buildReportingPeriodsApiBodyExtras(
   })
 
   return {
-    ...(jobData.replaceAllEmissions && { replaceAllEmissions: true }),
     documentReportYear,
     reportUrl: identity.reportURL,
     reportSourceUrl: trimmedSourceUrl,

--- a/tests/reportSaveIdentity.test.ts
+++ b/tests/reportSaveIdentity.test.ts
@@ -60,11 +60,10 @@ describe('reportSaveIdentity', () => {
           publicUrl: 'https://storage.googleapis.com/garbo/abc.pdf',
           sha256: identity.reportSha256,
         },
-        replaceAllEmissions: true,
       },
       [{ year: 2025, startDate: '2025-01-01', endDate: '2025-12-31' }]
     )
-    expect(extras.replaceAllEmissions).toBe(true)
+    expect(extras).not.toHaveProperty('replaceAllEmissions')
     expect(extras.reportSha256).toBe(identity.reportSha256)
     expect(extras.documentReportYear).toBe('2025')
   })


### PR DESCRIPTION
### ✨ What’s Changed?

On the reporting periods by reports change, the replaceAllEmissions was passed as well in a new step and it's should not be, this PR removes that field.

### 🔍 How to Review / Test

<!-- Include relevant commands, curl examples, or steps in staging -->

### 📋 Checklist

- [x] PR title starts with `[#issue-number]`; if no issue is applicable use: `[fix]`, `[feat]`, `[ops]`, or `[prod]`
- [x] I’ve added/updated tests (or noted why they’re not needed)
- [ ] I’ve verified the change runs locally (and in Docker/k8s if relevant)
- [ ] If this changes the API contract, I’ve called that out clearly (and considered backward compatibility)
- [ ] If this includes a DB change, I’ve included a migration + rollout/rollback notes
- [ ] I’ve considered observability (logs/metrics/traces) and added what’s needed
- [x] I’ve set labels, linked issue, and milestone (if applicable)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->
