### PR TITLE
[feat] Add Redis caching to GET /api/companies/kpis

### DIFF
--- a/src/api/routes/external/company.read.ts
+++ b/src/api/routes/external/company.read.ts
@@ -20,6 +20,51 @@ import {
 } from '../../schemas'
 import { redisCache } from '../../../lib/redisCacheSingleton'
 
+async function getCompaniesDatabaseFingerprint() {
+  const [
+    companyCount,
+    reportingPeriodCount,
+    companyReportCount,
+    emissionsCount,
+    latestMetadata,
+    latestCompanyReport,
+  ] = await prisma.$transaction([
+    prisma.company.count(),
+    prisma.reportingPeriod.count(),
+    prisma.companyReport.count(),
+    prisma.emissions.count(),
+    prisma.metadata.findFirst({
+      select: { updatedAt: true },
+      orderBy: { updatedAt: 'desc' },
+    }),
+    prisma.companyReport.findFirst({
+      select: { createdAt: true },
+      orderBy: { createdAt: 'desc' },
+    }),
+  ])
+
+  return [
+    companyCount,
+    reportingPeriodCount,
+    companyReportCount,
+    emissionsCount,
+    latestMetadata?.updatedAt?.toISOString() || '',
+    latestCompanyReport?.createdAt?.toISOString() || '',
+  ].join('|')
+}
+
+async function getOrRefreshCompaniesEtag(databaseFingerprint: string) {
+  const cacheKey = 'companies:etag'
+  let currentEtag: string = await redisCache.get(cacheKey)
+
+  if (!currentEtag || !currentEtag.startsWith(databaseFingerprint)) {
+    currentEtag = `${databaseFingerprint}-${new Date().toISOString()}`
+    await redisCache.set(cacheKey, JSON.stringify(currentEtag))
+  }
+
+  return currentEtag
+}
+
 export async function companyReadRoutes(app: FastifyInstance) {
   app.register(cachePlugin)
 
@@ -39,46 +84,8 @@ export async function companyReadRoutes(app: FastifyInstance) {
     },
 
     async (request, reply) => {
-      const cacheKey = 'companies:etag'
-
-      let currentEtag: string = await redisCache.get(cacheKey)
-
-      // Check for database changes by looking at record counts across relevant tables
-      const [
-        companyCount,
-        reportingPeriodCount,
-        companyReportCount,
-        emissionsCount,
-        latestMetadata,
-        latestCompanyReport,
-      ] = await prisma.$transaction([
-        prisma.company.count(),
-        prisma.reportingPeriod.count(),
-        prisma.companyReport.count(),
-        prisma.emissions.count(),
-        prisma.metadata.findFirst({
-          select: { updatedAt: true },
-          orderBy: { updatedAt: 'desc' },
-        }),
-        prisma.companyReport.findFirst({
-          select: { createdAt: true },
-          orderBy: { createdAt: 'desc' },
-        }),
-      ])
-
-      const databaseFingerprint = [
-        companyCount,
-        reportingPeriodCount,
-        companyReportCount,
-        emissionsCount,
-        latestMetadata?.updatedAt?.toISOString() || '',
-        latestCompanyReport?.createdAt?.toISOString() || '',
-      ].join('|')
-
-      if (!currentEtag || !currentEtag.startsWith(databaseFingerprint)) {
-        currentEtag = `${databaseFingerprint}-${new Date().toISOString()}`
-        await redisCache.set(cacheKey, JSON.stringify(currentEtag))
-      }
+      const databaseFingerprint = await getCompaniesDatabaseFingerprint()
+      const currentEtag = await getOrRefreshCompaniesEtag(databaseFingerprint)
 
       const dataCacheKey = `companies:data:${databaseFingerprint}`
 
@@ -109,7 +116,20 @@ export async function companyReadRoutes(app: FastifyInstance) {
       },
     },
     async (_request, reply) => {
-      const kpis = await companyService.getCompanyKpis()
+      const databaseFingerprint = await getCompaniesDatabaseFingerprint()
+      const currentEtag = await getOrRefreshCompaniesEtag(databaseFingerprint)
+
+      const dataCacheKey = `companies:kpis:${databaseFingerprint}`
+
+      let kpis = await redisCache.get(dataCacheKey)
+
+      if (!kpis) {
+        kpis = await companyService.getCompanyKpis()
+        await redisCache.set(dataCacheKey, JSON.stringify(kpis))
+      }
+
+      reply.header('ETag', `${currentEtag}`)
+
       reply.send(kpis)
     }
   )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### ✨ What's Changed?

`GET /api/companies/kpis` now uses the same Redis caching strategy as `GET /api/companies`:

- Shared helpers compute a database fingerprint (record counts + latest metadata/report timestamps) and refresh the existing `companies:etag` key.
- KPI payloads are cached under `companies:kpis:{fingerprint}` with the standard 24h Redis TTL.
- Responses include an `ETag` header, consistent with the companies list endpoint.

This avoids loading and enriching every company from the database on each KPI request.

### 🔍 How to Review / Test

1. Call `GET /api/companies/kpis` twice with a valid `X-API-Key`.
2. Confirm the second request is faster and returns the same payload.
3. Confirm the response includes an `ETag` header.
4. After a relevant DB change (e.g. new reporting period), confirm the fingerprint changes and KPIs are recomputed.

### 📋 Checklist

- [x] PR title starts with `[feat]`
- [x] No new tests needed — behavior mirrors the existing companies list cache pattern
- [x] Verified route registry tests pass
- [x] No API contract change (response shape unchanged; `ETag` header added, matching list endpoint)

### 🛠 Related Issue

Related to #1194

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d1018fd-ef04-4c81-bc70-3934336b7712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d1018fd-ef04-4c81-bc70-3934336b7712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

