### PR TITLE
Add coverage entry confirmed missing flag

### DIFF
--- a/prisma/migrations/20260708140000_coverage_entry_confirmed_missing/migration.sql
+++ b/prisma/migrations/20260708140000_coverage_entry_confirmed_missing/migration.sql
@@ -1,0 +1,3 @@
+-- Staff confirmed a list name has no DB company match (overrides ambiguous auto-match).
+
+ALTER TABLE "coverage_list_entries" ADD COLUMN "match_confirmed_missing" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -625,6 +625,8 @@ model CoverageListEntry {
   /// Staff-confirmed DB company match; overrides auto-matching when set.
   matchedCompanyId String?          @map("matched_company_id")
   matchedCompany   Company?         @relation(fields: [matchedCompanyId], references: [id], onDelete: SetNull)
+  /// Staff confirmed this list name is not in the DB (overrides ambiguous suggestions).
+  matchConfirmedMissing Boolean     @default(false) @map("match_confirmed_missing")
 
   @@index([yearId])
   @@index([matchedCompanyId])


### PR DESCRIPTION
## Summary
- Adds `match_confirmed_missing` boolean on `coverage_list_entries`
- Used when staff dismisses an ambiguous auto-match and confirms the company is not in Garbo

## Deploy order
Merge and migrate **before** the API and Validate PRs in this series.

## Test plan
- [ ] `prisma migrate deploy` on stage
- [ ] Verify column exists on `coverage_list_entries`


Made with [Cursor](https://cursor.com)