### PR TITLE
[1329] Registry name backfill and add new companyIdentifier table

### DIFF
--- a/doc/COMPANY_IDENTIFIERS_PLAN.md
+++ b/doc/COMPANY_IDENTIFIERS_PLAN.md
@@ -1,0 +1,331 @@
+# Company identifiers and non-blocking Wikidata
+
+Plan for moving company identity off `wikidataId` as the sole primary key, introducing a flexible identifier model, and making the pipeline proceed without blocking on Wikidata approval.
+
+**Repos involved**
+
+| Repo                  | Role                                                                       |
+| --------------------- | -------------------------------------------------------------------------- |
+| **garbo**             | Prisma migrations (source of truth), workers, internal API                 |
+| **API** (unearth-api) | Partner/integration/staff HTTP API — schema and handlers synced from garbo |
+| **validate**          | Staff UI — editor, job approvals, overview                                 |
+| **pipeline-api**      | Process/swimlane aggregation for Validate job status                       |
+
+Garbo and unearth-api share one PostgreSQL database. Migrations run in garbo; unearth-api picks up schema + service changes when deployed.
+
+---
+
+## Background: what exists today
+
+### Done (company internal id — step 1)
+
+- `Company.id` (UUID) added and backfilled (`20260602120000_add_company_internal_id`).
+- **unearth-api** staff routes use internal id: `POST /api/companies/`, `POST /api/companies/:id`.
+- **unearth-api** read routes resolve wikidataId, full UUID, or 8-char UUID prefix.
+- **validate** creates/updates companies by internal `id` via unearth-api.
+- **garbo workers** still save via `/companies/${wikidataId}` and require `wikidata.node` before company creation.
+
+### Still blocking
+
+1. **`wikidataId` is still `@id`** on `Company`. Seven child tables FK to it.
+2. **Pipeline flow**: in `precheck.ts`, `guessWikidata` is a **child** of `extractEmissions`. BullMQ runs children before the parent, so Wikidata approval (`moveToDelayed`) blocks emissions extraction, `checkDB`, and all saves.
+3. **`checkDB`** creates companies keyed by `wikidata.node` and metadata `comment: 'Created by Garbo AI'`.
+
+---
+
+## Target model
+
+### `CompanyIdentifier` table (not a JSON array)
+
+Each row: `type` (enum), `value`, and standard `Metadata` (including `verifiedBy` for human review).
+
+```prisma
+enum CompanyIdentifierType {
+  WIKIDATA
+  LEI
+  ORG_NUMBER
+  ISIN
+}
+
+model CompanyIdentifier {
+  id        String                @id @default(cuid())
+  companyId String                // FK → Company.id (stable; survives PK flip)
+  type      CompanyIdentifierType
+  value     String
+  company   Company               @relation(...)
+  metadata  Metadata[]
+
+  @@unique([companyId, type])
+  @@index([type, value])
+  @@map("company_identifiers")
+}
+```
+
+`Metadata` gains `companyIdentifierId` (same pattern as `scope1Id`, `industryId`, etc.).
+
+### Legacy columns (transition)
+
+Keep `Company.wikidataId` and `Company.lei` during transition. **Dual-write**: identifier service updates both the table and legacy columns so partner API responses stay unchanged.
+
+### Verification
+
+| State                                    | `metadata.verifiedBy`                   | Typical `source`                          |
+| ---------------------------------------- | --------------------------------------- | ----------------------------------------- |
+| Pipeline guess, not reviewed             | `null`                                  | `wikidata-search`, `override-wikidata-id` |
+| Auto-matched production DB               | optional bot / `null`                   | `production-database`                     |
+| Human approved in Validate               | approver user id                        | from approval                             |
+| Manual editor save with `verified: true` | editor user id                          | `validate-editor`                         |
+| Backfill from legacy columns             | `null` (or `--mark-verified` in script) | `migration-backfill`                      |
+
+Query “is Wikidata verified?” → `CompanyIdentifier` where `type = WIKIDATA` and latest metadata has non-null `verifiedBy`.
+
+Do **not** attach company-creation metadata (`Created by Garbo AI`) to identifier rows.
+
+### Partner / external API
+
+No response shape change. `PartnerCompanyBase` keeps `id`, `wikidataId`, `lei` populated from legacy columns (dual-write). Do not expose `identifiers[]` on partner routes in early phases.
+
+---
+
+## Implementation phases
+
+### Phase 1 — Identifier table + backfill + dual-write (garbo only)
+
+**Scope:** garbo repo only. unearth-api sync happens before stage/prod deploy of API that reads new columns.
+
+| Step | Work                                                                                 |
+| ---- | ------------------------------------------------------------------------------------ |
+| 1.1  | Prisma: `CompanyIdentifierType`, `CompanyIdentifier`, `Metadata.companyIdentifierId` |
+| 1.2  | Migration SQL                                                                        |
+| 1.3  | `companyIdentifierService` — upsert, sync from legacy columns                        |
+| 1.4  | Dual-write in `companyService.upsertCompany`                                         |
+| 1.5  | Include `identifiers` on internal/pipeline company detail reads + Zod schemas        |
+| 1.6  | Backfill script `scripts/backfill-company-identifiers.ts`                            |
+| 1.7  | Tests for identifier service and sync                                                |
+
+**Exit criteria:** All companies have identifier rows for existing `wikidataId` / `lei`; new upserts keep table and columns in sync; internal GET returns `identifiers`.
+
+### Phase 2 — Primary key flip (`Company.id`)
+
+| Step | Work                                                                                                                        |
+| ---- | --------------------------------------------------------------------------------------------------------------------------- |
+| 2.1  | Make `Company.id` the `@id`; `wikidataId` nullable `@unique`                                                                |
+| 2.2  | Repoint FKs: `BaseYear`, `Industry`, `ReportingPeriod`, `Goal`, `Initiative`, `Description`, `CompanyReport` → `Company.id` |
+| 2.3  | Rename `Industry.companyWikidataId` → `companyId`                                                                           |
+| 2.4  | Data migration script + validation queries                                                                                  |
+| 2.5  | Refactor `changeCompanyWikidataId` → identifier upsert (no PK rewrite)                                                      |
+| 2.6  | Sync schema + services to unearth-api                                                                                       |
+| 2.7  | Allow `POST /api/companies/` without `wikidataId`                                                                           |
+
+**Gap:** Large migration; plan maintenance window or multi-step FK migration. unearth-api cannot serve companies without wikidata until this lands.
+
+### Phase 3 — Non-blocking pipeline + worker URL migration (garbo)
+
+| Step | Work                                                                                                                      |
+| ---- | ------------------------------------------------------------------------------------------------------------------------- |
+| 3.1  | **Restructure `precheck` flow** — `guessWikidata` must not be a child of `extractEmissions`                               |
+| 3.2  | **`checkDB`** — create company via `POST /companies` (name only) → store `companyId` on job data                          |
+| 3.3  | **`saveToAPI`** — use `/companies/${companyId}/...` (requires garbo staff routes aligned with unearth-api)                |
+| 3.4  | **`guessWikidata`** — async; upsert unverified `WIKIDATA` identifier; on approval set `verifiedBy`; do not block pipeline |
+| 3.5  | **`extractEmissions` / `extractLEI`** — work without approved Wikidata; LEI via GLEIF name search                         |
+| 3.6  | **`companySaveLock`** — key by `company.id` not `wikidataId`                                                              |
+| 3.7  | **Registry / `ReportRun`** — prefer `companyId` on job and archive rows                                                   |
+| 3.8  | **`sendCompanyLink`** — link by internal id or resolved Wikidata                                                          |
+| 3.9  | **Wikipedia/Wikidata upload workers** — only when verified Wikidata identifier exists                                     |
+
+**Gap:** Garbo internal API still uses `/:wikidataId` routes; port staff `/:id` routes from unearth-api into garbo (or point workers at unearth-api) before changing worker URLs.
+
+### Phase 4 — Validate UI + verification UX
+
+| Step | Work                                                                        |
+| ---- | --------------------------------------------------------------------------- |
+| 4.1  | `CompanyDetailTab` — identifiers list with verification badges              |
+| 4.2  | `companies-api` / schemas — parse `identifiers`                             |
+| 4.3  | `WikidataApprovalDisplay` — on approve, persist verified identifier via API |
+| 4.4  | Swimlane — “Wikidata unverified” vs “pipeline blocked”                      |
+| 4.5  | Overview/registry — handle null `wikidataId` where applicable               |
+
+### Phase 5 — Deprecation (later)
+
+Remove legacy `lei` / direct `wikidataId` columns when all consumers use identifiers.
+
+### Phase 6 — Metadata history + `previousValue` (separate PR)
+
+**Scope:** Own PR(s), independent of identifier/pipeline phases. Partner/Bolt contract unchanged — staff/pipeline reads and internal write paths only.
+
+**Goal:** Every new `Metadata` row can record what changed, and Validate can show full audit history (not just the latest snapshot).
+
+#### Schema
+
+| Step | Work                                                              |
+| ---- | ----------------------------------------------------------------- |
+| 6.1  | Add `Metadata.previousValue Json?` (nullable; old rows stay null) |
+| 6.2  | Migration in garbo; sync schema to unearth-api                    |
+
+Use `Json` so one field covers strings (Wikidata Q-id), numbers (scope 1 total), and partial objects (scope 2 `mb` / `lb` / `unknown`).
+
+#### Shared write helper
+
+| Step | Work                                                                                                           |
+| ---- | -------------------------------------------------------------------------------------------------------------- |
+| 6.3  | Extend `metadataService.createMetadata` (or add `createMetadataForChange`) to accept optional `previousValue`  |
+| 6.4  | Optional helper to compare before/after payloads and derive `previousValue` only when a field actually changed |
+
+#### Wire all metadata-creating write paths
+
+Apply globally, not identifiers-only. Incremental rollout within the PR is fine; schema ships once.
+
+| Area | Work                                                                                                                                                                                                     |
+| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 6.5  | **Identifiers** — pass `existing.value` when identifier value changes                                                                                                                                    |
+| 6.6  | **Industry, goals, initiatives, base year, descriptions** — load existing, compare, create metadata with `previousValue`                                                                                 |
+| 6.7  | **Reporting periods / emissions / economy** — refactor so each **changed datapoint** gets its own metadata row with its own `previousValue` (not one shared `createdMetadata` per period for all fields) |
+| 6.8  | **`emissionsService` upserts** — read current row before update; set `previousValue` on value change                                                                                                     |
+| 6.9  | Pipeline saves — covered once staff POST handlers populate `previousValue`                                                                                                                               |
+
+**Note:** Historical rows cannot be backfilled with previous values; this is forward-looking from deploy date.
+
+#### Internal reads + Validate UI
+
+| Step | Work                                                                                                                         |
+| ---- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 6.10 | Add `metadataHistoryArgs` (no `take: 1`) alongside existing `metadataArgs` on **pipeline/staff detail** queries only         |
+| 6.11 | `transformMetadata` — keep `metadata` as latest; expose `metadataHistory` as array                                           |
+| 6.12 | Extend `InternalCompanyDetails` / nested Zod schemas with optional `metadataHistory` and `previousValue` on `MetadataSchema` |
+| 6.13 | Validate `MetadataDetailsDialog` — timeline UI showing source, user, verifiedBy, `previousValue` → current field value       |
+| 6.14 | Sync garbo + unearth-api                                                                                                     |
+
+**Do not change:** `PartnerCompanyList`, `PartnerCompanyDetails`, or Bolt-facing routes.
+
+#### Exit criteria
+
+- New saves attach `previousValue` when a datapoint value changes (all staff write paths).
+- `GET /api/pipeline/companies/:ref` returns `metadataHistory` on nested fields.
+- Validate metadata modal shows history including previous values where present.
+- Partner API responses byte-identical in shape (no new fields on partner schemas).
+
+#### Effort (estimate)
+
+~2–3 weeks total; reporting-period refactor is the bulk of the work.
+
+---
+
+## Gaps and cross-cutting concerns
+
+Document these in each phase so they are not lost.
+
+### garbo ↔ unearth-api drift
+
+Workers call garbo's `API_BASE_URL`. unearth-api is ahead on internal-id staff routes. Before Phase 3, align garbo `company.update` / read routes with unearth-api `staff/` handlers.
+
+### Migrations owned by garbo only
+
+unearth-api README: schema errors usually mean garbo migrations are not applied. Run backfill on staging before prod API deploy.
+
+### FK migration scope (Phase 2)
+
+Seven relations reference `wikidataId` today:
+
+- `BaseYear.companyId`
+- `Industry.companyWikidataId`
+- `ReportingPeriod.companyId`
+- `Goal.companyId`
+- `Initiative.companyId`
+- `Description.companyId`
+- `CompanyReport.companyId`
+
+Plus optional `wikidataId` on `Report`, `ReportRun`, `ReportRunJob` (not FK to Company PK).
+
+### Search alignment
+
+garbo `getAllCompaniesBySearchTerm` orders by `wikidataId`; unearth-api searches by `id`. Align when flipping PK.
+
+### Concurrent pipeline runs
+
+`companySaveLock` and registry identity must use stable `companyId` after Phase 2/3.
+
+### Tests to add/update
+
+- `companyIdentifierService` unit tests
+- `companyService.wikidata` / upsert sync tests
+- `saveToAPI.test.ts` (Phase 3)
+- `CompanyDetailTab.test.tsx` (Phase 4)
+- Pipeline flow integration tests (Phase 3)
+- `metadataService` / reporting-period save tests (Phase 6)
+
+### Registry placeholder names (related uncommitted work)
+
+Local changes to `registryReportIdentity.ts` / `registryService.ts` fix merging `"Unknown"` company names from pipeline into registry rows. Orthogonal to identifiers but useful for Phase 3; commit or merge separately.
+
+---
+
+## Pipeline flow (current vs target)
+
+### Current (blocking)
+
+```
+precheck
+  └── extractEmissions (parent — waits for children)
+        ├── guessWikidata  ← blocks on approval
+        └── followUpFiscalYear
+  └── extractEmissions runs follow-ups → checkDB → diff* → saveToAPI
+```
+
+### Target (non-blocking)
+
+```
+precheck
+  ├── create/find company by internal id (early)
+  ├── extractEmissions + follow-ups → checkDB → diff* → saveToAPI  (uses companyId)
+  └── guessWikidata (parallel / async) → upsert WIKIDATA identifier when known/approved
+```
+
+---
+
+## Phase 1 runbook
+
+```bash
+# After merge to environment with DB access:
+npx prisma migrate deploy
+
+# Backfill (staging first):
+npx tsx scripts/backfill-company-identifiers.ts --dry-run
+npx tsx scripts/backfill-company-identifiers.ts
+
+# Optional: mark backfilled Wikidata as verified (curated prod only):
+npx tsx scripts/backfill-company-identifiers.ts --mark-verified
+```
+
+Verify:
+
+```sql
+SELECT COUNT(*) FROM "Company";
+SELECT COUNT(*) FROM "company_identifiers" WHERE type = 'WIKIDATA';
+SELECT c."wikidataId", i.value
+FROM "Company" c
+LEFT JOIN "company_identifiers" i ON i."companyId" = c.id AND i.type = 'WIKIDATA'
+WHERE c."wikidataId" IS NOT NULL AND (i.value IS NULL OR i.value <> c."wikidataId");
+```
+
+---
+
+## unearth-api sync checklist (post Phase 1)
+
+When deploying API against a DB with Phase 1 migration:
+
+- [ ] Copy Prisma schema changes
+- [ ] Copy `companyIdentifierService`
+- [ ] Dual-write in `companyService.upsertCompany`
+- [ ] `identifiers` on staff/pipeline detail responses + Zod schemas
+- [ ] `npx prisma generate` in API repo (no new migration in API)
+
+---
+
+## References
+
+- `prisma/schema.prisma` — `Company`, `Metadata`
+- `src/workers/precheck.ts` — flow construction
+- `src/workers/guessWikidata.ts` — approval blocking
+- `src/workers/checkDB.ts` — company creation
+- `doc/pipeline.md` — worker documentation
+- unearth-api `README.md` — Relationship to Garbo

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,13 +85,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -110,21 +110,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -151,14 +151,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -168,14 +168,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -195,9 +195,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -205,29 +205,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -247,9 +247,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -257,9 +257,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -267,9 +267,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -277,27 +277,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -546,33 +546,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -580,14 +580,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -4020,15 +4020,15 @@
       }
     },
     "node_modules/@types/request/node_modules/form-data": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
-      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
+        "hasown": "^2.0.4",
         "mime-types": "^2.1.35",
         "safe-buffer": "^5.2.1"
       },
@@ -4880,9 +4880,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.29",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
-      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4972,9 +4972,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
       "dev": true,
       "funding": [
         {
@@ -4992,10 +4992,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -5170,9 +5170,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001792",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
-      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -5944,16 +5944,16 @@
       }
     },
     "node_modules/deepl-node/node_modules/form-data": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
-      "integrity": "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.5.tgz",
+      "integrity": "sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
+        "hasown": "^2.0.4",
         "mime-types": "^2.1.35"
       },
       "engines": {
@@ -6229,9 +6229,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.354",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.354.tgz",
-      "integrity": "sha512-JaBHwWcfIdmSAfWM5l3uwjGd431j8YEMikZ+K/2nXVuBqJKyZ0f+2h4n4JY5AyNiZmnY9qQr2RU3v9DxDmHMNg==",
+      "version": "1.5.381",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.381.tgz",
+      "integrity": "sha512-n9Wa6yB+vDsGuA8AKbl/0z7HbvWqt5jxIdvr1IUicd0ryPrk7/xzwqLv8D9AbbvZ6avVNtXYLTfmgFHkwkyelg==",
       "dev": true,
       "license": "ISC"
     },
@@ -7515,9 +7515,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -9522,9 +9522,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10391,11 +10391,14 @@
       "optional": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.44",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
-      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -12358,9 +12361,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
@@ -12443,9 +12446,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.9",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
-      "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
+      "version": "29.4.11",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12455,7 +12458,7 @@
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.4",
+        "semver": "^7.8.0",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -12629,9 +12632,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -12957,9 +12960,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "optional": true,
       "peer": true,

--- a/prisma/migrations/20260629120000_add_company_identifiers/migration.sql
+++ b/prisma/migrations/20260629120000_add_company_identifiers/migration.sql
@@ -1,0 +1,27 @@
+-- CreateEnum
+CREATE TYPE "CompanyIdentifierType" AS ENUM ('WIKIDATA', 'LEI', 'ORG_NUMBER', 'ISIN');
+
+-- CreateTable
+CREATE TABLE "company_identifiers" (
+    "id" TEXT NOT NULL,
+    "companyId" TEXT NOT NULL,
+    "type" "CompanyIdentifierType" NOT NULL,
+    "value" TEXT NOT NULL,
+
+    CONSTRAINT "company_identifiers_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "company_identifiers_companyId_type_key" ON "company_identifiers"("companyId", "type");
+
+-- CreateIndex
+CREATE INDEX "company_identifiers_type_value_idx" ON "company_identifiers"("type", "value");
+
+-- AddForeignKey
+ALTER TABLE "company_identifiers" ADD CONSTRAINT "company_identifiers_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "Company"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AlterTable
+ALTER TABLE "Metadata" ADD COLUMN "companyIdentifierId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "Metadata" ADD CONSTRAINT "Metadata_companyIdentifierId_fkey" FOREIGN KEY ("companyIdentifierId") REFERENCES "company_identifiers"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,6 +43,29 @@ model Company {
   tags String[]
 
   logoUrl String?
+
+  identifiers CompanyIdentifier[]
+}
+
+enum CompanyIdentifierType {
+  WIKIDATA
+  LEI
+  ORG_NUMBER
+  ISIN
+}
+
+model CompanyIdentifier {
+  id        String                @id @default(cuid())
+  companyId String
+  type      CompanyIdentifierType
+  value     String
+
+  company  Company    @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  metadata Metadata[]
+
+  @@unique([companyId, type])
+  @@index([type, value])
+  @@map("company_identifiers")
 }
 
 /// Valid tag options for company tags. Company.tags[] may only contain values that exist as slug here.
@@ -352,6 +375,7 @@ model Metadata {
   turnoverId             String?
   employeesId            String?
   descriptionId          String?
+  companyIdentifierId    String?
 
   goal                 Goal?                 @relation(fields: [goalId], references: [id])
   initiative           Initiative?           @relation(fields: [initiativeId], references: [id])
@@ -370,6 +394,7 @@ model Metadata {
   turnover             Turnover?             @relation(fields: [turnoverId], references: [id])
   employees            Employees?            @relation(fields: [employeesId], references: [id])
   description          Description?          @relation(fields: [descriptionId], references: [id], onDelete: Cascade)
+  companyIdentifier    CompanyIdentifier?    @relation(fields: [companyIdentifierId], references: [id], onDelete: SetNull)
 }
 
 model User {

--- a/scripts/backfill-company-identifiers.ts
+++ b/scripts/backfill-company-identifiers.ts
@@ -1,0 +1,73 @@
+/**
+ * Backfill `company_identifiers` from legacy `Company.wikidataId` and `Company.lei`.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-company-identifiers.ts --dry-run
+ *   npx tsx scripts/backfill-company-identifiers.ts
+ *   npx tsx scripts/backfill-company-identifiers.ts --mark-verified
+ *
+ * Run against staging first.
+ */
+
+import 'dotenv/config'
+import { parseArgs } from 'node:util'
+
+import { prisma } from '../src/lib/prisma'
+import { companyIdentifierService } from '../src/api/services/companyIdentifierService'
+
+const { values } = parseArgs({
+  options: {
+    'dry-run': { type: 'boolean', default: false },
+    'mark-verified': { type: 'boolean', default: false },
+  },
+})
+
+const dryRun = values['dry-run'] ?? false
+const markVerified = values['mark-verified'] ?? false
+
+async function main() {
+  const companies = await prisma.company.findMany({
+    select: { id: true, wikidataId: true, lei: true, name: true },
+    orderBy: { name: 'asc' },
+  })
+
+  console.info(`Found ${companies.length} companies`)
+
+  let synced = 0
+  let skipped = 0
+
+  for (const company of companies) {
+    const hasWikidata = Boolean(company.wikidataId?.trim())
+    const hasLei = Boolean(company.lei?.trim())
+
+    if (!hasWikidata && !hasLei) {
+      skipped++
+      continue
+    }
+
+    if (dryRun) {
+      console.info(
+        `[dry-run] ${company.name} (${company.id}): wikidata=${hasWikidata}, lei=${hasLei}`
+      )
+      synced++
+      continue
+    }
+
+    await companyIdentifierService.syncFromLegacyColumns(company, {
+      source: 'migration-backfill',
+      verified: markVerified,
+    })
+    synced++
+  }
+
+  console.info(`Done. synced=${synced}, skipped=${skipped}, dryRun=${dryRun}`)
+}
+
+main()
+  .catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/src/api/args.ts
+++ b/src/api/args.ts
@@ -104,6 +104,14 @@ export const detailedCompanyArgs = {
     },
     lei: true,
     tags: true,
+    identifiers: {
+      select: {
+        id: true,
+        type: true,
+        value: true,
+        metadata: metadataArgs,
+      },
+    },
     reportingPeriods: {
       select: {
         id: true,

--- a/src/api/args.ts
+++ b/src/api/args.ts
@@ -104,14 +104,6 @@ export const detailedCompanyArgs = {
     },
     lei: true,
     tags: true,
-    identifiers: {
-      select: {
-        id: true,
-        type: true,
-        value: true,
-        metadata: metadataArgs,
-      },
-    },
     reportingPeriods: {
       select: {
         id: true,
@@ -265,6 +257,21 @@ export const detailedCompanyArgs = {
     },
     baseYear: {
       select: { id: true, year: true, metadata: metadataArgs },
+    },
+  },
+} satisfies Prisma.CompanyDefaultArgs
+
+/** Staff/pipeline company detail — includes identifiers (not on partner reads). */
+export const pipelineCompanyDetailArgs = {
+  select: {
+    ...detailedCompanyArgs.select,
+    identifiers: {
+      select: {
+        id: true,
+        type: true,
+        value: true,
+        metadata: metadataArgs,
+      },
     },
   },
 } satisfies Prisma.CompanyDefaultArgs

--- a/src/api/routes/internal/company.industry.ts
+++ b/src/api/routes/internal/company.industry.ts
@@ -38,6 +38,7 @@ export async function companyIndustryRoutes(app: FastifyInstance) {
       } = request.body
       const { wikidataId } = request.params
 
+      // TODO(Klimatbyran/garbo#1333): wrap createMetadata + industryService.upsertIndustry in $transaction.
       const createdMetadata = await metadataService.createMetadata({
         metadata,
         user: request.user,

--- a/src/api/routes/internal/company.update.ts
+++ b/src/api/routes/internal/company.update.ts
@@ -68,6 +68,7 @@ export async function companyUpdateRoutes(app: FastifyInstance) {
           url,
           logoUrl: logoUrl ?? undefined,
           lei,
+          user: request.user,
         })
         await Promise.all(
           (descriptions ?? []).map(async (description) => {

--- a/src/api/schemas/response.ts
+++ b/src/api/schemas/response.ts
@@ -61,7 +61,7 @@ export const CompanyIdentifierSchema = z.object({
   id: z.string(),
   type: CompanyIdentifierTypeSchema,
   value: z.string(),
-  metadata: MetadataSchema,
+  metadata: MetadataSchema.nullable(),
 })
 
 const CompanyBaseSchema = z.object({

--- a/src/api/schemas/response.ts
+++ b/src/api/schemas/response.ts
@@ -50,6 +50,20 @@ export const MetadataSchema = z.object({
 
 export const MinimalMetadataSchema = MetadataSchema.pick({ verifiedBy: true })
 
+export const CompanyIdentifierTypeSchema = z.enum([
+  'WIKIDATA',
+  'LEI',
+  'ORG_NUMBER',
+  'ISIN',
+])
+
+export const CompanyIdentifierSchema = z.object({
+  id: z.string(),
+  type: CompanyIdentifierTypeSchema,
+  value: z.string(),
+  metadata: MetadataSchema,
+})
+
 const CompanyBaseSchema = z.object({
   id: companyIdSchema,
   wikidataId: wikidataIdSchema,
@@ -505,6 +519,7 @@ export const CompanyDetails = CompanyBase.extend({
  */
 export const InternalCompanyDetails = CompanyDetails.extend({
   tags: z.array(z.string()),
+  identifiers: z.array(CompanyIdentifierSchema).optional(),
 })
 
 function transformYearlyData(

--- a/src/api/services/authService.ts
+++ b/src/api/services/authService.ts
@@ -4,6 +4,7 @@ import { prisma } from '../../lib/prisma'
 import jwt from 'jsonwebtoken'
 import { serviceAuthenticationBody } from '../types'
 import { User } from '@prisma/client'
+import { getOrCreateServiceBotUser } from './serviceBotUser'
 
 interface GithubUserinfo {
   login: string
@@ -89,29 +90,7 @@ class AuthService {
       throw new Error('Invalid secret')
     }
 
-    let user = await prisma.user.findFirst({
-      where: {
-        name: serviceAuth.client_id,
-      },
-    })
-
-    if (!user) {
-      user = await prisma.user.upsert({
-        where: {
-          name: serviceAuth.client_id,
-        },
-        update: {
-          name: serviceAuth.client_id,
-          email: serviceAuth.client_id + '@klimatkollen.se',
-          bot: true,
-        },
-        create: {
-          name: serviceAuth.client_id,
-          email: serviceAuth.client_id + '@klimatkollen.se',
-          bot: true,
-        },
-      })
-    }
+    const user = await getOrCreateServiceBotUser(serviceAuth.client_id)
 
     return this.createToken(user)
   }

--- a/src/api/services/companyIdentifierService.ts
+++ b/src/api/services/companyIdentifierService.ts
@@ -1,19 +1,9 @@
 import { CompanyIdentifierType, User } from '@prisma/client'
 import { prisma } from '../../lib/prisma'
-
-const GARBO_BOT_NAME = 'garbo'
-
-async function getGarboBotUser(): Promise<User> {
-  return prisma.user.upsert({
-    where: { name: GARBO_BOT_NAME },
-    update: {},
-    create: {
-      name: GARBO_BOT_NAME,
-      email: 'garbo@klimatkollen.se',
-      bot: true,
-    },
-  })
-}
+import {
+  GARBO_SERVICE_CLIENT_ID,
+  getOrCreateServiceBotUser,
+} from './serviceBotUser'
 
 class CompanyIdentifierService {
   async upsertIdentifier({
@@ -83,7 +73,8 @@ class CompanyIdentifierService {
       verified?: boolean
     }
   ) {
-    const user = options?.user ?? (await getGarboBotUser())
+    const user =
+      options?.user ?? (await getOrCreateServiceBotUser(GARBO_SERVICE_CLIENT_ID))
     const source = options?.source ?? 'company-column-sync'
 
     const synced: Array<{ id: string; value?: string }> = []

--- a/src/api/services/companyIdentifierService.ts
+++ b/src/api/services/companyIdentifierService.ts
@@ -42,9 +42,7 @@ class CompanyIdentifierService {
         comment: metadata?.comment,
         source: metadata?.source,
         user: { connect: { id: user.id } },
-        verifiedBy: verified
-          ? { connect: { id: user.id } }
-          : undefined,
+        verifiedBy: verified ? { connect: { id: user.id } } : undefined,
       },
     })
 
@@ -74,7 +72,8 @@ class CompanyIdentifierService {
     }
   ) {
     const user =
-      options?.user ?? (await getOrCreateServiceBotUser(GARBO_SERVICE_CLIENT_ID))
+      options?.user ??
+      (await getOrCreateServiceBotUser(GARBO_SERVICE_CLIENT_ID))
     const source = options?.source ?? 'company-column-sync'
 
     const synced: Array<{ id: string; value?: string }> = []

--- a/src/api/services/companyIdentifierService.ts
+++ b/src/api/services/companyIdentifierService.ts
@@ -1,0 +1,128 @@
+import { CompanyIdentifierType, User } from '@prisma/client'
+import { prisma } from '../../lib/prisma'
+
+const GARBO_BOT_NAME = 'garbo'
+
+async function getGarboBotUser(): Promise<User> {
+  return prisma.user.upsert({
+    where: { name: GARBO_BOT_NAME },
+    update: {},
+    create: {
+      name: GARBO_BOT_NAME,
+      email: 'garbo@klimatkollen.se',
+      bot: true,
+    },
+  })
+}
+
+class CompanyIdentifierService {
+  async upsertIdentifier({
+    companyId,
+    type,
+    value,
+    user,
+    metadata,
+    verified = false,
+    skipMetadataIfUnchanged = false,
+  }: {
+    companyId: string
+    type: CompanyIdentifierType
+    value: string
+    user: User
+    metadata?: { source?: string; comment?: string }
+    verified?: boolean
+    skipMetadataIfUnchanged?: boolean
+  }): Promise<{ id: string; value: string } | null> {
+    const trimmedValue = value.trim()
+    if (!trimmedValue) return null
+
+    const existing = await prisma.companyIdentifier.findUnique({
+      where: {
+        companyId_type: { companyId, type },
+      },
+      select: { id: true, value: true },
+    })
+
+    if (existing?.value === trimmedValue && skipMetadataIfUnchanged) {
+      return existing
+    }
+
+    const metadataRecord = await prisma.metadata.create({
+      data: {
+        comment: metadata?.comment,
+        source: metadata?.source,
+        user: { connect: { id: user.id } },
+        verifiedBy: verified
+          ? { connect: { id: user.id } }
+          : undefined,
+      },
+    })
+
+    return prisma.companyIdentifier.upsert({
+      where: {
+        companyId_type: { companyId, type },
+      },
+      create: {
+        companyId,
+        type,
+        value: trimmedValue,
+        metadata: { connect: { id: metadataRecord.id } },
+      },
+      update: {
+        value: trimmedValue,
+        metadata: { connect: { id: metadataRecord.id } },
+      },
+    })
+  }
+
+  async syncFromLegacyColumns(
+    company: { id: string; wikidataId: string; lei?: string | null },
+    options?: {
+      user?: User
+      source?: string
+      verified?: boolean
+    }
+  ) {
+    const user = options?.user ?? (await getGarboBotUser())
+    const source = options?.source ?? 'company-column-sync'
+
+    const synced: Array<{ id: string; value?: string }> = []
+
+    if (company.wikidataId.trim()) {
+      const row = await this.upsertIdentifier({
+        companyId: company.id,
+        type: 'WIKIDATA',
+        value: company.wikidataId,
+        user,
+        metadata: {
+          source,
+          comment: 'Synced from Company.wikidataId',
+        },
+        verified: options?.verified ?? false,
+        skipMetadataIfUnchanged: true,
+      })
+      if (row) synced.push(row)
+    }
+
+    const lei = company.lei?.trim()
+    if (lei) {
+      const row = await this.upsertIdentifier({
+        companyId: company.id,
+        type: 'LEI',
+        value: lei,
+        user,
+        metadata: {
+          source,
+          comment: 'Synced from Company.lei',
+        },
+        verified: options?.verified ?? false,
+        skipMetadataIfUnchanged: true,
+      })
+      if (row) synced.push(row)
+    }
+
+    return synced
+  }
+}
+
+export const companyIdentifierService = new CompanyIdentifierService()

--- a/src/api/services/companyIdentifierService.ts
+++ b/src/api/services/companyIdentifierService.ts
@@ -37,29 +37,31 @@ class CompanyIdentifierService {
       return existing
     }
 
-    const metadataRecord = await prisma.metadata.create({
-      data: {
-        comment: metadata?.comment,
-        source: metadata?.source,
-        user: { connect: { id: user.id } },
-        verifiedBy: verified ? { connect: { id: user.id } } : undefined,
-      },
-    })
+    return prisma.$transaction(async (transaction) => {
+      const metadataRecord = await transaction.metadata.create({
+        data: {
+          comment: metadata?.comment,
+          source: metadata?.source,
+          user: { connect: { id: user.id } },
+          verifiedBy: verified ? { connect: { id: user.id } } : undefined,
+        },
+      })
 
-    return prisma.companyIdentifier.upsert({
-      where: {
-        companyId_type: { companyId, type },
-      },
-      create: {
-        companyId,
-        type,
-        value: trimmedValue,
-        metadata: { connect: { id: metadataRecord.id } },
-      },
-      update: {
-        value: trimmedValue,
-        metadata: { connect: { id: metadataRecord.id } },
-      },
+      return transaction.companyIdentifier.upsert({
+        where: {
+          companyId_type: { companyId, type },
+        },
+        create: {
+          companyId,
+          type,
+          value: trimmedValue,
+          metadata: { connect: { id: metadataRecord.id } },
+        },
+        update: {
+          value: trimmedValue,
+          metadata: { connect: { id: metadataRecord.id } },
+        },
+      })
     })
   }
 

--- a/src/api/services/companyService.ts
+++ b/src/api/services/companyService.ts
@@ -26,6 +26,7 @@ import { ReportsListResponseSchema } from '../schemas/response'
 import { z } from 'zod'
 import { registryService } from './registryService'
 import { pickOnePeriodPerDataYear } from './reportingPeriodPublicRead'
+import { companyIdentifierService } from './companyIdentifierService'
 import type { ReportingPeriod } from '@/types'
 
 const API_KEY = process.env.FIRECRAWL_API_KEY
@@ -166,7 +167,7 @@ class CompanyService {
     tags?: string[]
     lei?: string
   }) {
-    return prisma.company.upsert({
+    const company = await prisma.company.upsert({
       where: {
         wikidataId,
       },
@@ -174,13 +175,12 @@ class CompanyService {
         ...data,
         wikidataId,
       },
-      // TODO: Should we allow updating the wikidataId?
-      // Probably yes from a business perspective, but that also means we need to update all related records too.
-      // Updating the primary key can be tricky, especially with backups using the old primary key no longer being compatible.
-      // This might be a reason why we shouldn't use wikidataId as our primary key in the DB.
-      // However, no matter what, we could still use wikidataId in the API and in the URL structure.
       update: { ...data },
     })
+
+    await companyIdentifierService.syncFromLegacyColumns(company)
+
+    return company
   }
 
   async updateCompanyTags(wikidataId: string, tags: string[]) {

--- a/src/api/services/companyService.ts
+++ b/src/api/services/companyService.ts
@@ -4,11 +4,12 @@ import {
   Turnover,
   Description,
   Prisma,
+  User,
 } from '@prisma/client'
 import { OptionalNullable } from '../../lib/type-utils'
 import { DefaultEconomyType } from '../types'
 import { prisma } from '../../lib/prisma'
-import { economyArgs, detailedCompanyArgs, companyListArgs } from '../args'
+import { economyArgs, detailedCompanyArgs, pipelineCompanyDetailArgs, companyListArgs } from '../args'
 import {
   calculateEmissionChangeLastTwoYears,
   calculateScope2Total,
@@ -122,7 +123,7 @@ class CompanyService {
 
   async getCompanyWithMetadata(wikidataId: string) {
     const company = await prisma.company.findFirstOrThrow({
-      ...detailedCompanyArgs,
+      ...pipelineCompanyDetailArgs,
       where: {
         wikidataId,
       },
@@ -157,6 +158,7 @@ class CompanyService {
 
   async upsertCompany({
     wikidataId,
+    user,
     ...data
   }: {
     wikidataId: string
@@ -166,6 +168,7 @@ class CompanyService {
     internalComment?: string
     tags?: string[]
     lei?: string
+    user?: User
   }) {
     const company = await prisma.company.upsert({
       where: {
@@ -178,7 +181,10 @@ class CompanyService {
       update: { ...data },
     })
 
-    await companyIdentifierService.syncFromLegacyColumns(company)
+    await companyIdentifierService.syncFromLegacyColumns(company, {
+      user,
+      source: user ? 'validate-editor' : 'company-column-sync',
+    })
 
     return company
   }

--- a/src/api/services/companyService.ts
+++ b/src/api/services/companyService.ts
@@ -9,7 +9,12 @@ import {
 import { OptionalNullable } from '../../lib/type-utils'
 import { DefaultEconomyType } from '../types'
 import { prisma } from '../../lib/prisma'
-import { economyArgs, detailedCompanyArgs, pipelineCompanyDetailArgs, companyListArgs } from '../args'
+import {
+  economyArgs,
+  detailedCompanyArgs,
+  pipelineCompanyDetailArgs,
+  companyListArgs,
+} from '../args'
 import {
   calculateEmissionChangeLastTwoYears,
   calculateScope2Total,

--- a/src/api/services/companyService.ts
+++ b/src/api/services/companyService.ts
@@ -489,6 +489,7 @@ class CompanyService {
 export const companyService = new CompanyService()
 
 export function transformMetadata(data: any): any {
+  // TODO(Klimatbyran/garbo#1334): metadata arrays collapse to null; Zod schemas still require MetadataSchema.
   if (Array.isArray(data)) {
     return data.map((item) => transformMetadata(item))
   } else if (data && typeof data === 'object') {

--- a/src/api/services/emissionsService.ts
+++ b/src/api/services/emissionsService.ts
@@ -14,6 +14,7 @@ import { emissionsArgs } from '../args'
 import _ from 'lodash'
 
 class EmissionsService {
+  // TODO(Klimatbyran/garbo#1333): upsertScope* flows create metadata then connect in separate writes; use $transaction.
   async upsertEmissions({
     emissionsId,
     reportingPeriodId,

--- a/src/api/services/goalService.ts
+++ b/src/api/services/goalService.ts
@@ -3,6 +3,7 @@ import { prisma } from '../../lib/prisma'
 import { PostGoalBody, PostGoalsBody } from '../types'
 
 class GoalService {
+  // TODO(Klimatbyran/garbo#1333): createMetadata + goal.create should run in one $transaction.
   async createGoals(
     wikidataId: Company['wikidataId'],
     goals: PostGoalsBody['goals'],

--- a/src/api/services/metadataService.ts
+++ b/src/api/services/metadataService.ts
@@ -2,6 +2,7 @@ import { Metadata, User } from '@prisma/client'
 import { prisma } from '../../lib/prisma'
 
 class MetadataService {
+  // TODO(Klimatbyran/garbo#1333): Callers should wrap createMetadata + datapoint writes in prisma.$transaction.
   async createMetadata({
     user,
     metadata,

--- a/src/api/services/registryReportIdentity.ts
+++ b/src/api/services/registryReportIdentity.ts
@@ -28,6 +28,28 @@ export function trimStr(s: string | null | undefined): string | null {
   return trimmed.length ? trimmed : null
 }
 
+export function isPlaceholderCompanyName(
+  name: string | null | undefined
+): boolean {
+  const trimmed = trimStr(name)
+  if (!trimmed) return true
+  return trimmed.toLowerCase() === 'unknown'
+}
+
+/** Registry upsert: keep existing name unless it is missing or the placeholder "Unknown". */
+export function mergeCompanyNameFromPipeline(
+  existing: string | null | undefined,
+  incoming: string | null | undefined
+): string | undefined {
+  if (!isPlaceholderCompanyName(existing)) {
+    return trimStr(existing) ?? undefined
+  }
+  if (isPlaceholderCompanyName(incoming)) {
+    return trimStr(existing) ?? trimStr(incoming) ?? undefined
+  }
+  return trimStr(incoming) ?? undefined
+}
+
 /** Backfill / one-off catalog year parsing (tight window for current registry cleanup). */
 const REPORT_CATALOG_YEAR_MIN = 2000
 const REPORT_CATALOG_YEAR_MAX = 2026
@@ -292,11 +314,19 @@ export function copyMissingFields(
   ] as const
 
   for (const field of fields) {
-    if (
-      !trimStr(rowToKeep[field] as string | null) &&
-      trimStr(rowToDelete[field] as string | null)
-    ) {
-      patch[field] = trimStr(rowToDelete[field] as string | null) as any
+    const keepValue = rowToKeep[field] as string | null
+    const deleteValue = trimStr(rowToDelete[field] as string | null)
+    const keepIsEmpty =
+      field === 'companyName'
+        ? isPlaceholderCompanyName(keepValue)
+        : !trimStr(keepValue)
+    const deleteIsPresent =
+      field === 'companyName'
+        ? !isPlaceholderCompanyName(deleteValue)
+        : Boolean(deleteValue)
+
+    if (keepIsEmpty && deleteIsPresent) {
+      patch[field] = deleteValue as any
     }
   }
 

--- a/src/api/services/registryService.ts
+++ b/src/api/services/registryService.ts
@@ -9,6 +9,7 @@ import {
   buildReportMatchConditions,
   copyMissingFields,
   pickRowToKeep,
+  mergeCompanyNameFromPipeline,
   mergeReportYearFromPipeline,
   type RegistryReportIdentityRow,
   trimStr,
@@ -52,7 +53,10 @@ function patchRow(
   input: ReportInput
 ): Prisma.ReportUpdateInput {
   const update: Prisma.ReportUpdateInput = {
-    companyName: existing.companyName ?? input.companyName,
+    companyName: mergeCompanyNameFromPipeline(
+      existing.companyName,
+      input.companyName
+    ),
     wikidataId: existing.wikidataId ?? input.wikidataId ?? undefined,
     reportYear: mergeReportYearFromPipeline(
       existing.reportYear,
@@ -81,7 +85,10 @@ function applyMergedRows(
   const webUrl = findWebUrlUpgrade(merged, input.url)
 
   return {
-    companyName: merged.companyName ?? input.companyName,
+    companyName: mergeCompanyNameFromPipeline(
+      merged.companyName,
+      input.companyName
+    ),
     wikidataId: merged.wikidataId ?? input.wikidataId ?? undefined,
     reportYear: mergeReportYearFromPipeline(
       merged.reportYear,

--- a/src/api/services/serviceBotUser.ts
+++ b/src/api/services/serviceBotUser.ts
@@ -1,0 +1,22 @@
+import { User } from '@prisma/client'
+import { prisma } from '../../lib/prisma'
+
+/** Service client_id used by pipeline workers (`POST /auth/token`) and automated jobs. */
+export const GARBO_SERVICE_CLIENT_ID = 'garbo'
+
+export async function getOrCreateServiceBotUser(
+  clientId: string = GARBO_SERVICE_CLIENT_ID
+): Promise<User> {
+  return prisma.user.upsert({
+    where: { name: clientId },
+    update: {
+      bot: true,
+      email: `${clientId}@klimatkollen.se`,
+    },
+    create: {
+      name: clientId,
+      email: `${clientId}@klimatkollen.se`,
+      bot: true,
+    },
+  })
+}

--- a/tests/companyIdentifierService.test.ts
+++ b/tests/companyIdentifierService.test.ts
@@ -17,6 +17,11 @@ jest.unstable_mockModule('../src/lib/prisma', () => ({
   prisma: prismaMock,
 }))
 
+jest.unstable_mockModule('../src/api/services/serviceBotUser', () => ({
+  GARBO_SERVICE_CLIENT_ID: 'garbo',
+  getOrCreateServiceBotUser: jest.fn(async () => botUser),
+}))
+
 const { companyIdentifierService } = await import(
   '../src/api/services/companyIdentifierService'
 )
@@ -26,7 +31,6 @@ const botUser = { id: 'user-garbo', name: 'garbo', bot: true }
 describe('companyIdentifierService', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    prismaMock.user.upsert.mockResolvedValue(botUser)
   })
 
   it('upsertIdentifier creates row and metadata for new identifier', async () => {

--- a/tests/companyIdentifierService.test.ts
+++ b/tests/companyIdentifierService.test.ts
@@ -1,0 +1,93 @@
+import { jest } from '@jest/globals'
+
+const prismaMock = {
+  user: {
+    upsert: jest.fn<() => Promise<unknown>>(),
+  },
+  metadata: {
+    create: jest.fn<() => Promise<unknown>>(),
+  },
+  companyIdentifier: {
+    findUnique: jest.fn<() => Promise<unknown>>(),
+    upsert: jest.fn<() => Promise<unknown>>(),
+  },
+}
+
+jest.unstable_mockModule('../src/lib/prisma', () => ({
+  prisma: prismaMock,
+}))
+
+const { companyIdentifierService } = await import(
+  '../src/api/services/companyIdentifierService'
+)
+
+const botUser = { id: 'user-garbo', name: 'garbo', bot: true }
+
+describe('companyIdentifierService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    prismaMock.user.upsert.mockResolvedValue(botUser)
+  })
+
+  it('upsertIdentifier creates row and metadata for new identifier', async () => {
+    prismaMock.companyIdentifier.findUnique.mockResolvedValue(null)
+    prismaMock.metadata.create.mockResolvedValue({ id: 'meta-1' })
+    prismaMock.companyIdentifier.upsert.mockResolvedValue({
+      id: 'id-1',
+      type: 'WIKIDATA',
+      value: 'Q123',
+    })
+
+    await companyIdentifierService.upsertIdentifier({
+      companyId: 'company-1',
+      type: 'WIKIDATA',
+      value: 'Q123',
+      user: botUser as any,
+      metadata: { source: 'test' },
+    })
+
+    expect(prismaMock.metadata.create).toHaveBeenCalled()
+    expect(prismaMock.companyIdentifier.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { companyId_type: { companyId: 'company-1', type: 'WIKIDATA' } },
+        create: expect.objectContaining({ value: 'Q123' }),
+      })
+    )
+  })
+
+  it('upsertIdentifier skips metadata when value unchanged and skipMetadataIfUnchanged is set', async () => {
+    prismaMock.companyIdentifier.findUnique.mockResolvedValue({
+      id: 'id-1',
+      value: 'Q123',
+    })
+
+    const result = await companyIdentifierService.upsertIdentifier({
+      companyId: 'company-1',
+      type: 'WIKIDATA',
+      value: 'Q123',
+      user: botUser as any,
+      skipMetadataIfUnchanged: true,
+    })
+
+    expect(result).toEqual({ id: 'id-1', value: 'Q123' })
+    expect(prismaMock.metadata.create).not.toHaveBeenCalled()
+    expect(prismaMock.companyIdentifier.upsert).not.toHaveBeenCalled()
+  })
+
+  it('syncFromLegacyColumns upserts wikidata and lei from company columns', async () => {
+    prismaMock.companyIdentifier.findUnique.mockResolvedValue(null)
+    prismaMock.metadata.create.mockResolvedValue({ id: 'meta-1' })
+    prismaMock.companyIdentifier.upsert.mockResolvedValue({ id: 'id-1' })
+
+    await companyIdentifierService.syncFromLegacyColumns(
+      {
+        id: 'company-1',
+        wikidataId: 'Q99',
+        lei: 'LEI123',
+      },
+      { user: botUser as any, source: 'migration-backfill' }
+    )
+
+    expect(prismaMock.companyIdentifier.upsert).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/companyIdentifierService.test.ts
+++ b/tests/companyIdentifierService.test.ts
@@ -11,6 +11,10 @@ const prismaMock = {
     findUnique: jest.fn<() => Promise<unknown>>(),
     upsert: jest.fn<() => Promise<unknown>>(),
   },
+  $transaction: jest.fn(
+    async (callback: (client: typeof prismaMock) => Promise<unknown>) =>
+      callback(prismaMock)
+  ),
 }
 
 jest.unstable_mockModule('../src/lib/prisma', () => ({
@@ -51,6 +55,7 @@ describe('companyIdentifierService', () => {
     })
 
     expect(prismaMock.metadata.create).toHaveBeenCalled()
+    expect(prismaMock.$transaction).toHaveBeenCalled()
     expect(prismaMock.companyIdentifier.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { companyId_type: { companyId: 'company-1', type: 'WIKIDATA' } },

--- a/tests/registryReportIdentity.test.ts
+++ b/tests/registryReportIdentity.test.ts
@@ -2,6 +2,7 @@ import {
   buildReportMatchConditions,
   copyMissingFields,
   linkReportRowsByPdfBasename,
+  mergeCompanyNameFromPipeline,
   parseReportYearFromUrl,
   pdfBasenameFromUrl,
   pdfBasenamesMatchForIdentityLink,
@@ -301,5 +302,36 @@ describe('registryReportIdentity', () => {
     const patch = copyMissingFields(rowToKeep, rowToDelete)
     expect(patch.sourceUrl).toBe('https://src')
     expect(patch.url).toBe('https://human/page')
+  })
+
+  describe('mergeCompanyNameFromPipeline', () => {
+    it('replaces placeholder or missing names with the pipeline name', () => {
+      expect(mergeCompanyNameFromPipeline('Unknown', 'Acme Corp')).toBe(
+        'Acme Corp'
+      )
+      expect(mergeCompanyNameFromPipeline(null, 'Acme Corp')).toBe('Acme Corp')
+      expect(mergeCompanyNameFromPipeline('unknown', 'Acme Corp')).toBe(
+        'Acme Corp'
+      )
+    })
+
+    it('keeps a real existing name over the pipeline input', () => {
+      expect(mergeCompanyNameFromPipeline('Acme', 'New Name')).toBe('Acme')
+    })
+  })
+
+  it('copyMissingFields replaces placeholder company names', () => {
+    const rowToKeep = row({
+      id: 'a',
+      url: 'https://storage.googleapis.com/garbo/x.pdf',
+      companyName: 'Unknown',
+    })
+    const rowToDelete = row({
+      id: 'b',
+      url: 'https://human/page',
+      companyName: 'Acme Corp',
+    })
+    const patch = copyMissingFields(rowToKeep, rowToDelete)
+    expect(patch.companyName).toBe('Acme Corp')
   })
 })

--- a/tests/registryService.test.ts
+++ b/tests/registryService.test.ts
@@ -97,6 +97,47 @@ describe('registryService', () => {
     })
   })
 
+  it('upsert replaces placeholder company name with pipeline name', async () => {
+    const existing = {
+      id: 'r1',
+      url: 'https://example.com/report.pdf',
+      companyName: 'Unknown',
+      wikidataId: null,
+      reportYear: null,
+      sourceUrl: null,
+      s3Url: null,
+      s3Key: null,
+      s3Bucket: null,
+      sha256: 'a'.repeat(64),
+    }
+
+    mockPrisma.report.findMany.mockResolvedValueOnce([existing])
+    mockPrisma.report.update.mockResolvedValueOnce({
+      ...existing,
+      companyName: 'Acme Corp',
+      wikidataId: 'Q1',
+    })
+
+    await registryService.upsertReportInRegistry(
+      {
+        companyName: 'Acme Corp',
+        wikidataId: 'Q1',
+        reportYear: '2024',
+        url: 'https://example.com/report.pdf',
+        sha256: 'a'.repeat(64),
+      },
+      mockPrisma
+    )
+
+    expect(mockPrisma.report.update).toHaveBeenCalledWith({
+      where: { id: 'r1' },
+      data: expect.objectContaining({
+        companyName: 'Acme Corp',
+        wikidataId: 'Q1',
+      }),
+    })
+  })
+
   it('creates when no OR matches', async () => {
     mockPrisma.report.findMany.mockResolvedValueOnce([])
 

--- a/tests/serviceBotUser.test.ts
+++ b/tests/serviceBotUser.test.ts
@@ -1,0 +1,55 @@
+import { jest } from '@jest/globals'
+
+const prismaMock = {
+  user: {
+    upsert: jest.fn<() => Promise<unknown>>(),
+  },
+}
+
+jest.unstable_mockModule('../src/lib/prisma', () => ({
+  prisma: prismaMock,
+}))
+
+const { getOrCreateServiceBotUser, GARBO_SERVICE_CLIENT_ID } = await import(
+  '../src/api/services/serviceBotUser'
+)
+
+describe('serviceBotUser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('upserts a bot user for the garbo service client id', async () => {
+    const botUser = { id: 'u1', name: GARBO_SERVICE_CLIENT_ID, bot: true }
+    prismaMock.user.upsert.mockResolvedValue(botUser)
+
+    const result = await getOrCreateServiceBotUser()
+
+    expect(result).toEqual(botUser)
+    expect(prismaMock.user.upsert).toHaveBeenCalledWith({
+      where: { name: GARBO_SERVICE_CLIENT_ID },
+      update: {
+        bot: true,
+        email: 'garbo@klimatkollen.se',
+      },
+      create: {
+        name: GARBO_SERVICE_CLIENT_ID,
+        email: 'garbo@klimatkollen.se',
+        bot: true,
+      },
+    })
+  })
+
+  it('supports other service client ids', async () => {
+    prismaMock.user.upsert.mockResolvedValue({ id: 'u2', name: 'other-svc' })
+
+    await getOrCreateServiceBotUser('other-svc')
+
+    expect(prismaMock.user.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { name: 'other-svc' },
+        create: expect.objectContaining({ email: 'other-svc@klimatkollen.se' }),
+      })
+    )
+  })
+})


### PR DESCRIPTION
### ✨ What’s Changed?

Company identifiers table + dual-write

#### Summary

Introduces a `company_identifiers` table so companies can hold multiple typed identifiers (Wikidata, LEI, org number, ISIN) with standard `Metadata`, while keeping existing `Company.wikidataId` and `Company.lei` columns for backward compatibility.

This is **Phase 1** of the broader identifiers work. See [`doc/COMPANY_IDENTIFIERS_PLAN.md`](./COMPANY_IDENTIFIERS_PLAN.md) for the full roadmap (PK flip, non-blocking pipeline, Validate UI, metadata history).

**Partner / external API responses are unchanged** — `identifiers` are only loaded on pipeline/staff company detail reads, not on public partner routes.

---

#### What changed

##### Database

- New `CompanyIdentifierType` enum: `WIKIDATA`, `LEI`, `ORG_NUMBER`, `ISIN`
- New `company_identifiers` table (`companyId` → `Company.id`, unique per `(companyId, type)`)
- `Metadata.companyIdentifierId` FK (same pattern as `scope1Id`, `industryId`, etc.)
- Migration: `prisma/migrations/20260629120000_add_company_identifiers/`

#### Services

- **`companyIdentifierService`** — upsert identifier + metadata; `syncFromLegacyColumns` from `Company.wikidataId` / `Company.lei`
- **`companyService.upsertCompany`** — dual-writes to identifiers after every upsert; accepts optional `user` for staff saves
- **`serviceBotUser`** — shared `getOrCreateServiceBotUser()` used by `authService` (pipeline token) and automated identifier sync (backfill, no JWT)

#### API (internal only)

- `GET /api/pipeline/companies/:wikidataId` returns `identifiers[]` on `InternalCompanyDetails`
- `identifiers` use `pipelineCompanyDetailArgs` — **not** included in `detailedCompanyArgs` / partner reads
- Staff `POST /api/companies/:wikidataId` passes `request.user` into identifier sync (`source: validate-editor`)

#### Scripts

- `scripts/backfill-company-identifiers.ts` — idempotent backfill from legacy columns (`--dry-run`, `--mark-verified`)

#### Tests

- `tests/companyIdentifierService.test.ts`
- `tests/serviceBotUser.test.ts`

#### Also in this branch - Bug Fix

- `registryReportIdentity.ts` / `registryService.ts` — replace placeholder `"Unknown"` company names when pipeline provides a real name
- Related tests in `registryReportIdentity.test.ts`, `registryService.test.ts`

---

### What is intentionally not in this PR

Have several changes planned in connection with shifting to using companyID as primary key instead of wikidataID. This PR is a phase 1 of 6. 
- Primary key flip (`Company.id` as `@id`, nullable `wikidataId`) — Phase 2
- Non-blocking `guessWikidata` pipeline flow — Phase 3
- Validate UI for identifiers — Phase 4
- unearth-api sync — separate PR required before Validate can use `identifiers`
- Reverse sync (identifier table → legacy columns when only identifiers are updated)
- `Metadata.previousValue` / full metadata history — Phase 6

### 🔍 How to Review / Test

**Order matters:** garbo migration first, then backfill, then deploy unearth-api when that PR is ready.

```bash
# 1. Migrate
npx prisma migrate deploy

# 2. Backfill (staging first)
npx tsx scripts/backfill-company-identifiers.ts --dry-run
npx tsx scripts/backfill-company-identifiers.ts

# Optional: mark backfilled rows verified (curated prod only — sets verifiedBy to garbo bot)
npx tsx scripts/backfill-company-identifiers.ts --mark-verified
```

**Verify:**

```sql
SELECT COUNT(*) FROM "Company";
SELECT COUNT(*) FROM "company_identifiers" WHERE type = 'WIKIDATA';
SELECT c."wikidataId", i.value
FROM "Company" c
LEFT JOIN "company_identifiers" i ON i."companyId" = c.id AND i.type = 'WIKIDATA'
WHERE c."wikidataId" IS NOT NULL AND (i.value IS NULL OR i.value <> c."wikidataId");
```

---

### Follow-up

1. **unearth-api PR** — mirror schema, `companyIdentifierService`, dual-write, `pipelineCompanyDetailArgs`, internal Zod schemas
2. **Phase 2** — PK flip to `Company.id`
3. **Phase 3** — decouple `guessWikidata` from blocking pipeline

### 📋 Checklist

- [x] PR title starts with `[#issue-number]`; if no issue is applicable use: `[fix]`, `[feat]`, `[ops]`, or `[prod]`
- [x] I’ve added/updated tests (or noted why they’re not needed)
- [ ] I’ve verified the change runs locally (and in Docker/k8s if relevant)
- [x] If this changes the API contract, I’ve called that out clearly (and considered backward compatibility)
- [x] If this includes a DB change, I’ve included a migration + rollout/rollback notes
- [ ] I’ve considered observability (logs/metrics/traces) and added what’s needed
- [ ] I’ve set labels, linked issue, and milestone (if applicable)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->
