### PR TITLE
[Prod] Major Version Bump v6.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo",
-  "version": "5.12.1-rc.9",
+  "version": "6.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo",
-      "version": "5.12.1-rc.9",
+      "version": "6.0.0",
       "hasInstallScript": true,
       "license": "MIT License",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garbo",
-  "version": "5.12.1-rc.9",
+  "version": "6.0.0",
   "description": "",
   "type": "module",
   "exports": {


### PR DESCRIPTION
# 🚀 Production Release PR

> **Title format:** `[Prod] Major/Minor/Patch Version Bump vX.X.X`

## 📦 Release Type

_Select the appropriate release type by marking with an `x`._

- [x] Major version bump
- [ ] Minor version bump
- [ ] Patch version bump

### Rollback Version

_Note the relevant rollback version to enable quick rollback if necessary._

v5.12.0

## 🔁 Environment Promotion

This release promotes changes **from `staging` to `production`** (see `k8s/overlays/staging` and `k8s/overlays/production`).

## 📋 What's Being Released

_Provide a summary of the features, fixes, or updates included in this production release._

### Company identifiers — Phase 2 & 3

- **Phase 2 — Primary key flip** ([#1332](https://github.com/Klimatbyran/garbo/pull/1332)): `Company.id` (UUID) becomes the primary key; child table FKs repoint to `Company.id`; `wikidataId` is nullable `@unique`. Partner API URLs still accept wikidata Q-ids where they did before.
- **Phase 3 — Non-blocking Wikidata pipeline** ([#1339](https://github.com/Klimatbyran/garbo/pull/1339)): company resolve-or-create in `precheck`; workers save via `/companies/:companyId/...`; `guessWikidata` runs in parallel (not blocking emissions); early registry upsert from PDF identity; `ReportRun` / `ReportRunJob` store `companyId`.
- **Migration fix** ([#1346](https://github.com/Klimatbyran/garbo/pull/1346)): corrects the Phase 2 PK flip migration for prod rollout.

### Wikidata groundwork

- **Wikidata HTTP helper** ([#1315](https://github.com/Klimatbyran/garbo/pull/1315)): shared `fetchJsonWithRetries` and tighter typing in `read.ts`.
- **Klimatkollen company Wikidata registry** ([#1317](https://github.com/Klimatbyran/garbo/pull/1317)): known name → Q-id lookup data and helpers (not yet wired into pipeline search).

### API changes

- **Remove `GET /companies/kpis`** ([#1340](https://github.com/Klimatbyran/garbo/pull/1340)): endpoint and supporting code removed. `futureEmissionsTrendSlope` on main company responses is unchanged.
- **Archive runs `pdfUrls` filter** ([#1341](https://github.com/Klimatbyran/garbo/pull/1341)): `GET /api/internal-queue-archive/runs?pdfUrls=...` for Validate registry gap overview lookup when rows lack `companyReportId`.

### Pipeline & workers

- **Job status threadId fix** ([#1347](https://github.com/Klimatbyran/garbo/pull/1347)): propagate `threadId` from `checkDB` into diff/finalize child jobs so Validate shows a single year section per report (not split across `unknown-{companyName}` vs UUID).

### Data

- **Territorial data sync** ([#1311](https://github.com/Klimatbyran/garbo/pull/1311)): municipality and national data files updated from `territorial-data-pipeline`.

## 🗂 Deployment Notes (optional)

_Anything to watch out for: DB migrations, feature flags, long-running jobs, cache warmup, etc._

**Garbo (this PR)**

1. Deploy rolls out image; init container runs `prisma migrate deploy`:
   - `20260630120000_company_pk_flip` (Phase 2)
   - `20260701120000_report_run_company_id` (Phase 3)
2. **After Phase 2 migration**, validate PK flip on prod:
   ```bash
   kubectl exec deployment/garbo -c garbo -n garbo -- npx --yes tsx scripts/validate-company-pk-flip.ts
   ```
3. **Deploy order:** garbo (migrations) → unearth-api Phase 2/3 mirror → validate companion (Wikidata approver attribution) → smoke test pipeline end-to-end.

**unearth-api (paired release required)**

Deploy **unearth-api Phase 2 + Phase 3** to prod in the same window — shared DB, internal-id staff routes, and company create/save semantics must match garbo.

**validate (companion release recommended)**

- [validate #236](https://github.com/Klimatbyran/validate-frontend/pull/236): passes `verifiedByUserId` on Wikidata approve so garbo sets `metadata.verifiedBy` correctly.

**Rollback**

Reverting the Phase 2 PK flip migration is non-trivial. Prefer forward-fix; roll back app images to **v5.12.0** if needed.

**Not in this release**

- Phase 3.5 — ambiguous company-link approval (ICA-style name collisions)
- Phase 4 — Validate identifiers UI
- `Report.companyId` denormalization

## ✅ Checklist

- [x] Version number is updated correctly (code/package and/or k8s image tag)
- [x] All relevant changes have been QA-tested in staging
- [x] Rollback version has been updated
- [x] Title follows the required format: `[Prod] Major/Minor/Patch Version Bump vX.X.X`
- [ ] Phase 2 PK flip validated in prod after deploy
- [ ] unearth-api Phase 2/3 deployed to prod
- [ ] validate companion deployed (Wikidata approver attribution)

---

_This template is for versioned production releases only. For other PR types, please select a different template._
