### PR TITLE
[feat] Add lightweight companies Paris overview endpoint

### DIFF
--- a/src/api/routes/external/company.read.ts
+++ b/src/api/routes/external/company.read.ts
@@ -12,6 +12,7 @@ import {
 } from '../../services/reportingPeriodPublicRead'
 import {
   PartnerCompanyList,
+  CompanyParisOverviewList,
   wikidataIdParamSchema,
   PartnerCompanyDetails,
   getErrorSchemas,
@@ -101,7 +102,38 @@ export async function companyReadRoutes(app: FastifyInstance) {
     }
   )
 
-  // Register before /:wikidataId so "search" is not captured as an id
+  // Register before /:wikidataId so static paths are not captured as ids
+  app.get(
+    '/paris-overview',
+    {
+      schema: {
+        summary: 'Get Paris overview data for companies',
+        description:
+          'Retrieve a lightweight list of companies with Paris Agreement status and latest-year emissions for the overview chart',
+        tags: getTags('Companies'),
+        response: {
+          200: CompanyParisOverviewList,
+        },
+      },
+    },
+    async (request, reply) => {
+      const databaseFingerprint = await getCompaniesDatabaseFingerprint()
+      const currentEtag = await getOrRefreshCompaniesEtag(databaseFingerprint)
+
+      const dataCacheKey = `companies:paris-overview:data:${databaseFingerprint}`
+
+      let companies = await redisCache.get(dataCacheKey)
+
+      if (!companies) {
+        companies = await companyService.getParisOverviewForPublicRead()
+        await redisCache.set(dataCacheKey, JSON.stringify(companies))
+      }
+
+      reply.header('ETag', `${currentEtag}`)
+      reply.send(companies)
+    }
+  )
+
   app.get(
     '/search',
     {

--- a/src/api/schemas/response.ts
+++ b/src/api/schemas/response.ts
@@ -452,6 +452,19 @@ export const PartnerCompanyBase = CompanyBaseSchema.extend({
 
 export const PartnerCompanyList = z.array(PartnerCompanyBase)
 
+export const CompanyParisOverviewItem = z.object({
+  id: companyIdSchema,
+  wikidataId: wikidataIdSchema.nullable(),
+  name: z.string(),
+  meetsParis: z.boolean().nullable(),
+  emissions: z.number().nullable(),
+  emissionsYear: z.number().int().nullable(),
+  sectorCode: z.string().nullable(),
+  tags: z.array(z.string()),
+})
+
+export const CompanyParisOverviewList = z.array(CompanyParisOverviewItem)
+
 const PartnerCompanyFullBase = CompanyBaseSchema.extend({
   description: z.string().optional().nullable(),
   descriptions: z.array(ResponseDescriptionSchema).optional(),

--- a/src/api/security/routePermissions.test.ts
+++ b/src/api/security/routePermissions.test.ts
@@ -31,6 +31,9 @@ describe('routePermissions registry', () => {
     expect(resolveClientApiPermission('GET', '/api/companies/search')).toBe(
       'api.companies.search'
     )
+    expect(
+      resolveClientApiPermission('GET', '/api/companies/paris-overview')
+    ).toBe('api.companies.list')
     expect(resolveClientApiPermission('GET', '/api/companies/Q123')).toBe(
       'api.companies.read'
     )

--- a/src/api/security/routePermissions.ts
+++ b/src/api/security/routePermissions.ts
@@ -65,6 +65,12 @@ export const clientApiRouteRules: Rule[] = [
   },
   {
     method: 'GET',
+    type: 'exact',
+    path: '/api/companies/paris-overview',
+    permission: 'api.companies.list',
+  },
+  {
+    method: 'GET',
     type: 'prefix',
     path: '/api/companies/',
     permission: 'api.companies.read',

--- a/src/api/services/companyService.ts
+++ b/src/api/services/companyService.ts
@@ -37,6 +37,7 @@ import {
   getOrCreateServiceBotUser,
 } from './serviceBotUser'
 import type { ReportingPeriod } from '@/types'
+import { toCompanyParisOverviewItem } from '@/lib/company-emissions/companyMeetsParis'
 
 const API_KEY = process.env.FIRECRAWL_API_KEY
 
@@ -85,6 +86,12 @@ class CompanyService {
   async getAllCompaniesForPublicRead() {
     const companies = await prisma.company.findMany(companyListArgs)
     return this.enrichCompaniesWithMetadata(companies, true)
+  }
+
+  /** Public API: minimal payload for the companies overview Paris chart. */
+  async getParisOverviewForPublicRead() {
+    const companies = await this.getAllCompaniesForPublicRead()
+    return companies.map((company) => toCompanyParisOverviewItem(company))
   }
 
   async getAllCompaniesBySearchTerm(

--- a/src/lib/company-emissions/companyMeetsParis.test.ts
+++ b/src/lib/company-emissions/companyMeetsParis.test.ts
@@ -88,4 +88,51 @@ describe('toCompanyParisOverviewItem', () => {
       tags: ['sweden'],
     })
   })
+
+  it('returns meetsParis true when latest emissions are zero', () => {
+    const item = toCompanyParisOverviewItem({
+      id: 'company-id',
+      wikidataId: 'Q123',
+      name: 'Zero Emissions AB',
+      reportingPeriods: [
+        {
+          endDate: '2025-12-31',
+          emissions: { calculatedTotalEmissions: 0 },
+        },
+      ],
+      futureEmissionsTrendSlope: -50,
+    })
+
+    expect(item.meetsParis).toBe(true)
+    expect(item.emissions).toBeNull()
+    expect(item.emissionsYear).toBe(2025)
+  })
+
+  it('calculates meetsParis from older periods when latest has no emissions', () => {
+    const item = toCompanyParisOverviewItem({
+      id: 'company-id',
+      wikidataId: 'Q123',
+      name: 'Partial Data AB',
+      reportingPeriods: [
+        {
+          endDate: '2025-12-31',
+          emissions: { calculatedTotalEmissions: null },
+        },
+        {
+          endDate: '2024-12-31',
+          emissions: { calculatedTotalEmissions: 1000 },
+        },
+        {
+          endDate: '2023-12-31',
+          emissions: { calculatedTotalEmissions: 1100 },
+        },
+      ],
+      baseYear: { year: 2019 },
+      futureEmissionsTrendSlope: -20,
+    })
+
+    expect(item.meetsParis).toEqual(expect.any(Boolean))
+    expect(item.emissions).toBeNull()
+    expect(item.emissionsYear).toBe(2025)
+  })
 })

--- a/src/lib/company-emissions/companyMeetsParis.test.ts
+++ b/src/lib/company-emissions/companyMeetsParis.test.ts
@@ -1,0 +1,91 @@
+import {
+  calculateCompanyMeetsParis,
+  toCompanyParisOverviewItem,
+} from './companyMeetsParis'
+
+describe('calculateCompanyMeetsParis', () => {
+  it('returns null when trend slope is unavailable', () => {
+    expect(
+      calculateCompanyMeetsParis({
+        reportingPeriods: [
+          {
+            endDate: '2024-12-31',
+            emissions: { calculatedTotalEmissions: 1000 },
+          },
+        ],
+        futureEmissionsTrendSlope: null,
+      })
+    ).toBeNull()
+  })
+
+  it('returns true when 2025 emissions are zero', () => {
+    expect(
+      calculateCompanyMeetsParis({
+        reportingPeriods: [
+          {
+            endDate: '2025-12-31',
+            emissions: { calculatedTotalEmissions: 0 },
+          },
+        ],
+        futureEmissionsTrendSlope: -50,
+      })
+    ).toBe(true)
+  })
+
+  it('returns false for strongly increasing emissions', () => {
+    expect(
+      calculateCompanyMeetsParis({
+        reportingPeriods: [
+          {
+            endDate: '2023-12-31',
+            emissions: { calculatedTotalEmissions: 1000 },
+          },
+          {
+            endDate: '2024-12-31',
+            emissions: { calculatedTotalEmissions: 1200 },
+          },
+        ],
+        futureEmissionsTrendSlope: 200,
+      })
+    ).toBe(false)
+  })
+})
+
+describe('toCompanyParisOverviewItem', () => {
+  it('maps only fields needed for the Paris overview chart', () => {
+    const item = toCompanyParisOverviewItem({
+      id: 'company-id',
+      wikidataId: 'Q123',
+      name: 'Example AB',
+      tags: ['sweden'],
+      industry: {
+        industryGics: {
+          sectorCode: '15',
+        },
+      },
+      reportingPeriods: [
+        {
+          endDate: '2024-12-31',
+          emissions: { calculatedTotalEmissions: 1000 },
+        },
+        {
+          endDate: '2023-12-31',
+          emissions: { calculatedTotalEmissions: 1100 },
+        },
+      ],
+      baseYear: { year: 2019 },
+      futureEmissionsTrendSlope: -20,
+    })
+
+    expect(item).toEqual({
+      id: 'company-id',
+      wikidataId: 'Q123',
+      name: 'Example AB',
+      meetsParis: expect.any(Boolean),
+      emissions: 1000,
+      emissionsYear: 2024,
+      sectorCode: '15',
+      tags: ['sweden'],
+    })
+  })
+})

--- a/src/lib/company-emissions/companyMeetsParis.ts
+++ b/src/lib/company-emissions/companyMeetsParis.ts
@@ -166,10 +166,7 @@ export function toCompanyParisOverviewItem(company: {
     ? new Date(latestPeriod.endDate).getFullYear()
     : null
 
-  const meetsParis =
-    emissions == null || emissions <= 0
-      ? null
-      : calculateCompanyMeetsParis(company)
+  const meetsParis = calculateCompanyMeetsParis(company)
 
   return {
     id: company.id,

--- a/src/lib/company-emissions/companyMeetsParis.ts
+++ b/src/lib/company-emissions/companyMeetsParis.ts
@@ -1,0 +1,185 @@
+const CARBON_LAW_REDUCTION_RATE = 0.1172
+
+export interface CompanyForParisCalculation {
+  reportingPeriods: Array<{
+    endDate: Date | string
+    emissions?: {
+      calculatedTotalEmissions?: number | null
+    } | null
+  }>
+  baseYear?: { year: number } | null
+  futureEmissionsTrendSlope: number | null
+}
+
+interface TrendCoefficients {
+  slope: number
+  intercept: number
+}
+
+function buildTrendCoefficients(
+  company: CompanyForParisCalculation
+): TrendCoefficients | null {
+  const slope = company.futureEmissionsTrendSlope
+  if (slope === null || slope === undefined || !Number.isFinite(slope)) {
+    return null
+  }
+
+  const data = company.reportingPeriods
+    .filter(
+      (period) =>
+        period.emissions?.calculatedTotalEmissions !== null &&
+        period.emissions?.calculatedTotalEmissions !== undefined
+    )
+    .map((period) => ({
+      year: new Date(period.endDate).getFullYear(),
+      total: period.emissions!.calculatedTotalEmissions!,
+    }))
+    .sort((a, b) => a.year - b.year)
+
+  if (data.length === 0) {
+    return null
+  }
+
+  const baseYear = company.baseYear?.year
+  const dataSinceBaseYear = baseYear
+    ? data.filter((point) => point.year >= baseYear)
+    : data
+
+  if (dataSinceBaseYear.length === 0) {
+    return null
+  }
+
+  const lastDataPoint = dataSinceBaseYear[dataSinceBaseYear.length - 1]
+  const intercept = lastDataPoint.total - slope * lastDataPoint.year
+
+  return { slope, intercept }
+}
+
+function get2025Emissions(
+  company: CompanyForParisCalculation,
+  coefficients: TrendCoefficients
+): number | null {
+  const actual2025Data = company.reportingPeriods.find(
+    (period) => new Date(period.endDate).getFullYear() === 2025
+  )
+
+  if (actual2025Data?.emissions?.calculatedTotalEmissions != null) {
+    return actual2025Data.emissions.calculatedTotalEmissions
+  }
+
+  return coefficients.slope * 2025 + coefficients.intercept
+}
+
+function calculateCumulativeEmissions(
+  startEmissions: number,
+  slope: number,
+  startYear: number,
+  endYear: number
+): number {
+  let cumulative = 0
+  for (let year = startYear; year <= endYear; year++) {
+    const emissions = slope * year + (startEmissions - slope * startYear)
+    cumulative += Math.max(0, emissions)
+  }
+  return cumulative
+}
+
+function calculateCarbonLawCumulativeEmissions(
+  startEmissions: number,
+  startYear: number,
+  endYear: number
+): number {
+  let cumulative = 0
+  let currentEmissions = startEmissions
+
+  for (let year = startYear; year <= endYear; year++) {
+    cumulative += currentEmissions
+    currentEmissions *= 1 - CARBON_LAW_REDUCTION_RATE
+  }
+  return cumulative
+}
+
+export function calculateCompanyMeetsParis(
+  company: CompanyForParisCalculation
+): boolean | null {
+  const coefficients = buildTrendCoefficients(company)
+  if (!coefficients) {
+    return null
+  }
+
+  const emissions2025 = get2025Emissions(company, coefficients)
+  if (emissions2025 === null || emissions2025 === undefined) {
+    return null
+  }
+
+  if (emissions2025 <= 0) {
+    return true
+  }
+
+  const companyCumulativeEmissions = calculateCumulativeEmissions(
+    emissions2025,
+    coefficients.slope,
+    2025,
+    2050
+  )
+
+  const carbonLawCumulativeEmissions = calculateCarbonLawCumulativeEmissions(
+    emissions2025,
+    2025,
+    2050
+  )
+
+  return companyCumulativeEmissions <= carbonLawCumulativeEmissions
+}
+
+export interface CompanyParisOverviewItem {
+  id: string
+  wikidataId: string | null
+  name: string
+  meetsParis: boolean | null
+  emissions: number | null
+  emissionsYear: number | null
+  sectorCode: string | null
+  tags: string[]
+}
+
+export function toCompanyParisOverviewItem(company: {
+  id: string
+  wikidataId?: string | null
+  name: string
+  tags?: string[]
+  industry?: {
+    industryGics?: {
+      sectorCode?: string | null
+    } | null
+  } | null
+  reportingPeriods: CompanyForParisCalculation['reportingPeriods']
+  baseYear?: { year: number } | null
+  futureEmissionsTrendSlope: number | null
+}): CompanyParisOverviewItem {
+  const latestPeriod = [...company.reportingPeriods].sort(
+    (a, b) => new Date(b.endDate).getTime() - new Date(a.endDate).getTime()
+  )[0]
+
+  const emissions =
+    latestPeriod?.emissions?.calculatedTotalEmissions ?? null
+  const emissionsYear = latestPeriod
+    ? new Date(latestPeriod.endDate).getFullYear()
+    : null
+
+  const meetsParis =
+    emissions == null || emissions <= 0
+      ? null
+      : calculateCompanyMeetsParis(company)
+
+  return {
+    id: company.id,
+    wikidataId: company.wikidataId ?? null,
+    name: company.name,
+    meetsParis,
+    emissions: emissions != null && emissions > 0 ? emissions : null,
+    emissionsYear,
+    sectorCode: company.industry?.industryGics?.sectorCode ?? null,
+    tags: company.tags ?? [],
+  }
+}

--- a/src/lib/company-emissions/companyMeetsParis.ts
+++ b/src/lib/company-emissions/companyMeetsParis.ts
@@ -161,8 +161,7 @@ export function toCompanyParisOverviewItem(company: {
     (a, b) => new Date(b.endDate).getTime() - new Date(a.endDate).getTime()
   )[0]
 
-  const emissions =
-    latestPeriod?.emissions?.calculatedTotalEmissions ?? null
+  const emissions = latestPeriod?.emissions?.calculatedTotalEmissions ?? null
   const emissionsYear = latestPeriod
     ? new Date(latestPeriod.endDate).getFullYear()
     : null


### PR DESCRIPTION
Expose GET /api/companies/paris-overview with precomputed meetsParis status and latest-year emissions so the frontend overview chart can load a minimal payload instead of the full company list.

### ✨ What’s Changed?

<!-- Describe what this PR changes and why -->

### 🔍 How to Review / Test

<!-- Include relevant commands, curl examples, or steps in staging -->

### 📋 Checklist

- [x] PR title starts with `[#issue-number]`; if no issue is applicable use: `[fix]`, `[feat]`, `[ops]`, or `[prod]`
- [x] I’ve added/updated tests (or noted why they’re not needed)
- [x] I’ve verified the change runs locally (and in Docker/k8s if relevant)
- [x] If this changes the API contract, I’ve called that out clearly (and considered backward compatibility)
- [ ] If this includes a DB change, I’ve included a migration + rollout/rollback notes
- [x] I’ve considered observability (logs/metrics/traces) and added what’s needed
- [x] I’ve set labels, linked issue, and milestone (if applicable)

### 🛠 Related Issue

Closes #[issue-number] <!-- or: Related to #[issue-number] -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-only API and derived emissions logic; no auth or persistence changes. Main risk is incorrect Paris classification if the new formula diverges from product expectations.
> 
> **Overview**
> Adds **`GET /api/companies/paris-overview`**, a read-only companies endpoint that returns a **small payload** for the overview Paris chart instead of the full company list.
> 
> Each row includes **`meetsParis`**, **latest-year emissions** (positive values only; zero/null omitted from `emissions`), **`emissionsYear`**, **`sectorCode`**, and **tags**. Responses use the same **database fingerprint**, **Redis cache** (`companies:paris-overview:data:…`), and **ETag** pattern as the main companies list. The route is registered **before** `/:wikidataId` so `paris-overview` is not treated as an id.
> 
> **`calculateCompanyMeetsParis`** (new in `companyMeetsParis.ts`) compares projected cumulative emissions (2025–2050 from trend slope and optional 2025 actuals) against a **carbon-law** budget; missing slope/data yields **`meetsParis: null`**. **`companyService.getParisOverviewForPublicRead`** reuses public-read enrichment, then maps via **`toCompanyParisOverviewItem`**.
> 
> OpenAPI adds **`CompanyParisOverviewList`**; client API auth maps the path to **`api.companies.list`** (with tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e714a3235b15674a14f419429708db05754be1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->