### PR TITLE
Add coverage entry manual match column

### DIFF
--- a/prisma/migrations/20260708120000_coverage_entry_match_override/migration.sql
+++ b/prisma/migrations/20260708120000_coverage_entry_match_override/migration.sql
@@ -1,0 +1,7 @@
+-- Staff-confirmed company match for a coverage list entry (Validate Coverage tab).
+
+ALTER TABLE "coverage_list_entries" ADD COLUMN "matched_company_id" TEXT;
+
+CREATE INDEX "coverage_list_entries_matched_company_id_idx" ON "coverage_list_entries"("matched_company_id");
+
+ALTER TABLE "coverage_list_entries" ADD CONSTRAINT "coverage_list_entries_matched_company_id_fkey" FOREIGN KEY ("matched_company_id") REFERENCES "Company"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,8 @@ model Company {
   logoUrl String?
 
   identifiers CompanyIdentifier[]
+
+  coverageListEntries CoverageListEntry[]
 }
 
 enum CompanyIdentifierType {
@@ -615,12 +617,16 @@ model CoverageListYear {
 
 /// Pasted company name line belonging to a list year edition.
 model CoverageListEntry {
-  id        String           @id @default(cuid())
-  yearId    String           @map("year_id")
-  year      CoverageListYear @relation(fields: [yearId], references: [id], onDelete: Cascade)
-  name      String
-  sortOrder Int              @default(0) @map("sort_order")
+  id               String           @id @default(cuid())
+  yearId           String           @map("year_id")
+  year             CoverageListYear @relation(fields: [yearId], references: [id], onDelete: Cascade)
+  name             String
+  sortOrder        Int              @default(0) @map("sort_order")
+  /// Staff-confirmed DB company match; overrides auto-matching when set.
+  matchedCompanyId String?          @map("matched_company_id")
+  matchedCompany   Company?         @relation(fields: [matchedCompanyId], references: [id], onDelete: SetNull)
 
   @@index([yearId])
+  @@index([matchedCompanyId])
   @@map("coverage_list_entries")
 }


### PR DESCRIPTION
## Summary
- Adds optional `matched_company_id` on `coverage_list_entries` with FK to `Company(id)` ON DELETE SET NULL
- Schema-only change; no application code — API and Validate use this for staff-confirmed matches

## Deploy order
Merge and run this migration **before** the API and Validate PRs in this series.

## Test plan
- [ ] `prisma migrate deploy` on stage
- [ ] Verify column and FK exist on `coverage_list_entries`


Made with [Cursor](https://cursor.com)