### PR TITLE
Add pdfUrls filter to archive runs API for registry overview lookup

### DIFF
--- a/src/api/routes/internal/queue.archive.read.ts
+++ b/src/api/routes/internal/queue.archive.read.ts
@@ -13,6 +13,8 @@ const queryList = z.object({
   q: z.string().optional(),
   /** Comma-separated CompanyReport ids — narrows archive for Validate overview. */
   companyReportIds: z.string().optional(),
+  /** Comma-separated exact `ReportRun.pdfUrl` values — registry gap overview lookup. */
+  pdfUrls: z.string().optional(),
   /**
    * Comma-separated Garbo `Batch.id` (cuid). Single id = exact match; multiple = OR (`IN`).
    * @deprecated Prefer `batchDbIds`; kept for older clients.
@@ -70,6 +72,12 @@ export async function queueArchiveInternalReadRoutes(app: FastifyInstance) {
         if (t) companyReportIdSet.add(t)
       }
       const companyReportIds = [...companyReportIdSet]
+      const pdfUrlSet = new Set<string>()
+      for (const part of (q.pdfUrls ?? '').split(',')) {
+        const t = part.trim()
+        if (t) pdfUrlSet.add(t)
+      }
+      const pdfUrls = [...pdfUrlSet]
       const batchIdSet = new Set<string>()
       for (const part of (q.batchDbIds ?? '').split(',')) {
         const t = part.trim()
@@ -84,6 +92,7 @@ export async function queueArchiveInternalReadRoutes(app: FastifyInstance) {
         q: q.q,
         companyReportIds:
           companyReportIds.length > 0 ? companyReportIds : undefined,
+        pdfUrls: pdfUrls.length > 0 ? pdfUrls : undefined,
         batchDbIds: batchDbIds.length > 0 ? batchDbIds : undefined,
         batchName: q.batchName,
       })

--- a/src/api/services/reportRunArchiveReadService.ts
+++ b/src/api/services/reportRunArchiveReadService.ts
@@ -21,12 +21,14 @@ const batchListSelect = {
 function buildListWhere(args: {
   q?: string
   companyReportIds?: string[]
+  /** Exact `ReportRun.pdfUrl` values — OR match when more than one. */
+  pdfUrls?: string[]
   /** Garbo `Batch.id` values; OR match when more than one. */
   batchDbIds?: string[]
   /** Exact match on `Batch.batchName` (same string as pipeline `job.data.batchId`). */
   batchName?: string
 }): Prisma.ReportRunWhereInput {
-  const { q, companyReportIds, batchDbIds, batchName } = args
+  const { q, companyReportIds, pdfUrls, batchDbIds, batchName } = args
   const qTrim = q?.trim()
   const idList = (batchDbIds ?? []).map((s) => s.trim()).filter(Boolean)
   const batchNameTrim = batchName?.trim()
@@ -39,6 +41,14 @@ function buildListWhere(args: {
       ? { companyReportId: { in: reportIdList } }
       : reportIdList.length === 1
         ? { companyReportId: reportIdList[0] }
+        : null
+
+  const pdfUrlList = (pdfUrls ?? []).map((s) => s.trim()).filter(Boolean)
+  const pdfUrlWhere: Prisma.ReportRunWhereInput | null =
+    pdfUrlList.length > 1
+      ? { pdfUrl: { in: pdfUrlList } }
+      : pdfUrlList.length === 1
+        ? { pdfUrl: pdfUrlList[0] }
         : null
 
   const textWhere: Prisma.ReportRunWhereInput | null = qTrim
@@ -79,6 +89,7 @@ function buildListWhere(args: {
   if (textWhere) parts.push(textWhere)
   if (batchPick) parts.push(batchPick)
   if (companyReportWhere) parts.push(companyReportWhere)
+  if (pdfUrlWhere) parts.push(pdfUrlWhere)
 
   if (parts.length === 0) return {}
   if (parts.length === 1) return parts[0] as Prisma.ReportRunWhereInput
@@ -114,6 +125,7 @@ export async function listArchivedReportRuns(params: {
   pageSize: number
   q?: string
   companyReportIds?: string[]
+  pdfUrls?: string[]
   /** Stable Garbo `Batch.id` (cuid); multiple IDs are OR-matched. */
   batchDbIds?: string[]
   /** Exact pipeline batch string (`Batch.batchName`) when filtering without a known cuid. */
@@ -125,6 +137,7 @@ export async function listArchivedReportRuns(params: {
   const where = buildListWhere({
     q: params.q,
     companyReportIds: params.companyReportIds,
+    pdfUrls: params.pdfUrls,
     batchDbIds: params.batchDbIds,
     batchName: params.batchName,
   })


### PR DESCRIPTION
## Summary
- Adds a `pdfUrls` query parameter to `GET /api/internal-queue-archive/runs` (comma-separated exact `ReportRun.pdfUrl` values).
- Wires the filter through `listArchivedReportRuns` / `buildListWhere` using `pdfUrl IN (...)` when multiple URLs are provided.
- Enables scoped archive lookup for Validate's registry gap overview view, where rows often have no `CompanyReport` link and must be matched by PDF URL instead of `companyReportIds`.

## Context
The registry reports overview SQL path paginates registry rows from Postgres but still needs pipeline status from archived runs. Gap-filtered rows (`missingCompanyReportOnly`) typically lack `companyReportId`, so the existing `companyReportIds` archive filter is not enough.

The Unearth API overview service calls this endpoint with chunked `pdfUrls` for the current filter scope. Without this change, pipeline columns and completed/failed stats stay empty on the default gap view.

## API surface
```
GET /api/internal-queue-archive/runs?pdfUrls=https://example.com/a.pdf,https://example.com/b.pdf&page=1&pageSize=100
```

- `pdfUrls`: comma-separated, trimmed, deduped server-side
- Exact match on `ReportRun.pdfUrl` (caller sends trailing-slash variants if needed)
- Can be combined with existing filters (`q`, `companyReportIds`, `batchDbIds`, `batchName`) via `AND`


## Related
- Companion change: Unearth API overview (`fetchArchiveRunsForPdfUrls` / SQL registry gap path) — deploy API after Garbo