### PR TITLE
[Prod] Patch Version Bump v6.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo",
-  "version": "6.0.6-rc.1",
+  "version": "6.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo",
-      "version": "6.0.6-rc.1",
+      "version": "6.0.6",
       "hasInstallScript": true,
       "license": "MIT License",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garbo",
-  "version": "6.0.6-rc.1",
+  "version": "6.0.6",
   "description": "",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## 📦 Release Type

- [x] Patch version bump

### Rollback Version

v6.0.5

## 📋 What's Being Released

- Disable per-queue job eviction in favor of run-level Redis retention (#1362)
- Improves validate job status visibility when multiple `saveToAPI` attempts occur per run

## 🗂 Deployment Notes

- No new DB migrations in this patch
- Coordinate with **pipeline-api v0.4.4** (same Redis retention change)

## ✅ Checklist

- [x] Version updated (`6.0.6`)
- [ ] QA verified in staging
- [x] Rollback version recorded (v6.0.5)


Made with [Cursor](https://cursor.com)