### PR TITLE
[FIX] Modify backfill to set source and comment instead of verified by

### DIFF
--- a/doc/COMPANY_IDENTIFIERS_PLAN.md
+++ b/doc/COMPANY_IDENTIFIERS_PLAN.md
@@ -69,13 +69,13 @@ Keep `Company.wikidataId` and `Company.lei` during transition. **Dual-write**: i
 
 ### Verification
 
-| State                                    | `metadata.verifiedBy`                   | Typical `source`                          |
-| ---------------------------------------- | --------------------------------------- | ----------------------------------------- |
-| Pipeline guess, not reviewed             | `null`                                  | `wikidata-search`, `override-wikidata-id` |
-| Auto-matched production DB               | optional bot / `null`                   | `production-database`                     |
-| Human approved in Validate               | approver user id                        | from approval                             |
-| Manual editor save with `verified: true` | editor user id                          | `validate-editor`                         |
-| Backfill from legacy columns             | `null`                                  | `legacy-company-wikidata` / `legacy-company-lei` |
+| State                                    | `metadata.verifiedBy` | Typical `source`                                 |
+| ---------------------------------------- | --------------------- | ------------------------------------------------ |
+| Pipeline guess, not reviewed             | `null`                | `wikidata-search`, `override-wikidata-id`        |
+| Auto-matched production DB               | optional bot / `null` | `production-database`                            |
+| Human approved in Validate               | approver user id      | from approval                                    |
+| Manual editor save with `verified: true` | editor user id        | `validate-editor`                                |
+| Backfill from legacy columns             | `null`                | `legacy-company-wikidata` / `legacy-company-lei` |
 
 Query “is Wikidata verified?” → `CompanyIdentifier` where `type = WIKIDATA` and latest metadata has non-null `verifiedBy`.
 

--- a/doc/COMPANY_IDENTIFIERS_PLAN.md
+++ b/doc/COMPANY_IDENTIFIERS_PLAN.md
@@ -75,7 +75,7 @@ Keep `Company.wikidataId` and `Company.lei` during transition. **Dual-write**: i
 | Auto-matched production DB               | optional bot / `null`                   | `production-database`                     |
 | Human approved in Validate               | approver user id                        | from approval                             |
 | Manual editor save with `verified: true` | editor user id                          | `validate-editor`                         |
-| Backfill from legacy columns             | `null` (or `--mark-verified` in script) | `migration-backfill`                      |
+| Backfill from legacy columns             | `null`                                  | `legacy-company-wikidata` / `legacy-company-lei` |
 
 Query “is Wikidata verified?” → `CompanyIdentifier` where `type = WIKIDATA` and latest metadata has non-null `verifiedBy`.
 
@@ -291,10 +291,9 @@ npx prisma migrate deploy
 # Backfill (staging first):
 npx tsx scripts/backfill-company-identifiers.ts --dry-run
 npx tsx scripts/backfill-company-identifiers.ts
-
-# Optional: mark backfilled Wikidata as verified (curated prod only):
-npx tsx scripts/backfill-company-identifiers.ts --mark-verified
 ```
+
+Backfill sets legacy `source` / `comment` on metadata only (`verifiedBy` stays null). Wikidata and LEI use separate sources — see `scripts/backfill-company-identifiers.ts`.
 
 Verify:
 

--- a/scripts/backfill-company-identifiers.ts
+++ b/scripts/backfill-company-identifiers.ts
@@ -1,10 +1,11 @@
 /**
  * Backfill `company_identifiers` from legacy `Company.wikidataId` and `Company.lei`.
  *
+ * Metadata uses legacy-specific `source` and `comment`; does not set `verifiedBy`.
+ *
  * Usage:
  *   npx tsx scripts/backfill-company-identifiers.ts --dry-run
  *   npx tsx scripts/backfill-company-identifiers.ts
- *   npx tsx scripts/backfill-company-identifiers.ts --mark-verified
  *
  * Run against staging first.
  */
@@ -15,15 +16,25 @@ import { parseArgs } from 'node:util'
 import { prisma } from '../src/lib/prisma'
 import { companyIdentifierService } from '../src/api/services/companyIdentifierService'
 
+const LEGACY_WIKIDATA_METADATA = {
+  source: 'legacy-company-wikidata',
+  comment:
+    'Inherited from Company.wikidataId before company_identifiers table (Phase 1 backfill). Pre-identifier company identity.',
+} as const
+
+const LEGACY_LEI_METADATA = {
+  source: 'legacy-company-lei',
+  comment:
+    'Inherited from Company.lei before company_identifiers table (Phase 1 backfill).',
+} as const
+
 const { values } = parseArgs({
   options: {
     'dry-run': { type: 'boolean', default: false },
-    'mark-verified': { type: 'boolean', default: false },
   },
 })
 
 const dryRun = values['dry-run'] ?? false
-const markVerified = values['mark-verified'] ?? false
 
 async function main() {
   const companies = await prisma.company.findMany({
@@ -54,8 +65,8 @@ async function main() {
     }
 
     await companyIdentifierService.syncFromLegacyColumns(company, {
-      source: 'migration-backfill',
-      verified: markVerified,
+      wikidataMetadata: LEGACY_WIKIDATA_METADATA,
+      leiMetadata: LEGACY_LEI_METADATA,
     })
     synced++
   }

--- a/src/api/services/companyIdentifierService.ts
+++ b/src/api/services/companyIdentifierService.ts
@@ -66,29 +66,34 @@ class CompanyIdentifierService {
   }
 
   async syncFromLegacyColumns(
-    company: { id: string; wikidataId: string; lei?: string | null },
+    company: { id: string; wikidataId: string | null; lei?: string | null },
     options?: {
       user?: User
       source?: string
       verified?: boolean
+      wikidataMetadata?: { source?: string; comment?: string }
+      leiMetadata?: { source?: string; comment?: string }
     }
   ) {
     const user =
       options?.user ??
       (await getOrCreateServiceBotUser(GARBO_SERVICE_CLIENT_ID))
-    const source = options?.source ?? 'company-column-sync'
+    const defaultSource = options?.source ?? 'company-column-sync'
 
     const synced: Array<{ id: string; value?: string }> = []
 
-    if (company.wikidataId.trim()) {
+    if (company.wikidataId?.trim()) {
       const row = await this.upsertIdentifier({
         companyId: company.id,
         type: 'WIKIDATA',
         value: company.wikidataId,
         user,
         metadata: {
-          source,
-          comment: 'Synced from Company.wikidataId',
+          source:
+            options?.wikidataMetadata?.source ?? defaultSource,
+          comment:
+            options?.wikidataMetadata?.comment ??
+            'Synced from Company.wikidataId',
         },
         verified: options?.verified ?? false,
         skipMetadataIfUnchanged: true,
@@ -104,8 +109,9 @@ class CompanyIdentifierService {
         value: lei,
         user,
         metadata: {
-          source,
-          comment: 'Synced from Company.lei',
+          source: options?.leiMetadata?.source ?? defaultSource,
+          comment:
+            options?.leiMetadata?.comment ?? 'Synced from Company.lei',
         },
         verified: options?.verified ?? false,
         skipMetadataIfUnchanged: true,

--- a/src/api/services/companyIdentifierService.ts
+++ b/src/api/services/companyIdentifierService.ts
@@ -89,8 +89,7 @@ class CompanyIdentifierService {
         value: company.wikidataId,
         user,
         metadata: {
-          source:
-            options?.wikidataMetadata?.source ?? defaultSource,
+          source: options?.wikidataMetadata?.source ?? defaultSource,
           comment:
             options?.wikidataMetadata?.comment ??
             'Synced from Company.wikidataId',
@@ -110,8 +109,7 @@ class CompanyIdentifierService {
         user,
         metadata: {
           source: options?.leiMetadata?.source ?? defaultSource,
-          comment:
-            options?.leiMetadata?.comment ?? 'Synced from Company.lei',
+          comment: options?.leiMetadata?.comment ?? 'Synced from Company.lei',
         },
         verified: options?.verified ?? false,
         skipMetadataIfUnchanged: true,


### PR DESCRIPTION
### ✨ What’s Changed?

The identifiers metadata backfill should only set a source and comment to indicate this was from legacy fields rather than setting a verifiedby user. 

### 🔍 How to Review / Test

<!-- Include relevant commands, curl examples, or steps in staging -->

### 📋 Checklist

- [x] PR title starts with `[#issue-number]`; if no issue is applicable use: `[fix]`, `[feat]`, `[ops]`, or `[prod]`
- [x] I’ve added/updated tests (or noted why they’re not needed)
- [x] I’ve verified the change runs locally (and in Docker/k8s if relevant)
- [ ] If this changes the API contract, I’ve called that out clearly (and considered backward compatibility)
- [ ] If this includes a DB change, I’ve included a migration + rollout/rollback notes
- [ ] I’ve considered observability (logs/metrics/traces) and added what’s needed
- [x] I’ve set labels, linked issue, and milestone (if applicable)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->
