### PR TITLE
[Prod] Patch Version Bump v6.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo",
-  "version": "6.0.1-rc.1",
+  "version": "6.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo",
-      "version": "6.0.1-rc.1",
+      "version": "6.0.1",
       "hasInstallScript": true,
       "license": "MIT License",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garbo",
-  "version": "6.0.1-rc.1",
+  "version": "6.0.1",
   "description": "",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- Apply `20260701120000_coverage_lists` migration to prod Postgres ([#1337](https://github.com/Klimatbyran/garbo/pull/1337))
- Adds `coverage_lists`, `coverage_list_years`, and `coverage_list_entries` tables for Validate index constituent tracking
- **Schema-only release** — no Garbo application code changes; migration runs via deploy initContainer (`npm run migrate`)

## Release type
- [ ] Major version bump
- [ ] Minor version bump
- [x] Patch version bump

## Version / artifacts
- **Version being released**: v6.0.1
- **Rollback target version**: v6.0.0

## Migration details

On deploy, init container runs `prisma migrate deploy`, which applies:

```sql
-- 20260701120000_coverage_lists
CREATE TABLE coverage_lists ...
CREATE TABLE coverage_list_years ...
CREATE TABLE coverage_list_entries ...
```

Additive only — no data backfill required.

## Deployment notes

**Deploy this before unearth-api and validate coverage releases.**

**Order (prod):**
1. **Garbo** (this PR) deploy → verify migration applied:
   ```bash
   kubectl exec deployment/garbo -c garbo -n garbo -- npx prisma migrate status
   ```
2. [unearth-api v1.5.1](https://github.com/UnearthData/api/pull/43) deploy
3. [validate v1.13.1](https://github.com/Klimatbyran/validate-frontend/pull/246) deploy
4. Smoke test: Validate → Overview → Coverage → create list, paste names

**Rollback:** Revert image to v6.0.0. Tables are additive — rollback does not drop them; safe to leave empty tables if rolling back app only.

## Test plan
- [x] Migration applied on stage (`6.0.1-rc.x`)
- [ ] `prisma migrate status` clean on prod after deploy
- [ ] Tables exist: `coverage_lists`, `coverage_list_years`, `coverage_list_entries`
- [ ] Paired API + Validate smoke test passes

## Checklist
- [x] Version number updated correctly (`package.json` / `package-lock.json`)
- [x] Migration already merged and tested on stage
- [x] Rollback version recorded
- [x] Title follows required format


Made with [Cursor](https://cursor.com)