### PR TITLE
[Prod] Minor Version Bump v5.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo",
-  "version": "5.11.4-rc.3",
+  "version": "5.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo",
-      "version": "5.11.4-rc.3",
+      "version": "5.12.0",
       "hasInstallScript": true,
       "license": "MIT License",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garbo",
-  "version": "5.11.4-rc.3",
+  "version": "5.12.0",
   "description": "",
   "type": "module",
   "exports": {


### PR DESCRIPTION
# 🚀 Production Release PR

> **Title format:** `[Prod] Major/Minor/Patch Version Bump vX.X.X`

## 📦 Release Type

_Select the appropriate release type by marking with an `x`._

- [ ] Major version bump
- [x] Minor version bump
- [ ] Patch version bump

### Rollback Version

_Note the relevant rollback version to enable quick rollback if necessary._

v5.11.3

## 🔁 Environment Promotion

This release promotes changes **from `staging` to `production`** (see `k8s/overlays/staging` and `k8s/overlays/production`).

## 📋 What's Being Released

_Provide a summary of the features, fixes, or updates included in this production release._

- **Phase 1 — Company identifiers** ([#1330](https://github.com/Klimatbyran/garbo/pull/1330)): `company_identifiers` table, dual-write from `wikidataId`/`lei`, internal pipeline reads include `identifiers[]`, `serviceBotUser` for automated metadata
- Registry report identity: replace placeholder `"Unknown"` company names when pipeline provides a real name
- LEI worker: improved error handling ([#1300](https://github.com/Klimatbyran/garbo/pull/1300))
- `GET /api/companies/kpis`: add `sectorCode` for Klimatkollen sector filtering ([#1313](https://github.com/Klimatbyran/garbo/pull/1313))

**Partner API shape unchanged** — legacy `wikidataId` and `lei` columns remain on company responses.

## 🗂 Deployment Notes (optional)

_Anything to watch out for: DB migrations, feature flags, long-running jobs, cache warmup, etc._

**Garbo (this PR)**

1. Deploy rolls out image; init container runs `prisma migrate deploy` (Phase 1 migration: `20260629120000_add_company_identifiers`)
2. **After deploy**, run identifier backfill on prod:
   ```bash
   kubectl exec deployment/garbo -c garbo -n garbo -- npx --yes tsx scripts/backfill-company-identifiers.ts --dry-run
   kubectl exec deployment/garbo -c garbo -n garbo -- npx --yes tsx scripts/backfill-company-identifiers.ts
   ```
3. Verify (from [`doc/COMPANY_IDENTIFIERS_PLAN.md`](./doc/COMPANY_IDENTIFIERS_PLAN.md)):
   ```sql
   SELECT COUNT(*) FROM "Company";
   SELECT COUNT(*) FROM "company_identifiers" WHERE type = 'WIKIDATA';
   ```
4. Backfill sets legacy `source`\/`comment` only; `verifiedBy` stays null (see `scripts\/backfill-company-identifiers.ts`)

**unearth-api (paired release required)**

Deploy **API Phase 1** ([UnearthData/api#24](https://github.com/UnearthData/api/pull/24)) to prod in the same window — shared DB, dual-write + identifier reads.

**Not in this release:** Phase 2 PK flip ([#1332](https://github.com/Klimatbyran/garbo/pull/1332)) — stage only until Phase 1 is verified in prod.

## ✅ Checklist

- [x] Version number is updated correctly (code/package and/or k8s image tag)
- [ ] All relevant changes have been QA-tested in staging
- [x] Rollback version has been updated
- [x] Title follows the required format: `[Prod] Major/Minor/Patch Version Bump vX.X.X`
- [ ] Identifier backfill run and verified in prod after deploy
- [ ] unearth-api Phase 1 deployed to prod

---

_This template is for versioned production releases only. For other PR types, please select a different template._

Made with [Cursor](https://cursor.com)