### PR TITLE
[Prod] Patch Version Bump v6.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo",
-  "version": "6.0.5-rc.15",
+  "version": "6.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo",
-      "version": "6.0.5-rc.15",
+      "version": "6.0.5",
       "hasInstallScript": true,
       "license": "MIT License",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garbo",
-  "version": "6.0.5-rc.15",
+  "version": "6.0.5",
   "description": "",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## 📦 Release Type

- [ ] Major version bump
- [ ] Minor version bump
- [x] Patch version bump

### Rollback Version

v6.0.4

## 🔁 Environment Promotion

Promotes staging RC builds to production (`6.0.5`).

## 📋 What's Being Released

- Coverage list year stats columns (migration `20260709140000_coverage_list_year_stats`) (#1364)
- Improved Wikidata company search, ranking, classification, and guessWikidata refactor (#1316, #1321)
- Live Wikidata search test harness and tiered company search tests (#1322–#1328)
- `productionBasedEmissions` added to nation endpoint response (#1365)
- Territorial national data sync (#1363)

## 🗂 Deployment Notes

- **DB migration required:** run `prisma migrate deploy` in production after deploy
- Deploy **Garbo before API** if API depends on new coverage stats schema

## ✅ Checklist

- [x] Version number updated (`6.0.5`)
- [ ] QA verified in staging
- [x] Rollback version recorded (v6.0.4)
- [x] Title follows required format


Made with [Cursor](https://cursor.com)