### PR TITLE
Add cached coverage list year stats columns

### DIFF
--- a/prisma/migrations/20260709140000_coverage_list_year_stats/migration.sql
+++ b/prisma/migrations/20260709140000_coverage_list_year_stats/migration.sql
@@ -1,0 +1,6 @@
+-- Cache coverage match stats on list year editions so list overview reads stay fast.
+ALTER TABLE "coverage_list_years"
+ADD COLUMN "total_names" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN "matched_count" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN "ambiguous_count" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN "coverage_percent" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -617,13 +617,17 @@ model CoverageList {
 
 /// One edition per year for a coverage list.
 model CoverageListYear {
-  id        String              @id @default(cuid())
-  listId    String              @map("list_id")
-  list      CoverageList        @relation(fields: [listId], references: [id], onDelete: Cascade)
-  year      Int
-  createdAt DateTime            @default(now()) @map("created_at")
-  updatedAt DateTime            @updatedAt @map("updated_at")
-  entries   CoverageListEntry[]
+  id               String              @id @default(cuid())
+  listId           String              @map("list_id")
+  list             CoverageList        @relation(fields: [listId], references: [id], onDelete: Cascade)
+  year             Int
+  totalNames       Int                 @default(0) @map("total_names")
+  matchedCount     Int                 @default(0) @map("matched_count")
+  ambiguousCount   Int                 @default(0) @map("ambiguous_count")
+  coveragePercent  Int                 @default(0) @map("coverage_percent")
+  createdAt        DateTime            @default(now()) @map("created_at")
+  updatedAt        DateTime            @updatedAt @map("updated_at")
+  entries          CoverageListEntry[]
 
   @@unique([listId, year])
   @@index([listId])


### PR DESCRIPTION
## Summary
- Add `total_names`, `matched_count`, `ambiguous_count`, and `coverage_percent` columns to `coverage_list_years`
- Supports fast coverage list overview reads in the API (see UnearthData/api#54)

## Test plan
- [ ] `npm run prisma migrate dev` applies cleanly on a fresh DB
- [ ] `npm run prisma migrate deploy` on stage/prod before deploying API #54
- [ ] Existing coverage list years get default `0` values; run API backfill script after deploy


Made with [Cursor](https://cursor.com)