### PR TITLE
Fix saveToAPI turning grey after successful save

### DIFF
--- a/src/lib/DiffWorker.ts
+++ b/src/lib/DiffWorker.ts
@@ -3,7 +3,10 @@ import { Job, Queue, WorkerOptions } from 'bullmq'
 import redis from '../config/redis'
 import saveToAPI from '../workers/saveToAPI'
 import { canonicalPublicReportUrl, defaultMetadata } from './saveUtils'
-import { withPipelineJobOpts } from './pipelineJobOptions'
+import {
+  SAVE_TO_API_JOB_OPTIONS,
+  withPipelineJobOpts,
+} from './pipelineJobOptions'
 
 /**
  * Enqueue saveToAPI with a BullMQ parent link when possible. If the parent job
@@ -20,7 +23,11 @@ export async function enqueueSaveToAPIWithParentFallback(
     : undefined
 
   try {
-    await saveToAPI.queue.add(name, data, withPipelineJobOpts(parentOpts))
+    await saveToAPI.queue.add(
+      name,
+      data,
+      withPipelineJobOpts({ ...parentOpts, ...SAVE_TO_API_JOB_OPTIONS })
+    )
   } catch (error) {
     const msg =
       error instanceof Error
@@ -33,7 +40,11 @@ export async function enqueueSaveToAPIWithParentFallback(
       await job.log(
         `saveToAPI enqueue: parent missing; retrying without parent. (${msg})`
       )
-      await saveToAPI.queue.add(name, data, withPipelineJobOpts())
+      await saveToAPI.queue.add(
+        name,
+        data,
+        withPipelineJobOpts(SAVE_TO_API_JOB_OPTIONS)
+      )
       return
     }
 

--- a/src/lib/pipelineJobOptions.ts
+++ b/src/lib/pipelineJobOptions.ts
@@ -1,13 +1,20 @@
 import type { JobsOptions } from 'bullmq'
 
-/** Overflow safety net only — run-level pruning in pipeline-api is authoritative. */
+/**
+ * Completed jobs are evicted by run-level pruning in pipeline-api (15 most recent
+ * runs), not per-queue caps. Per-queue removeOnComplete caused saveToAPI jobs to
+ * disappear from live Jobbstatus while their run was still within the keep window.
+ */
 export const DEFAULT_PIPELINE_JOB_OPTIONS: JobsOptions = {
-  removeOnComplete: {
-    count: 30,
-  },
+  removeOnComplete: false,
   removeOnFail: {
     age: 1_209_600,
   },
+}
+
+/** Multiple saveToAPI jobs per run — never use per-queue eviction here. */
+export const SAVE_TO_API_JOB_OPTIONS: JobsOptions = {
+  removeOnComplete: false,
 }
 
 export function withPipelineJobOpts(opts?: JobsOptions): JobsOptions {


### PR DESCRIPTION
## Summary
- Disable BullMQ `removeOnComplete: { count: 30 }` for all pipeline jobs; run-level pruning (15 most recent runs) is the sole eviction path.
- Explicitly document and apply `SAVE_TO_API_JOB_OPTIONS` when enqueueing save jobs (multiple per run).

## Problem
Per-queue eviction removed `saveToAPI` jobs from runs still within the Redis keep window, so Jobbstatus showed API save as grey minutes after a successful write.

## Test plan
- [ ] Run a report through the pipeline with multiple diff saves (reporting-periods + industry, etc.)
- [ ] Confirm `saveToAPI` stays green in Jobbstatus for at least 15+ minutes after completion
- [ ] Confirm older runs are still pruned when the 16th run completes (or via `prune-runs-by-company` dry-run)

Pairs with https://github.com/Klimatbyran/pipeline-api/pull/76


Made with [Cursor](https://cursor.com)