### PR TITLE
Add TagOption.type enum and migration

### DIFF
--- a/prisma/migrations/20260707143000_add_tag_option_type/migration.sql
+++ b/prisma/migrations/20260707143000_add_tag_option_type/migration.sql
@@ -1,0 +1,11 @@
+-- CreateEnum
+CREATE TYPE "TagOptionType" AS ENUM ('COUNTRY', 'REGION', 'OWNERSHIP', 'MARKET_CAP', 'INDEX', 'OTHER');
+
+-- AlterTable
+ALTER TABLE "tag_options" ADD COLUMN "type" "TagOptionType" NOT NULL DEFAULT 'OTHER';
+
+-- Backfill known slugs
+UPDATE "tag_options" SET "type" = 'COUNTRY' WHERE "slug" IN ('sweden', 'norway', 'finland', 'denmark', 'iceland');
+UPDATE "tag_options" SET "type" = 'REGION' WHERE "slug" = 'baltics';
+UPDATE "tag_options" SET "type" = 'OWNERSHIP' WHERE "slug" IN ('public', 'private', 'state-owned', 'municipality-owned');
+UPDATE "tag_options" SET "type" = 'MARKET_CAP' WHERE "slug" IN ('large-cap', 'mid-cap', 'small-cap');

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -68,11 +68,21 @@ model CompanyIdentifier {
   @@map("company_identifiers")
 }
 
+enum TagOptionType {
+  COUNTRY
+  REGION
+  OWNERSHIP
+  MARKET_CAP
+  INDEX
+  OTHER
+}
+
 /// Valid tag options for company tags. Company.tags[] may only contain values that exist as slug here.
 model TagOption {
-  id    String  @id @default(cuid())
-  slug  String  @unique
+  id    String        @id @default(cuid())
+  slug  String        @unique
   label String?
+  type  TagOptionType @default(OTHER)
 
   @@map("tag_options")
 }

--- a/scripts/seed-tag-options.ts
+++ b/scripts/seed-tag-options.ts
@@ -6,27 +6,40 @@
  *   kubectl exec -it deployment/garbo -c garbo -n garbo-stage -- npm run seed:tags
  */
 import 'dotenv/config'
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient, TagOptionType } from '@prisma/client'
 
 const prisma = new PrismaClient()
 
-const TAG_OPTIONS = [
-  { slug: 'public', label: 'Publicly traded companies' },
-  { slug: 'large-cap', label: 'Large cap' },
-  { slug: 'mid-cap', label: 'Mid cap' },
-  { slug: 'state-owned', label: 'State owned' },
-  { slug: 'municipality-owned', label: 'Municipality owned' },
-  { slug: 'private', label: 'Private' },
-  { slug: 'small-cap', label: 'Small cap' },
-  { slug: 'baltics', label: 'Baltic countries' },
-] as const
+const TAG_OPTIONS: {
+  slug: string
+  label: string
+  type: TagOptionType
+}[] = [
+  { slug: 'public', label: 'Publicly traded companies', type: 'OWNERSHIP' },
+  { slug: 'large-cap', label: 'Large cap', type: 'MARKET_CAP' },
+  { slug: 'mid-cap', label: 'Mid cap', type: 'MARKET_CAP' },
+  { slug: 'state-owned', label: 'State owned', type: 'OWNERSHIP' },
+  {
+    slug: 'municipality-owned',
+    label: 'Municipality owned',
+    type: 'OWNERSHIP',
+  },
+  { slug: 'private', label: 'Private', type: 'OWNERSHIP' },
+  { slug: 'small-cap', label: 'Small cap', type: 'MARKET_CAP' },
+  { slug: 'baltics', label: 'Baltic countries', type: 'REGION' },
+  { slug: 'sweden', label: 'Sweden', type: 'COUNTRY' },
+  { slug: 'norway', label: 'Norway', type: 'COUNTRY' },
+  { slug: 'finland', label: 'Finland', type: 'COUNTRY' },
+  { slug: 'denmark', label: 'Denmark', type: 'COUNTRY' },
+  { slug: 'iceland', label: 'Iceland', type: 'COUNTRY' },
+]
 
 async function main() {
   for (const option of TAG_OPTIONS) {
     await prisma.tagOption.upsert({
       where: { slug: option.slug },
       create: option,
-      update: { label: option.label },
+      update: { label: option.label, type: option.type },
     })
   }
   console.log(`Seeded ${TAG_OPTIONS.length} tag options.`)

--- a/src/api/routes/tagOptions.ts
+++ b/src/api/routes/tagOptions.ts
@@ -1,10 +1,12 @@
 import { FastifyInstance, AuthenticatedFastifyRequest } from 'fastify'
+import type { TagOptionType } from '@prisma/client'
 
 import { tagOptionService } from '../services/tagOptionService'
 import {
   createTagOptionBodySchema,
   updateTagOptionBodySchema,
   tagOptionIdParamSchema,
+  tagOptionListQuerySchema,
   okResponseSchema,
   getErrorSchemas,
   tagOptionSchema,
@@ -20,14 +22,22 @@ export async function tagOptionsRoutes(app: FastifyInstance) {
         summary: 'List tag options',
         description: 'Returns all valid tag options for company tags',
         tags: getTags('TagOptions'),
+        querystring: tagOptionListQuerySchema,
         response: {
           200: tagOptionListResponseSchema,
           ...getErrorSchemas(500),
         },
       },
     },
-    async (_request, reply) => {
-      const options = await tagOptionService.findAll()
+    async (
+      request: AuthenticatedFastifyRequest<{
+        Querystring: { type?: string }
+      }>,
+      reply
+    ) => {
+      const options = await tagOptionService.findAll(
+        request.query.type as Parameters<typeof tagOptionService.findAll>[0]
+      )
       return reply.send(options)
     }
   )
@@ -48,11 +58,11 @@ export async function tagOptionsRoutes(app: FastifyInstance) {
     },
     async (
       request: AuthenticatedFastifyRequest<{
-        Body: { slug: string; label?: string }
+        Body: { slug: string; label?: string; type?: string }
       }>,
       reply
     ) => {
-      const { slug, label } = request.body
+      const { slug, label, type } = request.body
       const existing = await tagOptionService.findBySlug(slug)
       if (existing) {
         return reply.status(409).send({
@@ -60,7 +70,11 @@ export async function tagOptionsRoutes(app: FastifyInstance) {
           message: `Tag option with slug "${slug}" already exists`,
         })
       }
-      const created = await tagOptionService.create({ slug, label })
+      const created = await tagOptionService.create({
+        slug,
+        label,
+        type: type as TagOptionType | undefined,
+      })
       return reply.send(created)
     }
   )
@@ -84,7 +98,7 @@ export async function tagOptionsRoutes(app: FastifyInstance) {
     async (
       request: AuthenticatedFastifyRequest<{
         Params: { id: string }
-        Body: { slug?: string; label?: string | null }
+        Body: { slug?: string; label?: string | null; type?: string }
       }>,
       reply
     ) => {
@@ -109,6 +123,9 @@ export async function tagOptionsRoutes(app: FastifyInstance) {
       const updated = await tagOptionService.update(id, {
         slug: body.slug,
         label: body.label,
+        type: body.type as Parameters<
+          typeof tagOptionService.update
+        >[1]['type'],
       })
       return reply.send(updated)
     }

--- a/src/api/schemas/common.ts
+++ b/src/api/schemas/common.ts
@@ -20,6 +20,15 @@ export const yearSchema = z.string().regex(/\d{4}(?:-\d{4})?/)
 
 export const yearParamSchema = z.object({ year: yearSchema })
 
+export const TagOptionTypeSchema = z.enum([
+  'COUNTRY',
+  'REGION',
+  'OWNERSHIP',
+  'MARKET_CAP',
+  'INDEX',
+  'OTHER',
+])
+
 export const errorSchema = z.object({
   code: z.string().openapi('Error code'),
   message: z.string().optional().openapi('Error message'),

--- a/src/api/schemas/request.ts
+++ b/src/api/schemas/request.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import {
   emissionUnitSchemaWithDefault,
   emissionUnitSchemaGarbo,
+  TagOptionTypeSchema,
   wikidataIdSchema,
 } from './common'
 
@@ -32,11 +33,17 @@ const tagOptionSlugSchema = z
 export const createTagOptionBodySchema = z.object({
   slug: tagOptionSlugSchema,
   label: z.string().optional(),
+  type: TagOptionTypeSchema.optional(),
 })
 
 export const updateTagOptionBodySchema = z.object({
   slug: tagOptionSlugSchema.optional(),
   label: z.string().optional().nullable(),
+  type: TagOptionTypeSchema.optional(),
+})
+
+export const tagOptionListQuerySchema = z.object({
+  type: TagOptionTypeSchema.optional(),
 })
 
 export const tagOptionIdParamSchema = z.object({

--- a/src/api/schemas/response.ts
+++ b/src/api/schemas/response.ts
@@ -3,6 +3,7 @@ import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi'
 import {
   companyIdSchema,
   emissionUnitSchemaGarbo,
+  TagOptionTypeSchema,
   wikidataIdSchema,
 } from './common'
 
@@ -18,12 +19,21 @@ const dateStringSchema = z.union([
 export const okResponseSchema = z.object({ ok: z.boolean() })
 export const redirectResponseSchema = z.object({ location: z.string() })
 
+export { TagOptionTypeSchema } from './common'
+
 export const tagOptionSchema = z.object({
   id: z.string(),
   slug: z.string(),
   label: z.string().nullable(),
+  type: TagOptionTypeSchema,
 })
 export const tagOptionListResponseSchema = z.array(tagOptionSchema)
+
+export const companyTagSchema = z.object({
+  slug: z.string(),
+  type: TagOptionTypeSchema,
+  label: z.string().nullable().optional(),
+})
 export const emptyBodySchema = z.undefined()
 
 export const MetadataSchema = z.object({

--- a/src/api/services/tagOptionService.ts
+++ b/src/api/services/tagOptionService.ts
@@ -1,8 +1,10 @@
 import { prisma } from '../../lib/prisma'
+import type { TagOptionType } from '@prisma/client'
 
 class TagOptionService {
-  async findAll() {
+  async findAll(type?: TagOptionType) {
     return prisma.tagOption.findMany({
+      where: type ? { type } : undefined,
       orderBy: { slug: 'asc' },
     })
   }
@@ -19,23 +21,40 @@ class TagOptionService {
     })
   }
 
-  async create(data: { slug: string; label?: string | null }) {
+  async create(data: {
+    slug: string
+    label?: string | null
+    type?: TagOptionType
+  }) {
     return prisma.tagOption.create({
       data: {
         slug: data.slug,
         label: data.label ?? null,
+        type: data.type ?? 'OTHER',
       },
     })
   }
 
-  async update(id: string, data: { slug?: string; label?: string | null }) {
+  async update(
+    id: string,
+    data: {
+      slug?: string
+      label?: string | null
+      type?: TagOptionType
+    }
+  ) {
     const existing = await prisma.tagOption.findUniqueOrThrow({
       where: { id },
     })
 
-    const updates: { slug?: string; label?: string | null } = {}
+    const updates: {
+      slug?: string
+      label?: string | null
+      type?: TagOptionType
+    } = {}
     if (data.slug !== undefined) updates.slug = data.slug
     if (data.label !== undefined) updates.label = data.label
+    if (data.type !== undefined) updates.type = data.type
 
     if (data.slug !== undefined && data.slug !== existing.slug) {
       const oldSlug = existing.slug

--- a/src/workers/followUp/companyTags.ts
+++ b/src/workers/followUp/companyTags.ts
@@ -16,14 +16,17 @@ const queryTexts = [
 
 /** Fetches tag options from the API (no DB access in worker). */
 async function fetchTagOptions(): Promise<
-  { slug: string; label: string | null }[]
+  { slug: string; label: string | null; type?: string }[]
 > {
   const options = await apiFetch('/tag-options')
   if (!Array.isArray(options)) return []
-  return options.map((o: { slug?: string | null; label?: string | null }) => ({
-    slug: o.slug ?? '',
-    label: o.label ?? null,
-  }))
+  return options.map(
+    (o: { slug?: string | null; label?: string | null; type?: string }) => ({
+      slug: o.slug ?? '',
+      label: o.label ?? null,
+      type: o.type,
+    })
+  )
 }
 
 async function buildSchemaAndPrompt(): Promise<{


### PR DESCRIPTION
## Summary
- Adds `TagOptionType` enum (`COUNTRY`, `REGION`, `OWNERSHIP`, `MARKET_CAP`, `INDEX`, `OTHER`) and `type` column on `tag_options`
- Backfills known slugs in migration SQL and updates `seed-tag-options.ts` with Nordic countries
- Extends staff tag-options API with `type` on create/update and optional `?type=` filter on list

## Test plan
- [ ] Run migration locally: `npm run migrate`
- [ ] Seed tags: `npm run seed:tags`
- [ ] Verify `GET /tag-options?type=COUNTRY` returns country slugs with types
- [ ] Deploy Garbo to staging before API deploy


Made with [Cursor](https://cursor.com)