### PR TITLE
[Prod] Patch Version Bump v6.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo",
-  "version": "6.0.2-rc.2",
+  "version": "6.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo",
-      "version": "6.0.2-rc.2",
+      "version": "6.0.2",
       "hasInstallScript": true,
       "license": "MIT License",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garbo",
-  "version": "6.0.2-rc.2",
+  "version": "6.0.2",
   "description": "",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- Apply `20260708120000_coverage_entry_match_override` migration (`matched_company_id` on `coverage_list_entries`) ([#1352](https://github.com/Klimatbyran/garbo/pull/1352))
- Apply `20260708140000_coverage_entry_confirmed_missing` migration ([#1353](https://github.com/Klimatbyran/garbo/pull/1353))
- **Schema-only release** — migrations run via deploy initContainer (`npm run migrate`)

## Release type
- [ ] Major version bump
- [ ] Minor version bump
- [x] Patch version bump

## Version / artifacts
- **Version being released**: v6.0.2
- **Rollback target version**: v6.0.1

## Migration details

On deploy, init container runs `prisma migrate deploy`, which applies:

1. `matched_company_id` FK on `coverage_list_entries` (staff manual match overrides)
2. `match_confirmed_missing` boolean on `coverage_list_entries` (dismiss ambiguous suggestions)

Additive only — no data backfill required.

## Deployment notes

**Deploy this before unearth-api and validate coverage releases.**

**Order (prod):**
1. **Garbo** (this PR) deploy → verify migration applied:
   ```bash
   kubectl exec deployment/garbo -c garbo -n garbo -- npx prisma migrate status
   ```
2. [unearth-api v1.5.2](https://github.com/UnearthData/api/pull/47) deploy
3. [validate v1.13.2](https://github.com/Klimatbyran/validate-frontend/pull/252) deploy
4. Smoke test: Validate → Overview → Coverage → edit match, mark ambiguous as missing

**Rollback:** Revert image to v6.0.1. Columns are additive — safe to leave if rolling back app only.

## Test plan
- [x] Migrations applied on stage
- [ ] `prisma migrate status` clean on prod after deploy
- [ ] Columns exist: `matched_company_id`, `match_confirmed_missing` on `coverage_list_entries`
- [ ] Paired API + Validate smoke test passes

## Checklist
- [x] Version number updated correctly (`package.json` / `package-lock.json`)
- [x] Migrations merged and tested on stage
- [x] Rollback version recorded
- [x] Title follows required format


Made with [Cursor](https://cursor.com)