### PR TITLE
Wire pipeline-api prune hook env on workers

### DIFF
--- a/k8s/base/worker.yaml
+++ b/k8s/base/worker.yaml
@@ -198,6 +198,13 @@ spec:
                 secretKeyRef:
                   name: env
                   key: BACKUP_API_AUTH_HEADER
+            - name: PIPELINE_API_URL
+              value: http://pipeline-api:4000
+            - name: INTERNAL_SERVICE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: env
+                  key: INTERNAL_SERVICE_TOKEN
           imagePullPolicy: Always
 ---
 apiVersion: autoscaling/v2


### PR DESCRIPTION
## Summary
- Add `PIPELINE_API_URL=http://pipeline-api:4000` and `INTERNAL_SERVICE_TOKEN` to worker deployment for automatic Redis run pruning after `sendCompanyLink` completes.

## Test plan
- [x] Matching token set in `garbo-stage` env secret
- [ ] After deploy, completing a pipeline run triggers prune via pipeline-api


Made with [Cursor](https://cursor.com)