### PR TITLE
Fix job status split: propagate threadId from checkDB child flows

### DIFF
--- a/src/workers/checkDB.ts
+++ b/src/workers/checkDB.ts
@@ -157,6 +157,7 @@ const checkDB = new PipelineWorker(
     const base = {
       name: companyName,
       data: {
+        ...job.data,
         existingCompany,
         companyName,
         companyId,


### PR DESCRIPTION
## Summary
- Spread `job.data` when `checkDB` builds the diff/finalize flow payload so `threadId` (and other pipeline fields) reach `diffReportingPeriods`, `saveToAPI`, `sendCompanyLink`, etc.
- Without this, pipeline-api groups those jobs under `unknown-{companyName}` while preprocessing/extraction jobs stay on the upload `threadId`, so Validate job status shows one report as two year sections.

## Context
Stage soak: one PDF run looked like two parallel runs (`unknown-NEXT BIOMETRICS…` vs UUID `threadId`) with different job sets. Processing was correct; only the swimlane grouping was wrong.

## Test plan
- [ ] Deploy to stage
- [ ] Run one report through the full pipeline
- [ ] Job status tab: single year section per report, one `threadId` header
- [ ] Diff/approval and API save still complete normally


Made with [Cursor](https://cursor.com)