### PR TITLE
[Fix] Update handling of matching existing companies

### DIFF
--- a/doc/COMPANY_IDENTIFIERS_PLAN.md
+++ b/doc/COMPANY_IDENTIFIERS_PLAN.md
@@ -137,9 +137,9 @@ No response shape change. `PartnerCompanyBase` keeps `id`, `wikidataId`, `lei` p
 
 **Baseline shipped in Phase 3 (branch `1338-wikidataWorker`):** `resolveOrCreatePipelineCompanyId` in `src/lib/pipelineCompanyResolve.ts` — prefer `job.data.companyId`, then Wikidata Q-id lookup, then exact normalized name match after fuzzy DB search, else `POST /companies/`. No approval gate yet.
 
-### Phase 3.5 — Company link resolution + Wikidata matching (deferred)
+### Phase 3.5 — Company link resolution + Wikidata matching
 
-**Scope:** garbo + validate. Small middle step between Phase 3 and Phase 4. **Paused for now** — implement when ambiguous matches show up in stage/prod, or before a large batch run where wrong `companyId` would be costly.
+**Scope:** garbo + validate. Small middle step between Phase 3 and Phase 4. **Shipped (2026-07)** after duplicate-company issues in stage (e.g. Alfa Laval AB vs Alfa Laval, multiple rows with Q686030).
 
 **Problem:** Phase 3 auto-links only when exactly one Garbo row has the same normalized name as the name extracted from the report. Fuzzy search can return several candidates (e.g. ICA Sweden vs ICA Finland) while the PDF gives a short generic name (`"ICA"`). Today that falls through to **create a new company** rather than silently linking to the wrong row — but duplicates and manual cleanup are still possible.
 
@@ -147,12 +147,15 @@ No response shape change. `PartnerCompanyBase` keeps `id`, `wikidataId`, `lei` p
 
 | Step  | Work                                                                                                                                                                                                                                           |
 | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 3.5.1 | **Ambiguity heuristics** — pure function on fuzzy search candidates + extracted name: multiple exact matches; multiple fuzzy hits + short/generic name (e.g. one token or ≤4 chars); optional shared-prefix rule for ICA-style cases           |
-| 3.5.2 | **`precheck` approval gate** — when ambiguous, `requestApproval('companyLink', { extractedName, candidates })`, `moveToDelayed`; on approve read `companyId` (or explicit “create new”) from `approval.data.newValue` before spawning children |
-| 3.5.3 | **Validate `CompanyLinkApprovalDisplay`** — radio list of candidates (`id`, `name`, `wikidataId` if any) plus “Create new company”; mirror `WikidataApprovalDisplay` + `useJobRerunActions` approve/rerun pattern                              |
-| 3.5.4 | **Observability (optional, ~2–3 h)** — log/metric when candidates exist but no single exact match (measures how often the gate would fire without blocking yet)                                                                                |
-| 3.5.5 | **Re-run contract** — document/enforce pipeline-api passing `companyId` or `wikidataId` when re-processing a known company (most reliable path; name-only remains fallback)                                                                    |
-| 3.5.6 | **Tests** — unit tests for heuristics; precheck approval resume path; Validate parser for `approval.type === 'companyLink'`                                                                                                                    |
+| 3.5.1 | **Ambiguity heuristics** — `assessCompanyLinkResolution` in `src/lib/companyLinkResolve.ts` |
+| 3.5.2 | **`precheck` approval gate** — `requestApproval('companyLink', …)` when ambiguous; resume on approve |
+| 3.5.3 | **Validate `CompanyLinkApprovalDisplay`** — radio candidates + create-new; `useJobRerunActions` approve |
+| 3.5.4 | **Observability** — precheck logs candidate list when ambiguity gate fires |
+| 3.5.5 | **Re-run contract** — prefer `job.data.companyId` or `wikidata.node` on re-runs (documented in `resolvePipelineCompanyOutcome`) |
+| 3.5.6 | **Tests** — `companyLinkResolve.test.ts`, `pipelineCompanyResolve.test.ts`, Validate parser test |
+| 3.5.7 | **Wikidata relink gate** — when Q-id is already assigned elsewhere, `guessWikidata` requests `companyLink` approval instead of silent relink |
+| 3.5.9 | **Canonical run company id** — `ReportRun.companyId` synced from precheck/guessWikidata; `checkDB` waits for guessWikidata then resolves id before API save; `saveToAPI` re-resolves |
+| 3.5.8 | **Name suffix matching** — strip legal suffixes (`AB`, etc.) before exact name compare |
 
 **Repos / changes:**
 

--- a/doc/COMPANY_IDENTIFIERS_PLAN.md
+++ b/doc/COMPANY_IDENTIFIERS_PLAN.md
@@ -145,17 +145,17 @@ No response shape change. `PartnerCompanyBase` keeps `id`, `wikidataId`, `lei` p
 
 **Name source for matching (unchanged from Phase 3):** LLM extraction from report markdown in `precheck`, or `job.data.companyName` when set by pipeline-api / staff. Wikidata labels are **not** used for name matching; Wikidata is a separate resolution path via `job.data.wikidata.node` when present on the job (typical on re-runs).
 
-| Step  | Work                                                                                                                                                                                                                                           |
-| ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 3.5.1 | **Ambiguity heuristics** — `assessCompanyLinkResolution` in `src/lib/companyLinkResolve.ts` |
-| 3.5.2 | **`precheck` approval gate** — `requestApproval('companyLink', …)` when ambiguous; resume on approve |
-| 3.5.3 | **Validate `CompanyLinkApprovalDisplay`** — radio candidates + create-new; `useJobRerunActions` approve |
-| 3.5.4 | **Observability** — precheck logs candidate list when ambiguity gate fires |
-| 3.5.5 | **Re-run contract** — prefer `job.data.companyId` or `wikidata.node` on re-runs (documented in `resolvePipelineCompanyOutcome`) |
-| 3.5.6 | **Tests** — `companyLinkResolve.test.ts`, `pipelineCompanyResolve.test.ts`, Validate parser test |
-| 3.5.7 | **Wikidata relink gate** — when Q-id is already assigned elsewhere, `guessWikidata` requests `companyLink` approval instead of silent relink |
+| Step  | Work                                                                                                                                                                                 |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 3.5.1 | **Ambiguity heuristics** — `assessCompanyLinkResolution` in `src/lib/companyLinkResolve.ts`                                                                                          |
+| 3.5.2 | **`precheck` approval gate** — `requestApproval('companyLink', …)` when ambiguous; resume on approve                                                                                 |
+| 3.5.3 | **Validate `CompanyLinkApprovalDisplay`** — radio candidates + create-new; `useJobRerunActions` approve                                                                              |
+| 3.5.4 | **Observability** — precheck logs candidate list when ambiguity gate fires                                                                                                           |
+| 3.5.5 | **Re-run contract** — prefer `job.data.companyId` or `wikidata.node` on re-runs (documented in `resolvePipelineCompanyOutcome`)                                                      |
+| 3.5.6 | **Tests** — `companyLinkResolve.test.ts`, `pipelineCompanyResolve.test.ts`, Validate parser test                                                                                     |
+| 3.5.7 | **Wikidata relink gate** — when Q-id is already assigned elsewhere, `guessWikidata` requests `companyLink` approval instead of silent relink                                         |
 | 3.5.9 | **Canonical run company id** — `ReportRun.companyId` synced from precheck/guessWikidata; `checkDB` waits for guessWikidata then resolves id before API save; `saveToAPI` re-resolves |
-| 3.5.8 | **Name suffix matching** — strip legal suffixes (`AB`, etc.) before exact name compare |
+| 3.5.8 | **Name suffix matching** — strip legal suffixes (`AB`, etc.) before exact name compare                                                                                               |
 
 **Repos / changes:**
 

--- a/doc/chroma-storage-plan.md
+++ b/doc/chroma-storage-plan.md
@@ -25,12 +25,12 @@ flowchart LR
 
 Data lifecycle after this plan:
 
-| Artifact | Store | Retention | Recreate cost |
-|---|---|---|---|
-| PDF | S3 (pipeline-api cache) | forever | — |
-| Docling markdown | Postgres `ReportMarkdown` | forever | minutes of Docling (avoided) |
-| Embeddings/index | Chroma | ~90 days since last use | cents, <1 min |
-| Retrieved context per job | Postgres `ReportRunJob.markdown` | forever (already exists) | — |
+| Artifact                  | Store                            | Retention                | Recreate cost                |
+| ------------------------- | -------------------------------- | ------------------------ | ---------------------------- |
+| PDF                       | S3 (pipeline-api cache)          | forever                  | —                            |
+| Docling markdown          | Postgres `ReportMarkdown`        | forever                  | minutes of Docling (avoided) |
+| Embeddings/index          | Chroma                           | ~90 days since last use  | cents, <1 min                |
+| Retrieved context per job | Postgres `ReportRunJob.markdown` | forever (already exists) | —                            |
 
 ---
 
@@ -64,6 +64,7 @@ f93df5ca-… (HNSW vector index):    5.5 G
    ```
 
    60 Gi = 25 G current + ~19 G vacuum scratch + headroom (PVCs cannot shrink later, but post-cleanup usage will stay far below). Update `volumeSize` in `infra/clusters/garbo/infrastructure/{prod,stage}/chromadb-helm.yaml` to match, with a comment that the value does not resize existing volumes. Verify `indexMarkdown` succeeds again.
+
 3. **Vacuum**: stop writes (scale the worker deployment to 0). Check whether the 1.x server image ships the CLI (`kubectl -n garbo exec chromadb-0 -- chroma utils vacuum --help`); if not, scale chromadb to 0 and run a one-off Job with a Python image (`pip install chromadb`, PVC mounted) running `chroma utils vacuum --path /data`. Reclaims deleted pages/WAL and ensures auto-purge stays enabled.
 4. **Delete duplicate sources**: script (garbo repo, `scripts/chroma-dedupe.ts`) that lists distinct `source` values in the collection, compares against the `Report` registry (`url`, `sourceUrl`, `s3Url` columns), and deletes Chroma sources that are non-canonical duplicates of the same registry row (same PDF indexed under a stale/alternate URL). Log everything deleted. Vacuum again after.
 
@@ -95,6 +96,7 @@ model ReportMarkdown {
 ```
 
 Notes:
+
 - Postgres TOAST compresses large text automatically; no manual gzip needed. Expect ~100–300 KB effective per report, low single-digit GB for the whole corpus.
 - `sha256` comes from the `Report` registry row when available (pipeline-api already computes it); a follow-up can make `Report` ↔ `ReportMarkdown` a real relation, not required for v1.
 
@@ -108,13 +110,13 @@ Small service with the story-telling names the codebase prefers:
 
 ### 1.3 Pipeline changes
 
-| File | Change |
-|---|---|
-| `src/workers/indexMarkdown.ts` | After receiving markdown from the Docling child, call `saveReportMarkdown(url, markdown)` **before** `vectorDB.addReport`. Saving to Postgres first means a Chroma failure no longer loses the parse. |
-| `src/workers/parsePdf.ts` | Cache check becomes `hasReportMarkdown(url)` (with `vectorDB.hasReport(url)` fallback during transition). `forceReindex` keeps its meaning: delete vector index AND stored markdown, re-run Docling. |
+| File                                  | Change                                                                                                                                                                                                                                               |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/workers/indexMarkdown.ts`        | After receiving markdown from the Docling child, call `saveReportMarkdown(url, markdown)` **before** `vectorDB.addReport`. Saving to Postgres first means a Chroma failure no longer loses the parse.                                                |
+| `src/workers/parsePdf.ts`             | Cache check becomes `hasReportMarkdown(url)` (with `vectorDB.hasReport(url)` fallback during transition). `forceReindex` keeps its meaning: delete vector index AND stored markdown, re-run Docling.                                                 |
 | `src/workers/precheck.ts` cached path | `parsePdf` currently builds `cachedMarkdown` via a Chroma similarity query just to find the company name. Replace with the stored markdown (first ~15k chars is what `extractCompanyName` walks through anyway). Fewer Chroma queries, better input. |
-| `scripts/delete-report.ts` | Also delete the `ReportMarkdown` row (behind the same confirmation). |
-| `scripts/dev-reset.ts` | Also truncate `ReportMarkdown`. |
+| `scripts/delete-report.ts`            | Also delete the `ReportMarkdown` row (behind the same confirmation).                                                                                                                                                                                 |
+| `scripts/dev-reset.ts`                | Also truncate `ReportMarkdown`.                                                                                                                                                                                                                      |
 
 ### 1.4 Rollout
 
@@ -175,10 +177,10 @@ Goal: Chroma holds only the working set, forever bounded; reruns on cold reports
 
 Third branch in the cache logic:
 
-| State | Action |
-|---|---|
-| no markdown stored | full flow: Docling → indexMarkdown → precheck (today's cold path) |
-| markdown stored + index exists | straight to precheck (today's warm path, now reading markdown from Postgres) |
+| State                               | Action                                                                                                                                                             |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| no markdown stored                  | full flow: Docling → indexMarkdown → precheck (today's cold path)                                                                                                  |
+| markdown stored + index exists      | straight to precheck (today's warm path, now reading markdown from Postgres)                                                                                       |
 | **markdown stored + index missing** | **new**: flow of indexMarkdown → precheck, passing the stored markdown in job data (`indexMarkdown` already accepts `job.data.markdown` — no Docling child needed) |
 
 This is the piece that makes deletion safe: any rerun against a pruned report costs one embedding pass (~$0.02–0.05, <1 min), never a Docling parse.
@@ -198,12 +200,12 @@ The rerun buttons in validate (`useJobRerunActions`, `useRunReportsPipeline`) go
 
 ## Cross-repo summary
 
-| Repo | Changes |
-|---|---|
-| **garbo** | Workstreams 1–4: prisma migration, `markdownStore`, `markdownChunking`, `vectordb.ts` slimming, `parsePdf`/`precheck`/`indexMarkdown` updates, retention worker, backfill + dedupe scripts, script updates (`delete-report`, `dev-reset`), env vars `CHROMA_RETENTION_DAYS` added to `k8s/base/worker.yaml` + `.env.example` |
-| **infra** | Workstream 0 (vacuum Job, optional volume bump in `chromadb-helm.yaml` stage+prod), monitoring section below |
-| **pipeline-api** | No required changes. Optional improvement: always enqueue with the cached S3 URL (it already does when `cachePdf: true`) and pass `sha256` through job data so `ReportMarkdown.sha256` is populated at write time instead of via registry lookup |
-| **validate** | No required changes. Optional: surface the "rebuilding index" message distinctly in run status UI |
+| Repo             | Changes                                                                                                                                                                                                                                                                                                                      |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **garbo**        | Workstreams 1–4: prisma migration, `markdownStore`, `markdownChunking`, `vectordb.ts` slimming, `parsePdf`/`precheck`/`indexMarkdown` updates, retention worker, backfill + dedupe scripts, script updates (`delete-report`, `dev-reset`), env vars `CHROMA_RETENTION_DAYS` added to `k8s/base/worker.yaml` + `.env.example` |
+| **infra**        | Workstream 0 (vacuum Job, optional volume bump in `chromadb-helm.yaml` stage+prod), monitoring section below                                                                                                                                                                                                                 |
+| **pipeline-api** | No required changes. Optional improvement: always enqueue with the cached S3 URL (it already does when `cachePdf: true`) and pass `sha256` through job data so `ReportMarkdown.sha256` is populated at write time instead of via registry lookup                                                                             |
+| **validate**     | No required changes. Optional: surface the "rebuilding index" message distinctly in run status UI                                                                                                                                                                                                                            |
 
 Order of operations (safety-critical): **W0 (vacuum/dedupe) → W1 (store) → W2 (backfill) → W3 (slim writes) → W4 (retention)**. W3 and W4 can land together; retention must not be enabled before W2 reports zero uncovered sources.
 

--- a/doc/chroma-storage-plan.md
+++ b/doc/chroma-storage-plan.md
@@ -1,0 +1,249 @@
+# Plan: ChromaDB storage — cleanup now, bounded storage forever
+
+## Background
+
+The `indexMarkdown` job is failing because the ChromaDB volume (`data-chromadb-0`, 25 Gi PVC in the `garbo` namespace — helm says 30 Gi but see Workstream 0) is full. Investigation findings:
+
+- Chroma holds one collection, `emission_reports`. Every processed report is chunked (2000 chars, 200 overlap) and stored with an ada-002 embedding **plus a full copy of its parent paragraph in every chunk's metadata** (`src/lib/vectordb.ts`, `addReport`). A paragraph of length P is duplicated ~P/1800 times — 10–20× storage amplification, worse for reports with large sections.
+- Nothing is ever deleted. Chunks are keyed `${url}#index`, so the same PDF indexed under different URLs (web URL vs. pipeline-api S3 URL) is stored in full multiple times.
+- Chroma is also the **only** store of the Docling markdown output. `parsePdf` uses `vectorDB.hasReport(url)` as the "already parsed" cache. This is why nothing can be deleted today: deleting the index deletes the only copy of the expensive Docling parse.
+- The deployment (infra repo, Amikos chart 0.2.2 → Chroma 1.5.3, `sqliteDb.migrationMode: apply`) was upgraded in place; legacy SQLite/WAL bloat may be occupying significant space and is never reclaimed without a vacuum.
+
+## Target architecture
+
+Markdown becomes a first-class, permanent artifact in Postgres. Chroma becomes a **disposable working-set cache** that can be pruned or rebuilt at any time.
+
+```mermaid
+flowchart LR
+    PDF[PDF in S3<br/>keyed by sha256<br/>kept forever] --> DOC[doclingParsePDF<br/>runs ONCE per PDF]
+    DOC --> MD[(ReportMarkdown<br/>in Postgres<br/>kept forever)]
+    MD --> IDX[indexMarkdown<br/>cheap re-embed<br/>cents + <1 min]
+    IDX --> CHROMA[(Chroma<br/>working set only<br/>pruned after N days)]
+    CHROMA --> FU[followUp* jobs<br/>semantic retrieval]
+    MD --> FU
+```
+
+Data lifecycle after this plan:
+
+| Artifact | Store | Retention | Recreate cost |
+|---|---|---|---|
+| PDF | S3 (pipeline-api cache) | forever | — |
+| Docling markdown | Postgres `ReportMarkdown` | forever | minutes of Docling (avoided) |
+| Embeddings/index | Chroma | ~90 days since last use | cents, <1 min |
+| Retrieved context per job | Postgres `ReportRunJob.markdown` | forever (already exists) | — |
+
+---
+
+## Workstream 0 — Reclaim space now (ops + infra repo, no app code)
+
+Goal: get `indexMarkdown` unblocked this week. Safe to do immediately; none of this deletes parsed-markdown history.
+
+### Findings from prod (2026-07-08)
+
+```
+data-chromadb-0 PVC: 25Gi, /data 100% full (1.1 MB free)
+chroma.sqlite3:                    19 G   ← metadata + documents + WAL
+f93df5ca-… (HNSW vector index):    5.5 G
+```
+
+- The PVC is **25 Gi even though helm values say 30 Gi**: StatefulSet volume claim templates are immutable, so changing `volumeSize` in the HelmRelease never resizes an existing volume. The PVC must be patched directly.
+- SQLite at 3.5× the vector index confirms metadata (duplicated paragraphs) is the dominant consumer, not embeddings. The volume is only ~132 days old (created on Chroma 1.x, WAL auto-purge on), so expect vacuum to help moderately — the big reductions come from dedupe (step 4) and Workstream 3.
+- With ~1 MB free, **vacuum is impossible** (it rebuilds the DB into a copy, needing ~19 G scratch) and even deletes may fail. Expansion must happen first.
+
+### Steps
+
+1. **Snapshot the PV** (Harvester VolumeSnapshot) before touching anything. The helm values already set `retentionPolicyOnDelete: Retain`.
+2. **Expand the PVC directly** (this also resolves the immediate incident):
+
+   ```bash
+   kubectl get sc harvester -o jsonpath='{.allowVolumeExpansion}'   # must be true
+   kubectl -n garbo patch pvc data-chromadb-0 \
+     -p '{"spec":{"resources":{"requests":{"storage":"60Gi"}}}}'
+   kubectl -n garbo describe pvc data-chromadb-0   # if FileSystemResizePending:
+   kubectl -n garbo delete pod chromadb-0          # StatefulSet recreates it
+   ```
+
+   60 Gi = 25 G current + ~19 G vacuum scratch + headroom (PVCs cannot shrink later, but post-cleanup usage will stay far below). Update `volumeSize` in `infra/clusters/garbo/infrastructure/{prod,stage}/chromadb-helm.yaml` to match, with a comment that the value does not resize existing volumes. Verify `indexMarkdown` succeeds again.
+3. **Vacuum**: stop writes (scale the worker deployment to 0). Check whether the 1.x server image ships the CLI (`kubectl -n garbo exec chromadb-0 -- chroma utils vacuum --help`); if not, scale chromadb to 0 and run a one-off Job with a Python image (`pip install chromadb`, PVC mounted) running `chroma utils vacuum --path /data`. Reclaims deleted pages/WAL and ensures auto-purge stays enabled.
+4. **Delete duplicate sources**: script (garbo repo, `scripts/chroma-dedupe.ts`) that lists distinct `source` values in the collection, compares against the `Report` registry (`url`, `sourceUrl`, `s3Url` columns), and deletes Chroma sources that are non-canonical duplicates of the same registry row (same PDF indexed under a stale/alternate URL). Log everything deleted. Vacuum again after.
+
+> ⚠️ Do **not** run any age-based deletion in this phase. Old entries are still the only copy of their Docling parse until Workstream 2 completes.
+
+---
+
+## Workstream 1 — Markdown becomes first-class (garbo repo)
+
+Goal: every parsed report's markdown is durably stored in Postgres; the pipeline reads the cache from Postgres, not Chroma.
+
+### 1.1 Schema (`prisma/schema.prisma` + migration)
+
+```prisma
+/// Docling output for a processed PDF. Source of truth for "has this PDF been parsed".
+model ReportMarkdown {
+  id           String   @id @default(cuid())
+  /// Pipeline URL the report was processed under (matches Chroma `source` and job data `url`).
+  url          String   @unique
+  /// Content hash of the PDF when known — enables dedupe across URL variants.
+  sha256       String?
+  markdown     String
+  /// True when recovered from Chroma metadata rather than saved directly from Docling.
+  reconstructed Boolean @default(false)
+  parsedAt     DateTime @default(now())
+
+  @@index([sha256])
+}
+```
+
+Notes:
+- Postgres TOAST compresses large text automatically; no manual gzip needed. Expect ~100–300 KB effective per report, low single-digit GB for the whole corpus.
+- `sha256` comes from the `Report` registry row when available (pipeline-api already computes it); a follow-up can make `Report` ↔ `ReportMarkdown` a real relation, not required for v1.
+
+### 1.2 New module `src/lib/markdownStore.ts`
+
+Small service with the story-telling names the codebase prefers:
+
+- `saveReportMarkdown(url, markdown, { sha256?, reconstructed? })` — upsert by url; if `sha256` matches an existing row under a different url, reuse/point rather than store a second copy.
+- `getReportMarkdown(url): Promise<string | null>` — lookup by url, falling back to sha256 via the `Report` registry (handles "same PDF, different URL").
+- `hasReportMarkdown(url): Promise<boolean>`
+
+### 1.3 Pipeline changes
+
+| File | Change |
+|---|---|
+| `src/workers/indexMarkdown.ts` | After receiving markdown from the Docling child, call `saveReportMarkdown(url, markdown)` **before** `vectorDB.addReport`. Saving to Postgres first means a Chroma failure no longer loses the parse. |
+| `src/workers/parsePdf.ts` | Cache check becomes `hasReportMarkdown(url)` (with `vectorDB.hasReport(url)` fallback during transition). `forceReindex` keeps its meaning: delete vector index AND stored markdown, re-run Docling. |
+| `src/workers/precheck.ts` cached path | `parsePdf` currently builds `cachedMarkdown` via a Chroma similarity query just to find the company name. Replace with the stored markdown (first ~15k chars is what `extractCompanyName` walks through anyway). Fewer Chroma queries, better input. |
+| `scripts/delete-report.ts` | Also delete the `ReportMarkdown` row (behind the same confirmation). |
+| `scripts/dev-reset.ts` | Also truncate `ReportMarkdown`. |
+
+### 1.4 Rollout
+
+Deploy behind normal review; no feature flag needed — writes are additive and reads fall back to the old Chroma check. Verify in stage: process one new PDF, confirm `ReportMarkdown` row exists, re-enqueue the same URL, confirm Docling is skipped with log line `markdown cache hit (postgres)`.
+
+---
+
+## Workstream 2 — Backfill history (garbo repo, one-time)
+
+Goal: every report currently in Chroma gets a `ReportMarkdown` row, so history is fully covered before anything is pruned.
+
+1. Script `scripts/backfill-markdown-from-chroma.ts`:
+   - list distinct `source` values in the collection
+   - for each source without a `ReportMarkdown` row: `collection.get({ where: { source } })`, sort records by the numeric suffix of their `${url}#index` ids, take unique `paragraph` metadata values in order, rejoin (first paragraph as-is, subsequent prefixed `\n## `)
+   - save with `reconstructed: true`
+   - batch with the existing `withChromaLimit` semaphore pattern; resumable (skip sources already stored)
+2. **Known lossiness**: the original split was on `\n##`, so `###`-level headings are slightly mangled on reconstruction. This is fine for LLM retrieval context (the paragraphs Chroma returns today have the same artifact). The `reconstructed` flag records which rows could be improved by a future re-parse if ever needed.
+3. Run in stage first; in prod run as a k8s Job (pattern exists in `k8s/jobs/`). Completion criterion: `distinct Chroma sources without ReportMarkdown row = 0` (script prints this).
+
+---
+
+## Workstream 3 — Stop the amplification (garbo repo)
+
+Goal: new Chroma writes shrink ~10×; retrieval behavior unchanged.
+
+### 3.1 Write path (`src/lib/vectordb.ts`)
+
+`addReport` splits markdown into merged paragraphs (existing logic). Changes:
+
+- store `paragraphIndex: number` in chunk metadata **instead of** the full `paragraph` text
+- keep `source`, `type`, `parsed` metadata as-is (needed for filtering, dedupe, and retention)
+- chunk document text stays (Chroma requires the document for the embedding function; it's small)
+
+The paragraph list itself is derived deterministically from the stored markdown, so it needs no separate table: add `getReportParagraphs(url)` to `markdownStore` that loads the markdown and applies the exact same split+merge function. Extract that split+merge into a shared pure function (`src/lib/markdownChunking.ts`) so write path and read path can never drift.
+
+### 3.2 Read path (`src/lib/vectordb.ts`)
+
+`getRelevantMarkdown`:
+
+- query Chroma as today
+- for hits with `paragraph` metadata (old-format entries): use it directly — **backward compatible during transition**
+- for hits with `paragraphIndex`: resolve text via `getReportParagraphs(url)[index]`
+- dedupe and join as today
+
+Callers (`FollowUpWorker`, `precheck`, `assess`) are unchanged — same function, same output shape.
+
+### 3.3 No index migration needed
+
+Old entries keep working via the fallback; they age out naturally under Workstream 4 retention, or disappear when a report is re-indexed. No big-bang rewrite of the collection.
+
+---
+
+## Workstream 4 — Retention + reindex-on-demand (garbo repo)
+
+Goal: Chroma holds only the working set, forever bounded; reruns on cold reports "just work".
+
+### 4.1 Reindex-on-demand (`src/workers/parsePdf.ts`)
+
+Third branch in the cache logic:
+
+| State | Action |
+|---|---|
+| no markdown stored | full flow: Docling → indexMarkdown → precheck (today's cold path) |
+| markdown stored + index exists | straight to precheck (today's warm path, now reading markdown from Postgres) |
+| **markdown stored + index missing** | **new**: flow of indexMarkdown → precheck, passing the stored markdown in job data (`indexMarkdown` already accepts `job.data.markdown` — no Docling child needed) |
+
+This is the piece that makes deletion safe: any rerun against a pruned report costs one embedding pass (~$0.02–0.05, <1 min), never a Docling parse.
+
+### 4.2 Retention job
+
+- BullMQ repeatable job (weekly), new tiny worker `src/workers/chromaRetention.ts` registered in `startWorkers.ts` — no new infra since workers already run.
+- Logic: `collection.get` metadata-only, group by `source`, find sources whose newest `parsed` timestamp is older than `CHROMA_RETENTION_DAYS` (env, default 90) **and** which have a `ReportMarkdown` row (never prune the only copy — belt-and-braces even after backfill), then `collection.delete({ where: { source } })` per source.
+- Log a summary (sources pruned, chunks deleted, distinct sources remaining) and post it to the ops Discord channel via the existing messaging utilities — this doubles as the heartbeat that the job is alive.
+- Note: Chroma deletes don't shrink the SQLite file immediately; auto-purge (enabled by the Workstream 0 vacuum) plus HNSW segment cleanup keep it bounded. An occasional vacuum (e.g. quarterly, manual) fully compacts.
+
+### 4.3 `forceReindex` semantics (validate frontend, no change required)
+
+The rerun buttons in validate (`useJobRerunActions`, `useRunReportsPipeline`) go through pipeline-api → `parsePdf` job data unchanged. `forceReindex` still means "re-run Docling from scratch". The only user-visible difference is cold reruns showing the "Parsing…" step briefly for re-embedding — optional polish: a distinct message `♻️ Rebuilding search index from cached parse...` so operators don't think Docling is re-running.
+
+---
+
+## Cross-repo summary
+
+| Repo | Changes |
+|---|---|
+| **garbo** | Workstreams 1–4: prisma migration, `markdownStore`, `markdownChunking`, `vectordb.ts` slimming, `parsePdf`/`precheck`/`indexMarkdown` updates, retention worker, backfill + dedupe scripts, script updates (`delete-report`, `dev-reset`), env vars `CHROMA_RETENTION_DAYS` added to `k8s/base/worker.yaml` + `.env.example` |
+| **infra** | Workstream 0 (vacuum Job, optional volume bump in `chromadb-helm.yaml` stage+prod), monitoring section below |
+| **pipeline-api** | No required changes. Optional improvement: always enqueue with the cached S3 URL (it already does when `cachePdf: true`) and pass `sha256` through job data so `ReportMarkdown.sha256` is populated at write time instead of via registry lookup |
+| **validate** | No required changes. Optional: surface the "rebuilding index" message distinctly in run status UI |
+
+Order of operations (safety-critical): **W0 (vacuum/dedupe) → W1 (store) → W2 (backfill) → W3 (slim writes) → W4 (retention)**. W3 and W4 can land together; retention must not be enabled before W2 reports zero uncovered sources.
+
+---
+
+## Monitoring & alerts
+
+Infra already runs kube-prometheus-stack (Grafana persisted, **Alertmanager currently disabled**). Two options; recommended: use **Grafana-managed alerts** with a Discord webhook contact point (matches how the team already communicates), avoiding the Alertmanager enable/config work. Enable Alertmanager later if alert routing needs grow.
+
+### Disk / capacity (prevents this incident recurring)
+
+- `kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes` for the chromadb PVC: **warn < 30 % free, critical < 15 % free**. This is the alert that was missing this time. Add the same for the Postgres and Prometheus PVCs while at it.
+- Chroma pod memory working set vs. its 8 Gi limit (HNSW is memory-hungry; OOM kills present as the flaky Chroma errors seen in `indexMarkdown` retries): warn > 80 %.
+
+### Pipeline health (garbo)
+
+- `indexMarkdown` failure alerting already surfaces per-run via job thread messages; add a Grafana alert on BullMQ failed-job counts if/when queue metrics are exported. Pragmatic v1: the retention job's weekly Discord summary includes failed `indexMarkdown` count from `ReportRunJob` (`status = 'failed'`, `queueName = 'indexMarkdown'`, last 7 days).
+- **Docling re-run detector** (guards "never parse twice"): count of Docling runs for URLs that already had a `ReportMarkdown` row — should be ~0 outside explicit `forceReindex`. Include in the weekly summary; nonzero means the cache lookup regressed.
+- **Coverage metric** (until W2 completes, then as a permanent invariant): distinct Chroma sources without a `ReportMarkdown` row. Must be 0 before retention is enabled; alert if ever > 0 afterward.
+
+### Retention job health
+
+- Weekly Discord summary post = heartbeat. Alert condition: no summary for > 8 days (Grafana alert on absence if metrics exist; otherwise a human-visible gap in the ops channel is acceptable for v1).
+- Summary contents: sources pruned, chunks deleted, distinct sources remaining, estimated collection size, coverage metric, Docling re-run count.
+
+### Dashboards
+
+One Grafana dashboard: chroma PVC usage over time, chroma pod memory, distinct sources in collection (retention job can push this via Pushgateway later; v1 = logged numbers), `ReportMarkdown` row count and total bytes (`pg_column_size` sum), weekly Docling runs vs. cache hits.
+
+---
+
+## Rollback notes
+
+- W1 is additive; rolling back is removing reads, the table can stay.
+- W3 read path keeps the old-metadata fallback indefinitely; rolling back the write path just resumes fat metadata.
+- W4 retention can be paused by removing the repeatable job; nothing pruned is unrecoverable (markdown + reindex-on-demand restore any report).
+- The only irreversible step is deletion in W0 step 4 (dedupe) and W4 pruning — both gated on the registry/markdown-store checks described above, plus the W0 snapshot.
+
+## Open questions
+
+1. Retention window: 90 days default — right trade-off between rerun frequency and storage? (Operators rerun recent batches most; tune with data from the weekly summaries.)
+2. Should `forceReindex` from validate get a lighter sibling ("re-embed only") once reindex-on-demand exists? Cheap to add, unclear if needed.
+3. Populate `ReportMarkdown.sha256` from pipeline-api job data (small pipeline-api change) or registry lookup (garbo-only)? Registry lookup is enough for v1.

--- a/doc/rfc/README.md
+++ b/doc/rfc/README.md
@@ -1,5 +1,5 @@
 # RFCs
 
-| RFC                                                        | Status                  | Description                                                                 |
-| ---------------------------------------------------------- | ----------------------- | --------------------------------------------------------------------------- |
-| [chromadb-storage.md](./chromadb-storage.md)               | Draft — no decision yet | Postgres-backed markdown cache; Chroma as disposable working-set with retention |
+| RFC                                          | Status                  | Description                                                                     |
+| -------------------------------------------- | ----------------------- | ------------------------------------------------------------------------------- |
+| [chromadb-storage.md](./chromadb-storage.md) | Draft — no decision yet | Postgres-backed markdown cache; Chroma as disposable working-set with retention |

--- a/doc/rfc/README.md
+++ b/doc/rfc/README.md
@@ -1,0 +1,5 @@
+# RFCs
+
+| RFC                                                        | Status                  | Description                                                                 |
+| ---------------------------------------------------------- | ----------------------- | --------------------------------------------------------------------------- |
+| [chromadb-storage.md](./chromadb-storage.md)               | Draft — no decision yet | Postgres-backed markdown cache; Chroma as disposable working-set with retention |

--- a/doc/rfc/chromadb-storage.md
+++ b/doc/rfc/chromadb-storage.md
@@ -8,10 +8,10 @@ Make Docling markdown a first-class Postgres artifact and treat Chroma as a **di
 
 **Related docs**
 
-| Repo / doc | Plan |
-| ---------- | ---- |
-| garbo | [pipeline.md](../pipeline.md) — PDF → markdown → extraction flow |
-| garbo | [COMPANY_IDENTIFIERS_PLAN.md](../COMPANY_IDENTIFIERS_PLAN.md) — in-flight schema + pipeline identity work |
+| Repo / doc | Plan                                                                                                      |
+| ---------- | --------------------------------------------------------------------------------------------------------- |
+| garbo      | [pipeline.md](../pipeline.md) — PDF → markdown → extraction flow                                          |
+| garbo      | [COMPANY_IDENTIFIERS_PLAN.md](../COMPANY_IDENTIFIERS_PLAN.md) — in-flight schema + pipeline identity work |
 
 ---
 

--- a/doc/rfc/chromadb-storage.md
+++ b/doc/rfc/chromadb-storage.md
@@ -1,4 +1,19 @@
-# Plan: ChromaDB storage — cleanup now, bounded storage forever
+# ChromaDB storage — cleanup now, bounded storage forever (RFC)
+
+Make Docling markdown a first-class Postgres artifact and treat Chroma as a **disposable working-set cache** that can be pruned or rebuilt at any time.
+
+**Status:** Draft RFC — **no decision made**. Comments and alternatives welcome.
+
+**Audience:** Engineers across **garbo**, **infra**, **pipeline-api**, and **validate**.
+
+**Related docs**
+
+| Repo / doc | Plan |
+| ---------- | ---- |
+| garbo | [pipeline.md](../pipeline.md) — PDF → markdown → extraction flow |
+| garbo | [COMPANY_IDENTIFIERS_PLAN.md](../COMPANY_IDENTIFIERS_PLAN.md) — in-flight schema + pipeline identity work |
+
+---
 
 ## Background
 
@@ -9,7 +24,7 @@ The `indexMarkdown` job is failing because the ChromaDB volume (`data-chromadb-0
 - Chroma is also the **only** store of the Docling markdown output. `parsePdf` uses `vectorDB.hasReport(url)` as the "already parsed" cache. This is why nothing can be deleted today: deleting the index deletes the only copy of the expensive Docling parse.
 - The deployment (infra repo, Amikos chart 0.2.2 → Chroma 1.5.3, `sqliteDb.migrationMode: apply`) was upgraded in place; legacy SQLite/WAL bloat may be occupying significant space and is never reclaimed without a vacuum.
 
-## Target architecture
+## Proposed decision
 
 Markdown becomes a first-class, permanent artifact in Postgres. Chroma becomes a **disposable working-set cache** that can be pruned or rebuilt at any time.
 
@@ -23,7 +38,7 @@ flowchart LR
     MD --> FU
 ```
 
-Data lifecycle after this plan:
+Data lifecycle after this RFC is implemented:
 
 | Artifact                  | Store                            | Retention                | Recreate cost                |
 | ------------------------- | -------------------------------- | ------------------------ | ---------------------------- |
@@ -31,6 +46,8 @@ Data lifecycle after this plan:
 | Docling markdown          | Postgres `ReportMarkdown`        | forever                  | minutes of Docling (avoided) |
 | Embeddings/index          | Chroma                           | ~90 days since last use  | cents, <1 min                |
 | Retrieved context per job | Postgres `ReportRunJob.markdown` | forever (already exists) | —                            |
+
+**Order of operations (safety-critical):** W0 (vacuum/dedupe) → W1 (store) → W2 (backfill) → W3 (slim writes) → W4 (retention). W3 and W4 can land together; retention must not be enabled before W2 reports zero uncovered sources.
 
 ---
 
@@ -206,8 +223,6 @@ The rerun buttons in validate (`useJobRerunActions`, `useRunReportsPipeline`) go
 | **infra**        | Workstream 0 (vacuum Job, optional volume bump in `chromadb-helm.yaml` stage+prod), monitoring section below                                                                                                                                                                                                                 |
 | **pipeline-api** | No required changes. Optional improvement: always enqueue with the cached S3 URL (it already does when `cachePdf: true`) and pass `sha256` through job data so `ReportMarkdown.sha256` is populated at write time instead of via registry lookup                                                                             |
 | **validate**     | No required changes. Optional: surface the "rebuilding index" message distinctly in run status UI                                                                                                                                                                                                                            |
-
-Order of operations (safety-critical): **W0 (vacuum/dedupe) → W1 (store) → W2 (backfill) → W3 (slim writes) → W4 (retention)**. W3 and W4 can land together; retention must not be enabled before W2 reports zero uncovered sources.
 
 ---
 

--- a/k8s/jobs/README.md
+++ b/k8s/jobs/README.md
@@ -48,6 +48,27 @@ Sets `ReportingPeriod.companyReportId` for all rows. One `CompanyReport` per com
 
 6. Watch logs: `kubectl logs -n garbo-stage job/link-periods-to-company-reports-<suffix> -f`
 
+## Find duplicate companies (read-only scan)
+
+Reports potential duplicate `Company` rows using the same normalized-name / LEI / Wikidata-conflict rules as the pipeline company-link logic. **Does not modify the database.**
+
+1. Deploy a garbo image that includes `scripts/find-duplicate-companies.ts` (or pin `image:` in the YAML to a tag that has it).
+2. Edit `find-duplicate-companies.yaml`: set `metadata.namespace` to `garbo-stage` or `garbo` (add a `namespace:` field under `metadata` before create, or `kubectl create -n <ns> -f ...`).
+3. Optional: edit `args`, e.g. `--reason=wikidata_conflict`, `--limit=50`, or write `--json=/tmp/duplicate-companies.json` / `--csv=/tmp/duplicate-companies.csv`.
+4. Create the job:
+
+   ```bash
+   kubectl create -n garbo-stage -f k8s/jobs/find-duplicate-companies.yaml
+   ```
+
+5. Watch logs: `kubectl logs -n garbo-stage job/find-duplicate-companies-<suffix> -f`
+
+6. If you used `--json` or `--csv` under `/tmp`, copy files before the job TTL expires:
+
+   ```bash
+   kubectl cp -n garbo-stage <pod-name>:/tmp/duplicate-companies.csv ./duplicate-companies.csv
+   ```
+
 ## Reporting periods per document (deploy order)
 
 After the link job has run in that environment (no `companyReportId IS NULL`):

--- a/k8s/jobs/find-duplicate-companies.yaml
+++ b/k8s/jobs/find-duplicate-companies.yaml
@@ -1,0 +1,65 @@
+# One-off Job: scan Company rows for potential duplicates (read-only).
+# NOT applied by Flux — use: kubectl create -f k8s/jobs/find-duplicate-companies.yaml
+#
+# Requires a garbo image that includes scripts/find-duplicate-companies.ts (deploy after merge).
+# Pin `image:` to a specific tag if you need a known build.
+#
+# Examples (edit args before create):
+#   ["scripts/find-duplicate-companies.ts"]
+#   ["scripts/find-duplicate-companies.ts", "--reason=wikidata_conflict"]
+#   ["scripts/find-duplicate-companies.ts", "--limit=30"]
+#   ["scripts/find-duplicate-companies.ts", "--json=/tmp/duplicate-companies.json", "--csv=/tmp/duplicate-companies.csv"]
+#
+# Copy exports from the pod (while Job is still running or before ttl cleanup):
+#   kubectl cp -n garbo <pod>:/tmp/duplicate-companies.csv ./duplicate-companies.csv
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: find-duplicate-companies-
+  labels:
+    app: garbo
+    job-type: find-duplicate-companies
+spec:
+  ttlSecondsAfterFinished: 3600
+  backoffLimit: 0
+  activeDeadlineSeconds: 1800
+  template:
+    metadata:
+      labels:
+        app: garbo
+        job-type: find-duplicate-companies
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: scan
+          image: ghcr.io/klimatbyran/garbo
+          imagePullPolicy: Always
+          workingDir: /app
+          command: ['npx', '--yes', 'tsx']
+          args: ['scripts/find-duplicate-companies.ts']
+          resources:
+            requests:
+              cpu: '100m'
+              memory: '256Mi'
+            limits:
+              memory: '512Mi'
+          envFrom:
+            - secretRef:
+                name: env
+          env:
+            - name: NODE_ENV
+              value: production
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: redis
+                  key: redis-password
+                  optional: true
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql
+                  key: postgres-password
+            - name: DATABASE_URL
+              value: postgresql://postgres:$(POSTGRES_PASSWORD)@postgresql:5432/garbo

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "reset": "node --import tsx scripts/dev-reset.ts",
     "delete-report": "node --import tsx scripts/delete-report.ts",
     "dedupe:report-registry": "node --import dotenv/config --import tsx scripts/dedupe-report-registry.ts",
+    "find-duplicate-companies": "node --import dotenv/config --import tsx scripts/find-duplicate-companies.ts",
     "backfill:report-runs": "node --import tsx scripts/backfill-report-runs-from-bullmq.ts",
     "eslint": "npx eslint src",
     "format": "npx prettier --write .",

--- a/scripts/find-duplicate-companies.ts
+++ b/scripts/find-duplicate-companies.ts
@@ -1,0 +1,193 @@
+/**
+ * Find potential duplicate Company rows for manual review.
+ *
+ * Detection signals (same rules as pipeline company-link matching):
+ * - **normalized_name** — names equal after stripping legal suffixes (Alfa Laval AB vs Alfa Laval)
+ * - **lei** — same LEI on `Company.lei` or `CompanyIdentifier` (type LEI)
+ * - **wikidata_conflict** — same normalized name but different non-null Wikidata Q-ids
+ *
+ * Usage:
+ *   npm run find-duplicate-companies
+ *   npm run find-duplicate-companies -- --json=./duplicate-companies.json
+ *   npm run find-duplicate-companies -- --csv=./duplicate-companies.csv
+ *   npm run find-duplicate-companies -- --reason=wikidata_conflict
+ *   npm run find-duplicate-companies -- --min-group-size=3
+ */
+
+import 'dotenv/config'
+import { parseArgs } from 'node:util'
+import { writeFileSync } from 'node:fs'
+
+import { prisma } from '../src/lib/prisma'
+import {
+  findDuplicateCompanyGroups,
+  type DuplicateDetectionReason,
+  type DuplicateCompanyGroup,
+} from '../src/lib/findDuplicateCompanyGroups'
+
+const REASONS = [
+  'normalized_name',
+  'lei',
+  'wikidata_conflict',
+] as const satisfies readonly DuplicateDetectionReason[]
+
+function formatCompanyLine(group: DuplicateCompanyGroup) {
+  return group.companies
+    .map((company) => {
+      const wikidata = company.wikidataId ?? '—'
+      const lei = company.lei ?? '—'
+      return (
+        `    ${company.id}  ${company.name}\n` +
+        `      wikidata=${wikidata}  lei=${lei}  ` +
+        `periods=${company.reportingPeriodCount}  reports=${company.companyReportCount}`
+      )
+    })
+    .join('\n')
+}
+
+function toCsv(groups: DuplicateCompanyGroup[]): string {
+  const header =
+    'reason,group_key,company_id,company_name,wikidata_id,lei,reporting_period_count,company_report_count'
+  const rows = groups.flatMap((group) =>
+    group.companies.map((company) =>
+      [
+        group.reason,
+        JSON.stringify(group.key),
+        company.id,
+        JSON.stringify(company.name),
+        company.wikidataId ?? '',
+        company.lei ?? '',
+        company.reportingPeriodCount,
+        company.companyReportCount,
+      ].join(',')
+    )
+  )
+  return [header, ...rows].join('\n')
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      json: { type: 'string' },
+      csv: { type: 'string' },
+      reason: { type: 'string' },
+      'min-group-size': { type: 'string', default: '2' },
+      limit: { type: 'string' },
+    },
+    allowPositionals: false,
+  })
+
+  const minGroupSize = Math.max(2, Number(values['min-group-size']) || 2)
+  const reasonFilter = values.reason?.trim() as
+    | DuplicateDetectionReason
+    | undefined
+  if (reasonFilter && !REASONS.includes(reasonFilter)) {
+    throw new Error(
+      `Invalid --reason=${reasonFilter}. Use one of: ${REASONS.join(', ')}`
+    )
+  }
+
+  const [companies, identifiers] = await Promise.all([
+    prisma.company.findMany({
+      select: {
+        id: true,
+        name: true,
+        wikidataId: true,
+        lei: true,
+        _count: {
+          select: {
+            reportingPeriods: true,
+            companyReports: true,
+          },
+        },
+      },
+      orderBy: { name: 'asc' },
+    }),
+    prisma.companyIdentifier.findMany({
+      where: { type: { in: ['LEI', 'WIKIDATA'] } },
+      select: {
+        companyId: true,
+        type: true,
+        value: true,
+      },
+    }),
+  ])
+
+  const report = findDuplicateCompanyGroups({
+    companies: companies.map((company) => ({
+      id: company.id,
+      name: company.name,
+      wikidataId: company.wikidataId,
+      lei: company.lei,
+      reportingPeriodCount: company._count.reportingPeriods,
+      companyReportCount: company._count.companyReports,
+    })),
+    identifiers: identifiers.map((row) => ({
+      companyId: row.companyId,
+      type: row.type,
+      value: row.value,
+    })),
+    minGroupSize,
+  })
+
+  const groups = reasonFilter
+    ? report.groups.filter((group) => group.reason === reasonFilter)
+    : report.groups
+
+  const limit = values.limit ? Number(values.limit) : undefined
+  const groupsToShow = limit && limit > 0 ? groups.slice(0, limit) : groups
+
+  console.log('Duplicate company scan')
+  console.log('======================')
+  console.log(`Total companies:              ${report.totalCompanies}`)
+  console.log(`Duplicate groups:             ${report.groupCount}`)
+  console.log(`Companies in duplicate groups: ${report.companiesInGroups}`)
+  console.log(
+    `  normalized_name:            ${report.byReason.normalized_name}`
+  )
+  console.log(`  lei:                        ${report.byReason.lei}`)
+  console.log(
+    `  wikidata_conflict:          ${report.byReason.wikidata_conflict}`
+  )
+  console.log('')
+
+  if (groupsToShow.length === 0) {
+    console.log('No duplicate groups found.')
+  } else {
+    for (const group of groupsToShow) {
+      console.log(
+        `[${group.reason}] ${group.key} (${group.companies.length} companies)`
+      )
+      console.log(formatCompanyLine(group))
+      console.log('')
+    }
+    if (limit && groups.length > groupsToShow.length) {
+      console.log(
+        `… showing ${groupsToShow.length} of ${groups.length} groups (use --limit to adjust)`
+      )
+    }
+  }
+
+  if (values.json) {
+    writeFileSync(
+      values.json,
+      JSON.stringify({ ...report, groups }, null, 2),
+      'utf8'
+    )
+    console.log(`Wrote JSON report to ${values.json}`)
+  }
+
+  if (values.csv) {
+    writeFileSync(values.csv, toCsv(groups), 'utf8')
+    console.log(`Wrote CSV report to ${values.csv}`)
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/src/api/routes/internal/company.pipelineRead.ts
+++ b/src/api/routes/internal/company.pipelineRead.ts
@@ -114,7 +114,11 @@ export async function pipelineCompanyReadRoutes(app: FastifyInstance) {
         onePeriodPerDataYear: true,
       })
       reply.send(
-        companies.map((company) => ({ id: company.id, name: company.name }))
+        companies.map((company) => ({
+          id: company.id,
+          name: company.name,
+          wikidataId: company.wikidataId ?? null,
+        }))
       )
     }
   )

--- a/src/api/routes/internal/company.pipelineRead.ts
+++ b/src/api/routes/internal/company.pipelineRead.ts
@@ -118,6 +118,7 @@ export async function pipelineCompanyReadRoutes(app: FastifyInstance) {
           id: company.id,
           name: company.name,
           wikidataId: company.wikidataId ?? null,
+          lei: company.lei ?? null,
         }))
       )
     }

--- a/src/api/schemas/common.ts
+++ b/src/api/schemas/common.ts
@@ -38,6 +38,7 @@ export const pipelineCompanySearchHitSchema = z.object({
   id: companyIdSchema,
   name: z.string(),
   wikidataId: wikidataIdSchema.nullable().optional(),
+  lei: z.string().nullable().optional(),
 })
 
 export const pipelineCompanySearchListSchema = z.array(

--- a/src/api/schemas/common.ts
+++ b/src/api/schemas/common.ts
@@ -37,6 +37,7 @@ export const companyInitiativeParamsSchema = z.object({
 export const pipelineCompanySearchHitSchema = z.object({
   id: companyIdSchema,
   name: z.string(),
+  wikidataId: wikidataIdSchema.nullable().optional(),
 })
 
 export const pipelineCompanySearchListSchema = z.array(

--- a/src/api/services/companyService.ts
+++ b/src/api/services/companyService.ts
@@ -135,7 +135,44 @@ class CompanyService {
     param: string,
     args: typeof detailedCompanyArgs = detailedCompanyArgs
   ) {
+    const lei = param.trim().toUpperCase()
+    if (/^[A-Z0-9]{20}$/.test(lei)) {
+      const byLeiColumn = await prisma.company.findFirst({
+        ...args,
+        where: { lei },
+      })
+      if (byLeiColumn) return byLeiColumn
+
+      const identifierRow = await prisma.companyIdentifier.findFirst({
+        where: { type: 'LEI', value: lei },
+        select: { companyId: true },
+      })
+      if (identifierRow) {
+        return prisma.company.findFirstOrThrow({
+          ...args,
+          where: { id: identifierRow.companyId },
+        })
+      }
+    }
+
     if (/^Q\d+$/.test(param)) {
+      const byWikidataColumn = await prisma.company.findFirst({
+        ...args,
+        where: { wikidataId: param },
+      })
+      if (byWikidataColumn) return byWikidataColumn
+
+      const identifierRow = await prisma.companyIdentifier.findFirst({
+        where: { type: 'WIKIDATA', value: param },
+        select: { companyId: true },
+      })
+      if (identifierRow) {
+        return prisma.company.findFirstOrThrow({
+          ...args,
+          where: { id: identifierRow.companyId },
+        })
+      }
+
       return prisma.company.findFirstOrThrow({
         ...args,
         where: { wikidataId: param },

--- a/src/lib/companyLegalEntitySuffixes.ts
+++ b/src/lib/companyLegalEntitySuffixes.ts
@@ -1,0 +1,109 @@
+/**
+ * Legal-entity and corporate form tokens stripped when comparing company names.
+ * Matching is word-based (split on whitespace); prefer short standalone tokens.
+ */
+export const LEGAL_ENTITY_SUFFIXES = new Set([
+  // English / generic
+  'the',
+  'and',
+  'co',
+  'inc',
+  'corp',
+  'ltd',
+  'llc',
+  'lp',
+  'llp',
+  'plc',
+  'limited',
+  'incorporated',
+  'corporation',
+
+  // Sweden / Finland
+  'ab',
+  'aktiebolag',
+  'aktiebolaget',
+  'oy',
+  'oyj',
+  'publ',
+  '(publ)',
+  '(ab)',
+
+  // Norway / Denmark
+  'as',
+  'asa',
+  'aps',
+  'a/s',
+  'as/a',
+  '(as)',
+  '(asa)',
+
+  // Germany / Austria / Switzerland
+  'ag',
+  'gmbh',
+  'kg',
+  'ohg',
+  'kgaa',
+  'ug',
+  'gbr',
+  'se',
+  '(ag)',
+  '(gmbh)',
+
+  // France / Belgium / Netherlands / Luxembourg
+  'sa',
+  'sas',
+  'sarl',
+  'eurl',
+  'bv',
+  'nv',
+  'sprl',
+  'sca',
+  'scrl',
+
+  // Spain / Portugal / Italy
+  'sl',
+  'slu',
+  'srl',
+  'spa',
+  's.p.a',
+  'sau',
+
+  // Ireland / UK variants
+  'dac',
+  'teo',
+
+  // Australia / New Zealand / South Africa
+  'pty',
+
+  // Central / Eastern Europe
+  'sp',
+  'zoo',
+  'kft',
+  'rt',
+  'ood',
+  'ead',
+  'jsc',
+  'cjsc',
+  'ojsc',
+])
+
+function normalizeWordForSuffixMatch(word: string): string {
+  return word
+    .toLowerCase()
+    .replace(/^[([{]+/, '')
+    .replace(/[)\]},.;:]+$/, '')
+}
+
+export function isLegalEntitySuffix(word: string): boolean {
+  return LEGAL_ENTITY_SUFFIXES.has(normalizeWordForSuffixMatch(word))
+}
+
+export function stripLegalEntitySuffixes(name: string): string {
+  const stripped = name
+    .trim()
+    .split(/\s+/)
+    .filter((word) => !isLegalEntitySuffix(word))
+    .join(' ')
+    .trim()
+  return stripped || name.trim()
+}

--- a/src/lib/companyLinkResolve.test.ts
+++ b/src/lib/companyLinkResolve.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from '@jest/globals'
+import {
+  assessCompanyLinkResolution,
+  normalizeCompanyNameForMatch,
+  pickExactNameMatches,
+} from './companyLinkResolve'
+
+describe('companyLinkResolve', () => {
+  it('normalizes names by stripping legal entity suffixes', () => {
+    expect(normalizeCompanyNameForMatch('Alfa Laval AB')).toBe('alfa laval')
+    expect(normalizeCompanyNameForMatch('Alfa Laval')).toBe('alfa laval')
+  })
+
+  it('resolves when exactly one candidate matches the normalized name', () => {
+    const result = assessCompanyLinkResolution('Alfa Laval AB', [
+      { id: 'alfa-1', name: 'Alfa Laval', wikidataId: 'Q686030' },
+      { id: 'other', name: 'Other Co' },
+    ])
+    expect(result).toEqual({ action: 'resolve', companyId: 'alfa-1' })
+  })
+
+  it('flags ambiguity when multiple candidates share the normalized name', () => {
+    const candidates = [
+      { id: 'alfa-1', name: 'Alfa Laval', wikidataId: 'Q686030' },
+      { id: 'alfa-2', name: 'Alfa Laval', wikidataId: 'Q686030' },
+    ]
+    const result = assessCompanyLinkResolution('Alfa Laval', candidates)
+    expect(result).toEqual({ action: 'ambiguous', candidates })
+  })
+
+  it('flags ambiguity when several fuzzy hits exist without a single exact match', () => {
+    const candidates = [
+      { id: 'ica-se', name: 'ICA Gruppen AB' },
+      { id: 'ica-no', name: 'ICA Norge AS' },
+    ]
+    const result = assessCompanyLinkResolution('ICA', candidates)
+    expect(result).toEqual({ action: 'ambiguous', candidates })
+  })
+
+  it('creates a new company when search returns no candidates', () => {
+    expect(assessCompanyLinkResolution('Brand New Co', [])).toEqual({
+      action: 'create',
+    })
+  })
+
+  it('creates a new company when only one fuzzy hit does not exactly match', () => {
+    const result = assessCompanyLinkResolution('Totally Different Name', [
+      { id: 'alfa-1', name: 'Alfa Laval' },
+    ])
+    expect(result).toEqual({ action: 'create' })
+    expect(
+      pickExactNameMatches('Totally Different Name', [
+        { id: 'alfa-1', name: 'Alfa Laval' },
+      ])
+    ).toHaveLength(0)
+  })
+})

--- a/src/lib/companyLinkResolve.test.ts
+++ b/src/lib/companyLinkResolve.test.ts
@@ -78,7 +78,10 @@ describe('companyLinkResolve', () => {
 
   it('flags ambiguity when only one fuzzy hit does not exactly match', () => {
     const candidates = [{ id: 'alfa-1', name: 'Alfa Laval' }]
-    const result = assessCompanyLinkResolution('Totally Different Name', candidates)
+    const result = assessCompanyLinkResolution(
+      'Totally Different Name',
+      candidates
+    )
     expect(result).toEqual({ action: 'ambiguous', candidates })
     expect(
       pickExactNameMatches('Totally Different Name', candidates)

--- a/src/lib/companyLinkResolve.test.ts
+++ b/src/lib/companyLinkResolve.test.ts
@@ -1,14 +1,47 @@
 import { describe, it, expect } from '@jest/globals'
 import {
+  isLegalEntitySuffix,
+  stripLegalEntitySuffixes,
+} from './companyLegalEntitySuffixes'
+import {
   assessCompanyLinkResolution,
   normalizeCompanyNameForMatch,
   pickExactNameMatches,
 } from './companyLinkResolve'
 
+describe('companyLegalEntitySuffixes', () => {
+  it('recognizes Nordic and European legal forms', () => {
+    expect(isLegalEntitySuffix('ASA')).toBe(true)
+    expect(isLegalEntitySuffix('ASA.')).toBe(true)
+    expect(isLegalEntitySuffix('GmbH')).toBe(true)
+    expect(isLegalEntitySuffix('(AG)')).toBe(true)
+    expect(isLegalEntitySuffix('S.A.')).toBe(false)
+    expect(isLegalEntitySuffix('SA')).toBe(true)
+  })
+
+  it('recognizes US and UK legal forms', () => {
+    expect(isLegalEntitySuffix('Inc.')).toBe(true)
+    expect(isLegalEntitySuffix('LLC')).toBe(true)
+    expect(isLegalEntitySuffix('Corp')).toBe(true)
+    expect(isLegalEntitySuffix('Ltd')).toBe(true)
+    expect(isLegalEntitySuffix('PLC')).toBe(true)
+  })
+
+  it('does not treat ordinary words as suffixes', () => {
+    expect(isLegalEntitySuffix('Laval')).toBe(false)
+    expect(isLegalEntitySuffix('Group')).toBe(false)
+  })
+})
+
 describe('companyLinkResolve', () => {
   it('normalizes names by stripping legal entity suffixes', () => {
     expect(normalizeCompanyNameForMatch('Alfa Laval AB')).toBe('alfa laval')
     expect(normalizeCompanyNameForMatch('Alfa Laval')).toBe('alfa laval')
+    expect(normalizeCompanyNameForMatch('Equinor ASA')).toBe('equinor')
+    expect(normalizeCompanyNameForMatch('Siemens AG')).toBe('siemens')
+    expect(normalizeCompanyNameForMatch('Acme Corp.')).toBe('acme')
+    expect(normalizeCompanyNameForMatch('Example LLC')).toBe('example')
+    expect(stripLegalEntitySuffixes('Nokia Oyj')).toBe('Nokia')
   })
 
   it('resolves when exactly one candidate matches the normalized name', () => {
@@ -43,15 +76,12 @@ describe('companyLinkResolve', () => {
     })
   })
 
-  it('creates a new company when only one fuzzy hit does not exactly match', () => {
-    const result = assessCompanyLinkResolution('Totally Different Name', [
-      { id: 'alfa-1', name: 'Alfa Laval' },
-    ])
-    expect(result).toEqual({ action: 'create' })
+  it('flags ambiguity when only one fuzzy hit does not exactly match', () => {
+    const candidates = [{ id: 'alfa-1', name: 'Alfa Laval' }]
+    const result = assessCompanyLinkResolution('Totally Different Name', candidates)
+    expect(result).toEqual({ action: 'ambiguous', candidates })
     expect(
-      pickExactNameMatches('Totally Different Name', [
-        { id: 'alfa-1', name: 'Alfa Laval' },
-      ])
+      pickExactNameMatches('Totally Different Name', candidates)
     ).toHaveLength(0)
   })
 })

--- a/src/lib/companyLinkResolve.ts
+++ b/src/lib/companyLinkResolve.ts
@@ -1,0 +1,92 @@
+const LEGAL_ENTITY_SUFFIXES = new Set([
+  'ab',
+  'the',
+  'and',
+  'inc',
+  'co',
+  'publ',
+  '(publ)',
+  '(ab)',
+  'aktiebolag',
+  'aktiebolaget',
+])
+
+export type CompanyLinkCandidate = {
+  id: string
+  name: string
+  wikidataId?: string | null
+}
+
+export type CompanyLinkResolution =
+  | { action: 'resolve'; companyId: string }
+  | { action: 'ambiguous'; candidates: CompanyLinkCandidate[] }
+  | { action: 'create' }
+
+export function normalizeCompanyNameForMatch(name: string): string {
+  return name
+    .trim()
+    .toLocaleLowerCase('sv-SE')
+    .split(/\s+/)
+    .filter((word) => !LEGAL_ENTITY_SUFFIXES.has(word))
+    .join(' ')
+    .trim()
+}
+
+export function stripLegalEntitySuffixes(name: string): string {
+  const stripped = name
+    .trim()
+    .split(/\s+/)
+    .filter((word) => !LEGAL_ENTITY_SUFFIXES.has(word.toLowerCase()))
+    .join(' ')
+    .trim()
+  return stripped || name.trim()
+}
+
+export function dedupeCompanyLinkCandidates(
+  candidates: CompanyLinkCandidate[]
+): CompanyLinkCandidate[] {
+  const seen = new Set<string>()
+  return candidates.filter((candidate) => {
+    if (seen.has(candidate.id)) return false
+    seen.add(candidate.id)
+    return true
+  })
+}
+
+export function pickExactNameMatches(
+  extractedName: string,
+  candidates: CompanyLinkCandidate[]
+): CompanyLinkCandidate[] {
+  const target = normalizeCompanyNameForMatch(extractedName)
+  return candidates.filter(
+    (candidate) =>
+      candidate.name && normalizeCompanyNameForMatch(candidate.name) === target
+  )
+}
+
+/**
+ * Decide whether to auto-link, ask a human, or create a new company.
+ * Ask when multiple candidates exist and there is not exactly one exact name match.
+ */
+export function assessCompanyLinkResolution(
+  extractedName: string,
+  candidates: CompanyLinkCandidate[]
+): CompanyLinkResolution {
+  const uniqueCandidates = dedupeCompanyLinkCandidates(candidates)
+
+  if (uniqueCandidates.length === 0) {
+    return { action: 'create' }
+  }
+
+  const exactMatches = pickExactNameMatches(extractedName, uniqueCandidates)
+
+  if (exactMatches.length === 1) {
+    return { action: 'resolve', companyId: exactMatches[0].id }
+  }
+
+  if (uniqueCandidates.length > 1) {
+    return { action: 'ambiguous', candidates: uniqueCandidates }
+  }
+
+  return { action: 'create' }
+}

--- a/src/lib/companyLinkResolve.ts
+++ b/src/lib/companyLinkResolve.ts
@@ -1,20 +1,13 @@
-const LEGAL_ENTITY_SUFFIXES = new Set([
-  'ab',
-  'the',
-  'and',
-  'inc',
-  'co',
-  'publ',
-  '(publ)',
-  '(ab)',
-  'aktiebolag',
-  'aktiebolaget',
-])
+import {
+  isLegalEntitySuffix,
+  stripLegalEntitySuffixes,
+} from './companyLegalEntitySuffixes'
 
 export type CompanyLinkCandidate = {
   id: string
   name: string
   wikidataId?: string | null
+  lei?: string | null
 }
 
 export type CompanyLinkResolution =
@@ -22,24 +15,16 @@ export type CompanyLinkResolution =
   | { action: 'ambiguous'; candidates: CompanyLinkCandidate[] }
   | { action: 'create' }
 
+export { stripLegalEntitySuffixes }
+
 export function normalizeCompanyNameForMatch(name: string): string {
   return name
     .trim()
     .toLocaleLowerCase('sv-SE')
     .split(/\s+/)
-    .filter((word) => !LEGAL_ENTITY_SUFFIXES.has(word))
+    .filter((word) => !isLegalEntitySuffix(word))
     .join(' ')
     .trim()
-}
-
-export function stripLegalEntitySuffixes(name: string): string {
-  const stripped = name
-    .trim()
-    .split(/\s+/)
-    .filter((word) => !LEGAL_ENTITY_SUFFIXES.has(word.toLowerCase()))
-    .join(' ')
-    .trim()
-  return stripped || name.trim()
 }
 
 export function dedupeCompanyLinkCandidates(
@@ -66,7 +51,8 @@ export function pickExactNameMatches(
 
 /**
  * Decide whether to auto-link, ask a human, or create a new company.
- * Ask when multiple candidates exist and there is not exactly one exact name match.
+ * Auto-link only when exactly one candidate matches the normalized name.
+ * Any fuzzy hit without a single exact match goes to staff (including a lone non-exact hit).
  */
 export function assessCompanyLinkResolution(
   extractedName: string,
@@ -84,9 +70,5 @@ export function assessCompanyLinkResolution(
     return { action: 'resolve', companyId: exactMatches[0].id }
   }
 
-  if (uniqueCandidates.length > 1) {
-    return { action: 'ambiguous', candidates: uniqueCandidates }
-  }
-
-  return { action: 'create' }
+  return { action: 'ambiguous', candidates: uniqueCandidates }
 }

--- a/src/lib/findDuplicateCompanyGroups.test.ts
+++ b/src/lib/findDuplicateCompanyGroups.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from '@jest/globals'
+import { findDuplicateCompanyGroups } from './findDuplicateCompanyGroups'
+
+const company = (
+  id: string,
+  name: string,
+  extras?: { wikidataId?: string | null; lei?: string | null }
+) => ({
+  id,
+  name,
+  wikidataId: extras?.wikidataId ?? null,
+  lei: extras?.lei ?? null,
+  reportingPeriodCount: 0,
+  companyReportCount: 0,
+})
+
+describe('findDuplicateCompanyGroups', () => {
+  it('groups companies with the same normalized name', () => {
+    const report = findDuplicateCompanyGroups({
+      companies: [
+        company('a', 'Alfa Laval AB', { wikidataId: 'Q686030' }),
+        company('b', 'Alfa Laval'),
+        company('c', 'Other Co'),
+      ],
+    })
+
+    expect(report.byReason.normalized_name).toBe(1)
+    expect(report.companiesInGroups).toBe(2)
+    expect(report.groups[0]).toMatchObject({
+      reason: 'normalized_name',
+      key: 'alfa laval',
+      companies: expect.arrayContaining([
+        expect.objectContaining({ id: 'a' }),
+        expect.objectContaining({ id: 'b' }),
+      ]),
+    })
+  })
+
+  it('groups companies that share an LEI', () => {
+    const report = findDuplicateCompanyGroups({
+      companies: [
+        company('a', 'Acme Holdings', { lei: '5493001KJTIIGC8Y1R12' }),
+        company('b', 'Acme Corp'),
+      ],
+      identifiers: [
+        {
+          companyId: 'b',
+          type: 'LEI',
+          value: '5493001KJTIIGC8Y1R12',
+        },
+      ],
+    })
+
+    expect(report.byReason.lei).toBe(1)
+    expect(report.groups.some((group) => group.reason === 'lei')).toBe(true)
+  })
+
+  it('flags normalized-name groups with conflicting Wikidata ids', () => {
+    const report = findDuplicateCompanyGroups({
+      companies: [
+        company('a', 'Alfa Laval AB', { wikidataId: 'Q686030' }),
+        company('b', 'Alfa Laval', { wikidataId: 'Q999999' }),
+      ],
+    })
+
+    expect(report.byReason.wikidata_conflict).toBe(1)
+    expect(
+      report.groups.some((group) => group.reason === 'wikidata_conflict')
+    ).toBe(true)
+  })
+})

--- a/src/lib/findDuplicateCompanyGroups.ts
+++ b/src/lib/findDuplicateCompanyGroups.ts
@@ -1,0 +1,188 @@
+import { normalizeCompanyNameForMatch } from './companyLinkResolve'
+import { normalizeLei } from './normalizeLei'
+
+export type CompanyDuplicateRow = {
+  id: string
+  name: string
+  wikidataId: string | null
+  lei: string | null
+  reportingPeriodCount: number
+  companyReportCount: number
+}
+
+export type DuplicateDetectionReason =
+  | 'normalized_name'
+  | 'lei'
+  | 'wikidata_conflict'
+
+export type DuplicateCompanyGroup = {
+  reason: DuplicateDetectionReason
+  /** Grouping key (normalized name, LEI, etc.) */
+  key: string
+  companies: CompanyDuplicateRow[]
+}
+
+export type DuplicateCompanyReport = {
+  totalCompanies: number
+  groupCount: number
+  companiesInGroups: number
+  byReason: Record<DuplicateDetectionReason, number>
+  groups: DuplicateCompanyGroup[]
+}
+
+type IdentifierRow = {
+  companyId: string
+  type: 'LEI' | 'WIKIDATA'
+  value: string
+}
+
+function groupByKey<T>(
+  items: T[],
+  keyFor: (item: T) => string | null
+): Map<string, T[]> {
+  const groups = new Map<string, T[]>()
+  for (const item of items) {
+    const key = keyFor(item)
+    if (!key) continue
+    const bucket = groups.get(key) ?? []
+    bucket.push(item)
+    groups.set(key, bucket)
+  }
+  return groups
+}
+
+function collectLeiValues(
+  company: CompanyDuplicateRow,
+  identifiersByCompanyId: Map<string, IdentifierRow[]>
+): string[] {
+  const values = new Set<string>()
+  const fromColumn = normalizeLei(company.lei)
+  if (fromColumn) values.add(fromColumn)
+
+  for (const row of identifiersByCompanyId.get(company.id) ?? []) {
+    if (row.type !== 'LEI') continue
+    const normalized = normalizeLei(row.value)
+    if (normalized) values.add(normalized)
+  }
+
+  return [...values]
+}
+
+function findNormalizedNameGroups(
+  companies: CompanyDuplicateRow[],
+  minSize: number
+): DuplicateCompanyGroup[] {
+  const grouped = groupByKey(companies, (company) => {
+    const normalized = normalizeCompanyNameForMatch(company.name)
+    return normalized.length > 0 ? normalized : null
+  })
+
+  const result: DuplicateCompanyGroup[] = []
+  for (const [key, members] of grouped) {
+    if (members.length < minSize) continue
+    result.push({
+      reason: 'normalized_name',
+      key,
+      companies: members,
+    })
+  }
+
+  return result.toSorted((a, b) => b.companies.length - a.companies.length)
+}
+
+function findLeiGroups(
+  companies: CompanyDuplicateRow[],
+  identifiers: IdentifierRow[],
+  minSize: number
+): DuplicateCompanyGroup[] {
+  const identifiersByCompanyId = new Map<string, IdentifierRow[]>()
+  for (const row of identifiers) {
+    const bucket = identifiersByCompanyId.get(row.companyId) ?? []
+    bucket.push(row)
+    identifiersByCompanyId.set(row.companyId, bucket)
+  }
+
+  const leiToCompanies = new Map<string, CompanyDuplicateRow[]>()
+  for (const company of companies) {
+    for (const lei of collectLeiValues(company, identifiersByCompanyId)) {
+      const bucket = leiToCompanies.get(lei) ?? []
+      bucket.push(company)
+      leiToCompanies.set(lei, bucket)
+    }
+  }
+
+  const result: DuplicateCompanyGroup[] = []
+  for (const [lei, members] of leiToCompanies) {
+    const uniqueById = [...new Map(members.map((c) => [c.id, c])).values()]
+    if (uniqueById.length < minSize) continue
+    result.push({
+      reason: 'lei',
+      key: lei,
+      companies: uniqueById.toSorted((a, b) => a.name.localeCompare(b.name)),
+    })
+  }
+
+  return result.toSorted((a, b) => b.companies.length - a.companies.length)
+}
+
+/**
+ * Same normalized name but different non-null Wikidata Q-ids — strong duplicate signal
+ * (e.g. "Alfa Laval" vs "Alfa Laval AB" created as separate rows).
+ */
+function findWikidataConflictGroups(
+  nameGroups: DuplicateCompanyGroup[]
+): DuplicateCompanyGroup[] {
+  const result: DuplicateCompanyGroup[] = []
+
+  for (const group of nameGroups) {
+    const wikidataIds = new Set(
+      group.companies
+        .map((company) => company.wikidataId?.trim())
+        .filter((id): id is string => Boolean(id))
+    )
+    if (wikidataIds.size < 2) continue
+
+    result.push({
+      reason: 'wikidata_conflict',
+      key: group.key,
+      companies: group.companies.toSorted((a, b) =>
+        a.name.localeCompare(b.name)
+      ),
+    })
+  }
+
+  return result.toSorted((a, b) => b.companies.length - a.companies.length)
+}
+
+export function findDuplicateCompanyGroups(input: {
+  companies: CompanyDuplicateRow[]
+  identifiers?: IdentifierRow[]
+  minGroupSize?: number
+}): DuplicateCompanyReport {
+  const minGroupSize = input.minGroupSize ?? 2
+  const identifiers = input.identifiers ?? []
+
+  const nameGroups = findNormalizedNameGroups(input.companies, minGroupSize)
+  const leiGroups = findLeiGroups(input.companies, identifiers, minGroupSize)
+  const wikidataConflictGroups = findWikidataConflictGroups(nameGroups)
+
+  const groups = [...nameGroups, ...leiGroups, ...wikidataConflictGroups]
+
+  const companiesInGroups = new Set(
+    groups.flatMap((group) => group.companies.map((company) => company.id))
+  )
+
+  const byReason: Record<DuplicateDetectionReason, number> = {
+    normalized_name: nameGroups.length,
+    lei: leiGroups.length,
+    wikidata_conflict: wikidataConflictGroups.length,
+  }
+
+  return {
+    totalCompanies: input.companies.length,
+    groupCount: groups.length,
+    companiesInGroups: companiesInGroups.size,
+    byReason,
+    groups,
+  }
+}

--- a/src/lib/normalizeLei.test.ts
+++ b/src/lib/normalizeLei.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from '@jest/globals'
+import { normalizeLei, isLeiFormat } from './normalizeLei'
+
+describe('normalizeLei', () => {
+  it('accepts a valid 20-character LEI', () => {
+    expect(normalizeLei('5493001KJTIIGC8Y1R12')).toBe('5493001KJTIIGC8Y1R12')
+    expect(normalizeLei('  5493001kjtiigc8y1r12  ')).toBe(
+      '5493001KJTIIGC8Y1R12'
+    )
+  })
+
+  it('rejects invalid LEI values', () => {
+    expect(normalizeLei('')).toBeNull()
+    expect(normalizeLei('too-short')).toBeNull()
+    expect(normalizeLei(undefined)).toBeNull()
+  })
+
+  it('detects LEI format', () => {
+    expect(isLeiFormat('5493001KJTIIGC8Y1R12')).toBe(true)
+    expect(isLeiFormat('not-a-lei')).toBe(false)
+  })
+})

--- a/src/lib/normalizeLei.ts
+++ b/src/lib/normalizeLei.ts
@@ -1,0 +1,12 @@
+const LEI_PATTERN = /^[A-Z0-9]{20}$/
+
+/** Normalize a Legal Entity Identifier to uppercase 20-char form, or null if invalid. */
+export function normalizeLei(value: string | undefined | null): string | null {
+  const trimmed = value?.trim().toUpperCase()
+  if (!trimmed || !LEI_PATTERN.test(trimmed)) return null
+  return trimmed
+}
+
+export function isLeiFormat(value: string): boolean {
+  return LEI_PATTERN.test(value.trim().toUpperCase())
+}

--- a/src/lib/pipelineCompanyResolve.test.ts
+++ b/src/lib/pipelineCompanyResolve.test.ts
@@ -15,15 +15,15 @@ jest.unstable_mockModule('./api', () => ({
 
 let resolveOrCreatePipelineCompanyId: typeof import('./pipelineCompanyResolve').resolveOrCreatePipelineCompanyId
 let resolvePipelineCompanyOutcome: typeof import('./pipelineCompanyResolve').resolvePipelineCompanyOutcome
-let resolveTargetCompanyIdForWikidata: typeof import('./pipelineCompanyResolve').resolveTargetCompanyIdForWikidata
 let findCompanyByWikidataId: typeof import('./pipelineCompanyResolve').findCompanyByWikidataId
+let findCompanyByLei: typeof import('./pipelineCompanyResolve').findCompanyByLei
 
 beforeAll(async () => {
   ;({
     resolveOrCreatePipelineCompanyId,
     resolvePipelineCompanyOutcome,
-    resolveTargetCompanyIdForWikidata,
     findCompanyByWikidataId,
+    findCompanyByLei,
   } = await import('./pipelineCompanyResolve'))
 })
 
@@ -47,7 +47,7 @@ describe('resolveOrCreatePipelineCompanyId', () => {
         typeof path === 'string' &&
         path.includes('/pipeline/companies/Q123')
       ) {
-        return { id: 'from-wikidata' }
+        return { id: 'from-wikidata', name: 'Acme', wikidataId: 'Q123' }
       }
       throw new Error(`unexpected path ${String(path)}`)
     })
@@ -57,6 +57,28 @@ describe('resolveOrCreatePipelineCompanyId', () => {
       'Acme AB'
     )
     expect(result).toEqual({ companyId: 'from-wikidata', method: 'wikidata' })
+  })
+
+  it('resolves by lei before name search', async () => {
+    mockApiFetch.mockImplementation(async (path: unknown) => {
+      if (
+        typeof path === 'string' &&
+        path.includes('/pipeline/companies/5493001KJTIIGC8Y1R12')
+      ) {
+        return {
+          id: 'from-lei',
+          name: 'Acme',
+          lei: '5493001KJTIIGC8Y1R12',
+        }
+      }
+      throw new Error(`unexpected path ${String(path)}`)
+    })
+
+    const result = await resolveOrCreatePipelineCompanyId(
+      { lei: '5493001KJTIIGC8Y1R12' },
+      'Acme AB'
+    )
+    expect(result).toEqual({ companyId: 'from-lei', method: 'lei' })
   })
 
   it('resolves by exact name match when a single hit matches', async () => {
@@ -112,28 +134,28 @@ describe('resolveOrCreatePipelineCompanyId', () => {
       id: 'existing-alfa',
       name: 'Alfa Laval',
       wikidataId: 'Q686030',
-    })
-
-    const relink = await resolveTargetCompanyIdForWikidata(
-      'duplicate-id',
-      'Q686030'
-    )
-    expect(relink).toEqual({
-      companyId: 'existing-alfa',
-      relinked: true,
+      lei: null,
     })
   })
 
-  it('keeps the current company when wikidata is not assigned elsewhere', async () => {
-    mockApiFetch.mockImplementation(async () => null)
+  it('finds the company that already owns an lei', async () => {
+    mockApiFetch.mockImplementation(async (path: unknown) => {
+      if (path === '/pipeline/companies/5493001KJTIIGC8Y1R12') {
+        return {
+          id: 'existing-lei',
+          name: 'Acme',
+          lei: '5493001KJTIIGC8Y1R12',
+        }
+      }
+      throw new Error(`unexpected path ${String(path)}`)
+    })
 
-    const result = await resolveTargetCompanyIdForWikidata(
-      'current-id',
-      'Q686030'
-    )
+    const result = await findCompanyByLei('5493001KJTIIGC8Y1R12')
     expect(result).toEqual({
-      companyId: 'current-id',
-      relinked: false,
+      id: 'existing-lei',
+      name: 'Acme',
+      wikidataId: null,
+      lei: '5493001KJTIIGC8Y1R12',
     })
   })
 
@@ -185,6 +207,28 @@ describe('resolvePipelineCompanyOutcome', () => {
         { id: 'alfa-1', name: 'Alfa Laval', wikidataId: 'Q686030' },
         { id: 'alfa-2', name: 'Alfa Laval', wikidataId: 'Q686030' },
       ],
+    })
+  })
+
+  it('returns ambiguous when a single fuzzy hit does not exactly match', async () => {
+    mockApiFetch.mockImplementation(async (path: unknown) => {
+      if (
+        typeof path === 'string' &&
+        path.includes('/pipeline/companies/search')
+      ) {
+        return [{ id: 'alfa-1', name: 'Alfa Laval', wikidataId: 'Q686030' }]
+      }
+      throw new Error(`unexpected path ${String(path)}`)
+    })
+
+    const result = await resolvePipelineCompanyOutcome(
+      {},
+      'Totally Different Name'
+    )
+    expect(result).toEqual({
+      status: 'ambiguous',
+      extractedName: 'Totally Different Name',
+      candidates: [{ id: 'alfa-1', name: 'Alfa Laval', wikidataId: 'Q686030' }],
     })
   })
 })

--- a/src/lib/pipelineCompanyResolve.test.ts
+++ b/src/lib/pipelineCompanyResolve.test.ts
@@ -98,7 +98,11 @@ describe('resolveOrCreatePipelineCompanyId', () => {
   it('finds the company that already owns a wikidata id', async () => {
     mockApiFetch.mockImplementation(async (path: unknown) => {
       if (path === '/pipeline/companies/Q686030') {
-        return { id: 'existing-alfa', name: 'Alfa Laval', wikidataId: 'Q686030' }
+        return {
+          id: 'existing-alfa',
+          name: 'Alfa Laval',
+          wikidataId: 'Q686030',
+        }
       }
       throw new Error(`unexpected path ${String(path)}`)
     })

--- a/src/lib/pipelineCompanyResolve.test.ts
+++ b/src/lib/pipelineCompanyResolve.test.ts
@@ -14,11 +14,17 @@ jest.unstable_mockModule('./api', () => ({
 }))
 
 let resolveOrCreatePipelineCompanyId: typeof import('./pipelineCompanyResolve').resolveOrCreatePipelineCompanyId
+let resolvePipelineCompanyOutcome: typeof import('./pipelineCompanyResolve').resolvePipelineCompanyOutcome
+let resolveTargetCompanyIdForWikidata: typeof import('./pipelineCompanyResolve').resolveTargetCompanyIdForWikidata
+let findCompanyByWikidataId: typeof import('./pipelineCompanyResolve').findCompanyByWikidataId
 
 beforeAll(async () => {
-  ;({ resolveOrCreatePipelineCompanyId } = await import(
-    './pipelineCompanyResolve'
-  ))
+  ;({
+    resolveOrCreatePipelineCompanyId,
+    resolvePipelineCompanyOutcome,
+    resolveTargetCompanyIdForWikidata,
+    findCompanyByWikidataId,
+  } = await import('./pipelineCompanyResolve'))
 })
 
 describe('resolveOrCreatePipelineCompanyId', () => {
@@ -71,6 +77,62 @@ describe('resolveOrCreatePipelineCompanyId', () => {
     expect(result).toEqual({ companyId: 'exact', method: 'exact_name' })
   })
 
+  it('matches names ignoring legal entity suffixes', async () => {
+    mockApiFetch.mockImplementation(async (path: unknown) => {
+      if (
+        typeof path === 'string' &&
+        path.includes('/pipeline/companies/search')
+      ) {
+        if (path.includes('Alfa%20Laval%20AB')) {
+          return [{ id: 'alfa', name: 'Alfa Laval', wikidataId: 'Q686030' }]
+        }
+        throw new Error(`unexpected search path ${path}`)
+      }
+      throw new Error(`unexpected path ${String(path)}`)
+    })
+
+    const result = await resolveOrCreatePipelineCompanyId({}, 'Alfa Laval AB')
+    expect(result).toEqual({ companyId: 'alfa', method: 'exact_name' })
+  })
+
+  it('finds the company that already owns a wikidata id', async () => {
+    mockApiFetch.mockImplementation(async (path: unknown) => {
+      if (path === '/pipeline/companies/Q686030') {
+        return { id: 'existing-alfa', name: 'Alfa Laval', wikidataId: 'Q686030' }
+      }
+      throw new Error(`unexpected path ${String(path)}`)
+    })
+
+    const result = await findCompanyByWikidataId('Q686030')
+    expect(result).toEqual({
+      id: 'existing-alfa',
+      name: 'Alfa Laval',
+      wikidataId: 'Q686030',
+    })
+
+    const relink = await resolveTargetCompanyIdForWikidata(
+      'duplicate-id',
+      'Q686030'
+    )
+    expect(relink).toEqual({
+      companyId: 'existing-alfa',
+      relinked: true,
+    })
+  })
+
+  it('keeps the current company when wikidata is not assigned elsewhere', async () => {
+    mockApiFetch.mockImplementation(async () => null)
+
+    const result = await resolveTargetCompanyIdForWikidata(
+      'current-id',
+      'Q686030'
+    )
+    expect(result).toEqual({
+      companyId: 'current-id',
+      relinked: false,
+    })
+  })
+
   it('creates a company when no match is found', async () => {
     mockApiFetch.mockImplementation(
       async (path: unknown, init?: { body?: unknown }) => {
@@ -89,5 +151,36 @@ describe('resolveOrCreatePipelineCompanyId', () => {
 
     const result = await resolveOrCreatePipelineCompanyId({}, 'Brand New Co')
     expect(result).toEqual({ companyId: 'new-company', method: 'created' })
+  })
+})
+
+describe('resolvePipelineCompanyOutcome', () => {
+  beforeEach(() => {
+    mockApiFetch.mockReset()
+  })
+
+  it('returns ambiguous when multiple companies match the normalized name', async () => {
+    mockApiFetch.mockImplementation(async (path: unknown) => {
+      if (
+        typeof path === 'string' &&
+        path.includes('/pipeline/companies/search')
+      ) {
+        return [
+          { id: 'alfa-1', name: 'Alfa Laval', wikidataId: 'Q686030' },
+          { id: 'alfa-2', name: 'Alfa Laval', wikidataId: 'Q686030' },
+        ]
+      }
+      throw new Error(`unexpected path ${String(path)}`)
+    })
+
+    const result = await resolvePipelineCompanyOutcome({}, 'Alfa Laval AB')
+    expect(result).toEqual({
+      status: 'ambiguous',
+      extractedName: 'Alfa Laval AB',
+      candidates: [
+        { id: 'alfa-1', name: 'Alfa Laval', wikidataId: 'Q686030' },
+        { id: 'alfa-2', name: 'Alfa Laval', wikidataId: 'Q686030' },
+      ],
+    })
   })
 })

--- a/src/lib/pipelineCompanyResolve.ts
+++ b/src/lib/pipelineCompanyResolve.ts
@@ -1,4 +1,9 @@
 import { apiFetch } from './api'
+import {
+  assessCompanyLinkResolution,
+  type CompanyLinkCandidate,
+  stripLegalEntitySuffixes,
+} from './companyLinkResolve'
 import { pipelineCompanyReadPath } from './pipelineCompanyPath'
 
 type PipelineCompanyRef = {
@@ -7,12 +12,11 @@ type PipelineCompanyRef = {
   wikidata?: { node?: string }
 }
 
-type CompanySearchHit = { id: string; name: string }
-
 export type CompanyResolutionMethod =
   | 'job_data'
   | 'wikidata'
   | 'exact_name'
+  | 'approved_link'
   | 'created'
 
 export type CompanyResolution = {
@@ -20,20 +24,84 @@ export type CompanyResolution = {
   method: CompanyResolutionMethod
 }
 
-function normalizeCompanyName(name: string): string {
-  return name.trim().toLocaleLowerCase('sv-SE')
+export type PipelineCompanyResolveOutcome =
+  | { status: 'resolved'; companyId: string; method: CompanyResolutionMethod }
+  | {
+      status: 'ambiguous'
+      extractedName: string
+      candidates: CompanyLinkCandidate[]
+    }
+  | { status: 'create'; extractedName: string }
+
+async function searchCompaniesByName(
+  companyName: string
+): Promise<CompanyLinkCandidate[]> {
+  const hits = (await apiFetch(
+    `/pipeline/companies/search?q=${encodeURIComponent(companyName)}`
+  ).catch(() => [])) as CompanyLinkCandidate[]
+  return Array.isArray(hits) ? hits : []
+}
+
+async function collectNameSearchCandidates(
+  companyName: string
+): Promise<CompanyLinkCandidate[]> {
+  const namesToTry = [companyName]
+  const strippedName = stripLegalEntitySuffixes(companyName)
+  if (strippedName !== companyName.trim()) {
+    namesToTry.push(strippedName)
+  }
+
+  const byId = new Map<string, CompanyLinkCandidate>()
+  for (const query of namesToTry) {
+    for (const hit of await searchCompaniesByName(query)) {
+      byId.set(hit.id, hit)
+    }
+  }
+  return [...byId.values()]
+}
+
+/** Look up which company already owns a Wikidata Q-id in the current API. */
+export async function findCompanyByWikidataId(
+  wikidataId: string
+): Promise<CompanyLinkCandidate | null> {
+  const existing = (await apiFetch(pipelineCompanyReadPath(wikidataId)).catch(
+    () => null
+  )) as { id?: string; name?: string; wikidataId?: string | null } | null
+
+  if (!existing?.id) return null
+  return {
+    id: existing.id,
+    name: existing.name ?? '',
+    wikidataId: existing.wikidataId ?? wikidataId,
+  }
+}
+
+/** @deprecated Use findCompanyByWikidataId; relink now requires staff approval in guessWikidata. */
+export async function resolveTargetCompanyIdForWikidata(
+  companyId: string,
+  wikidataId: string
+): Promise<{ companyId: string; relinked: boolean }> {
+  const owner = await findCompanyByWikidataId(wikidataId)
+  if (owner?.id && owner.id !== companyId) {
+    return { companyId: owner.id, relinked: true }
+  }
+  return { companyId, relinked: false }
 }
 
 /**
- * Resolve the stable Garbo company id for a pipeline run.
- * Prefer explicit job data, then wikidata lookup, then exact name match, else create.
+ * Resolve the stable Garbo company id for a pipeline run without creating a company.
+ * Returns ambiguous when staff must pick among multiple candidates.
  */
-export async function resolveOrCreatePipelineCompanyId(
+export async function resolvePipelineCompanyOutcome(
   jobData: PipelineCompanyRef,
   companyName: string
-): Promise<CompanyResolution> {
+): Promise<PipelineCompanyResolveOutcome> {
   if (jobData.companyId?.trim()) {
-    return { companyId: jobData.companyId.trim(), method: 'job_data' }
+    return {
+      status: 'resolved',
+      companyId: jobData.companyId.trim(),
+      method: 'job_data',
+    }
   }
 
   const wikidataId = jobData.wikidata?.node?.trim()
@@ -42,22 +110,49 @@ export async function resolveOrCreatePipelineCompanyId(
       pipelineCompanyReadPath(wikidataId)
     ).catch(() => null)
     if (byWikidata?.id) {
-      return { companyId: byWikidata.id as string, method: 'wikidata' }
+      return {
+        status: 'resolved',
+        companyId: byWikidata.id as string,
+        method: 'wikidata',
+      }
     }
   }
 
-  const searchHits = (await apiFetch(
-    `/pipeline/companies/search?q=${encodeURIComponent(companyName)}`
-  ).catch(() => [])) as CompanySearchHit[]
+  const candidates = await collectNameSearchCandidates(companyName)
+  const assessment = assessCompanyLinkResolution(companyName, candidates)
 
-  if (Array.isArray(searchHits)) {
-    const target = normalizeCompanyName(companyName)
-    const exactMatches = searchHits.filter(
-      (hit) => hit.name && normalizeCompanyName(hit.name) === target
-    )
-    if (exactMatches.length === 1) {
-      return { companyId: exactMatches[0].id, method: 'exact_name' }
+  if (assessment.action === 'resolve') {
+    return {
+      status: 'resolved',
+      companyId: assessment.companyId,
+      method: 'exact_name',
     }
+  }
+
+  if (assessment.action === 'ambiguous') {
+    return {
+      status: 'ambiguous',
+      extractedName: companyName,
+      candidates: assessment.candidates,
+    }
+  }
+
+  return { status: 'create', extractedName: companyName }
+}
+
+/**
+ * Resolve the stable Garbo company id for a pipeline run.
+ * Prefer explicit job data, then wikidata lookup, then exact name match, else create.
+ * Ambiguous matches fall through to create — use resolvePipelineCompanyOutcome in precheck.
+ */
+export async function resolveOrCreatePipelineCompanyId(
+  jobData: PipelineCompanyRef,
+  companyName: string
+): Promise<CompanyResolution> {
+  const outcome = await resolvePipelineCompanyOutcome(jobData, companyName)
+
+  if (outcome.status === 'resolved') {
+    return { companyId: outcome.companyId, method: outcome.method }
   }
 
   const created = await apiFetch('/companies/', {

--- a/src/lib/pipelineCompanyResolve.ts
+++ b/src/lib/pipelineCompanyResolve.ts
@@ -4,17 +4,20 @@ import {
   type CompanyLinkCandidate,
   stripLegalEntitySuffixes,
 } from './companyLinkResolve'
+import { normalizeLei } from './normalizeLei'
 import { pipelineCompanyReadPath } from './pipelineCompanyPath'
 
 type PipelineCompanyRef = {
   companyId?: string
   companyName?: string
   wikidata?: { node?: string }
+  lei?: string
 }
 
 export type CompanyResolutionMethod =
   | 'job_data'
   | 'wikidata'
+  | 'lei'
   | 'exact_name'
   | 'approved_link'
   | 'created'
@@ -32,6 +35,27 @@ export type PipelineCompanyResolveOutcome =
       candidates: CompanyLinkCandidate[]
     }
   | { status: 'create'; extractedName: string }
+
+type PipelineCompanyRecord = {
+  id?: string
+  name?: string
+  wikidataId?: string | null
+  lei?: string | null
+}
+
+function toCompanyLinkCandidate(
+  record: PipelineCompanyRecord,
+  fallbackId?: string
+): CompanyLinkCandidate | null {
+  const id = record.id ?? fallbackId
+  if (!id) return null
+  return {
+    id,
+    name: record.name ?? '',
+    wikidataId: record.wikidataId ?? null,
+    lei: record.lei ?? null,
+  }
+}
 
 async function searchCompaniesByName(
   companyName: string
@@ -60,37 +84,36 @@ async function collectNameSearchCandidates(
   return [...byId.values()]
 }
 
+async function findCompanyByIdentifier(
+  identifier: string
+): Promise<CompanyLinkCandidate | null> {
+  const existing = (await apiFetch(pipelineCompanyReadPath(identifier)).catch(
+    () => null
+  )) as PipelineCompanyRecord | null
+
+  return toCompanyLinkCandidate(existing ?? {}, identifier)
+}
+
 /** Look up which company already owns a Wikidata Q-id in the current API. */
 export async function findCompanyByWikidataId(
   wikidataId: string
 ): Promise<CompanyLinkCandidate | null> {
-  const existing = (await apiFetch(pipelineCompanyReadPath(wikidataId)).catch(
-    () => null
-  )) as { id?: string; name?: string; wikidataId?: string | null } | null
-
-  if (!existing?.id) return null
-  return {
-    id: existing.id,
-    name: existing.name ?? '',
-    wikidataId: existing.wikidataId ?? wikidataId,
-  }
+  return findCompanyByIdentifier(wikidataId)
 }
 
-/** @deprecated Use findCompanyByWikidataId; relink now requires staff approval in guessWikidata. */
-export async function resolveTargetCompanyIdForWikidata(
-  companyId: string,
-  wikidataId: string
-): Promise<{ companyId: string; relinked: boolean }> {
-  const owner = await findCompanyByWikidataId(wikidataId)
-  if (owner?.id && owner.id !== companyId) {
-    return { companyId: owner.id, relinked: true }
-  }
-  return { companyId, relinked: false }
+/** Look up which company already owns an LEI in the current API. */
+export async function findCompanyByLei(
+  lei: string
+): Promise<CompanyLinkCandidate | null> {
+  const normalizedLei = normalizeLei(lei)
+  if (!normalizedLei) return null
+  return findCompanyByIdentifier(normalizedLei)
 }
 
 /**
  * Resolve the stable Garbo company id for a pipeline run without creating a company.
- * Returns ambiguous when staff must pick among multiple candidates.
+ * Prefers explicit job data, then Wikidata, then LEI, then exact name match.
+ * Returns ambiguous when staff must pick among candidates.
  */
 export async function resolvePipelineCompanyOutcome(
   jobData: PipelineCompanyRef,
@@ -106,14 +129,24 @@ export async function resolvePipelineCompanyOutcome(
 
   const wikidataId = jobData.wikidata?.node?.trim()
   if (wikidataId) {
-    const byWikidata = await apiFetch(
-      pipelineCompanyReadPath(wikidataId)
-    ).catch(() => null)
+    const byWikidata = await findCompanyByWikidataId(wikidataId)
     if (byWikidata?.id) {
       return {
         status: 'resolved',
-        companyId: byWikidata.id as string,
+        companyId: byWikidata.id,
         method: 'wikidata',
+      }
+    }
+  }
+
+  const normalizedLei = normalizeLei(jobData.lei)
+  if (normalizedLei) {
+    const byLei = await findCompanyByLei(normalizedLei)
+    if (byLei?.id) {
+      return {
+        status: 'resolved',
+        companyId: byLei.id,
+        method: 'lei',
       }
     }
   }
@@ -142,7 +175,7 @@ export async function resolvePipelineCompanyOutcome(
 
 /**
  * Resolve the stable Garbo company id for a pipeline run.
- * Prefer explicit job data, then wikidata lookup, then exact name match, else create.
+ * Prefer explicit job data, then identifiers, then exact name match, else create.
  * Ambiguous matches fall through to create — use resolvePipelineCompanyOutcome in precheck.
  */
 export async function resolveOrCreatePipelineCompanyId(

--- a/src/lib/pipelineRunCompanyId.test.ts
+++ b/src/lib/pipelineRunCompanyId.test.ts
@@ -50,10 +50,7 @@ describe('pipelineRunCompanyId', () => {
   it('falls back to job data when ReportRun has no companyId', async () => {
     prismaMock.reportRun.findUnique.mockResolvedValue({ companyId: null })
 
-    const result = await getCanonicalCompanyIdForThread(
-      'thread-1',
-      'job-id'
-    )
+    const result = await getCanonicalCompanyIdForThread('thread-1', 'job-id')
     expect(result).toEqual({
       companyId: 'job-id',
       source: 'job_data',

--- a/src/lib/pipelineRunCompanyId.test.ts
+++ b/src/lib/pipelineRunCompanyId.test.ts
@@ -1,0 +1,106 @@
+import {
+  jest,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  beforeAll,
+} from '@jest/globals'
+
+const prismaMock = {
+  reportRun: {
+    findUnique: jest.fn<() => Promise<{ companyId: string | null } | null>>(),
+    upsert: jest.fn<() => Promise<unknown>>(),
+    updateMany: jest.fn<() => Promise<unknown>>(),
+  },
+}
+
+jest.unstable_mockModule('./prisma', () => ({
+  prisma: prismaMock,
+}))
+
+let getCanonicalCompanyIdForThread: typeof import('./pipelineRunCompanyId').getCanonicalCompanyIdForThread
+let syncCanonicalReportRunCompanyId: typeof import('./pipelineRunCompanyId').syncCanonicalReportRunCompanyId
+
+beforeAll(async () => {
+  ;({ getCanonicalCompanyIdForThread, syncCanonicalReportRunCompanyId } =
+    await import('./pipelineRunCompanyId'))
+})
+
+describe('pipelineRunCompanyId', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('prefers ReportRun.companyId over job data', async () => {
+    prismaMock.reportRun.findUnique.mockResolvedValue({
+      companyId: 'canonical-id',
+    })
+
+    const result = await getCanonicalCompanyIdForThread(
+      'thread-1',
+      'stale-job-id'
+    )
+    expect(result).toEqual({
+      companyId: 'canonical-id',
+      source: 'report_run',
+    })
+  })
+
+  it('falls back to job data when ReportRun has no companyId', async () => {
+    prismaMock.reportRun.findUnique.mockResolvedValue({ companyId: null })
+
+    const result = await getCanonicalCompanyIdForThread(
+      'thread-1',
+      'job-id'
+    )
+    expect(result).toEqual({
+      companyId: 'job-id',
+      source: 'job_data',
+    })
+  })
+
+  it('upserts ReportRun when pdfUrl is available', async () => {
+    await syncCanonicalReportRunCompanyId({
+      threadId: 'thread-1',
+      companyId: 'company-1',
+      pdfUrl: 'https://example.com/report.pdf',
+      companyName: 'Alfa Laval',
+      wikidataId: 'Q686030',
+    })
+
+    expect(prismaMock.reportRun.upsert).toHaveBeenCalledWith({
+      where: { threadId: 'thread-1' },
+      create: {
+        threadId: 'thread-1',
+        pdfUrl: 'https://example.com/report.pdf',
+        companyId: 'company-1',
+        companyName: 'Alfa Laval',
+        wikidataId: 'Q686030',
+      },
+      update: {
+        companyId: 'company-1',
+        companyName: 'Alfa Laval',
+        wikidataId: 'Q686030',
+      },
+    })
+  })
+
+  it('updates existing ReportRun when pdfUrl is missing', async () => {
+    await syncCanonicalReportRunCompanyId({
+      threadId: 'thread-1',
+      companyId: 'company-1',
+      companyName: 'Alfa Laval',
+    })
+
+    expect(prismaMock.reportRun.updateMany).toHaveBeenCalledWith({
+      where: { threadId: 'thread-1' },
+      data: {
+        companyId: 'company-1',
+        companyName: 'Alfa Laval',
+        wikidataId: undefined,
+      },
+    })
+    expect(prismaMock.reportRun.upsert).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/pipelineRunCompanyId.ts
+++ b/src/lib/pipelineRunCompanyId.ts
@@ -1,0 +1,118 @@
+import { Queue } from 'bullmq'
+import redis from '../config/redis'
+import { prisma } from './prisma'
+
+const GUESS_WIKIDATA_QUEUE = 'guessWikidata'
+
+const GUESS_WIKIDATA_TERMINAL_STATES = new Set(['completed', 'failed'])
+
+export type CanonicalCompanyIdSource = 'report_run' | 'job_data'
+
+export type CanonicalCompanyId = {
+  companyId: string
+  source: CanonicalCompanyIdSource
+}
+
+export type SyncReportRunCompanyInput = {
+  threadId: string
+  companyId: string
+  pdfUrl?: string | null
+  companyName?: string | null
+  wikidataId?: string | null
+}
+
+export async function syncCanonicalReportRunCompanyId(
+  input: SyncReportRunCompanyInput
+): Promise<void> {
+  const threadId = input.threadId.trim()
+  const companyId = input.companyId.trim()
+  if (!threadId || !companyId) return
+
+  const pdfUrl = input.pdfUrl?.trim()
+  const data = {
+    companyId,
+    companyName: input.companyName ?? undefined,
+    wikidataId: input.wikidataId ?? undefined,
+  }
+
+  if (!pdfUrl) {
+    await prisma.reportRun.updateMany({
+      where: { threadId },
+      data,
+    })
+    return
+  }
+
+  await prisma.reportRun.upsert({
+    where: { threadId },
+    create: {
+      threadId,
+      pdfUrl,
+      companyId,
+      companyName: input.companyName ?? null,
+      wikidataId: input.wikidataId ?? null,
+    },
+    update: data,
+  })
+}
+
+export async function getCanonicalCompanyIdForThread(
+  threadId: string | undefined,
+  fallbackCompanyId: string
+): Promise<CanonicalCompanyId> {
+  const normalizedThreadId = threadId?.trim()
+  const normalizedFallback = fallbackCompanyId.trim()
+  if (!normalizedThreadId) {
+    return { companyId: normalizedFallback, source: 'job_data' }
+  }
+
+  const reportRun = await prisma.reportRun.findUnique({
+    where: { threadId: normalizedThreadId },
+    select: { companyId: true },
+  })
+
+  const canonicalCompanyId = reportRun?.companyId?.trim()
+  if (canonicalCompanyId) {
+    return { companyId: canonicalCompanyId, source: 'report_run' }
+  }
+
+  return { companyId: normalizedFallback, source: 'job_data' }
+}
+
+async function listGuessWikidataJobsForThread(threadId: string) {
+  const queue = new Queue(GUESS_WIKIDATA_QUEUE, { connection: redis })
+  try {
+    const jobs = await queue.getJobs([
+      'delayed',
+      'waiting',
+      'active',
+      'prioritized',
+      'waiting-children',
+      'completed',
+      'failed',
+    ])
+    return jobs.filter((job) => job.data?.threadId === threadId)
+  } finally {
+    await queue.close()
+  }
+}
+
+/** True while a guessWikidata job for this thread is still running or awaiting approval. */
+export async function isGuessWikidataPendingForThread(
+  threadId: string
+): Promise<boolean> {
+  const normalizedThreadId = threadId.trim()
+  if (!normalizedThreadId) return false
+
+  const jobs = await listGuessWikidataJobsForThread(normalizedThreadId)
+  if (jobs.length === 0) return false
+
+  for (const job of jobs) {
+    const state = await job.getState()
+    if (!GUESS_WIKIDATA_TERMINAL_STATES.has(state)) {
+      return true
+    }
+  }
+
+  return false
+}

--- a/src/lib/pipelineRunCompanyId.ts
+++ b/src/lib/pipelineRunCompanyId.ts
@@ -99,8 +99,9 @@ async function listGuessWikidataJobsForThread(threadId: string) {
 
 function isCompanyLinkApprovalPending(jobData: unknown): boolean {
   if (!jobData || typeof jobData !== 'object') return false
-  const approval = (jobData as { approval?: { type?: string; approved?: boolean } })
-    .approval
+  const approval = (
+    jobData as { approval?: { type?: string; approved?: boolean } }
+  ).approval
   return approval?.type === 'companyLink' && approval.approved !== true
 }
 

--- a/src/lib/pipelineRunCompanyId.ts
+++ b/src/lib/pipelineRunCompanyId.ts
@@ -97,8 +97,18 @@ async function listGuessWikidataJobsForThread(threadId: string) {
   }
 }
 
-/** True while a guessWikidata job for this thread is still running or awaiting approval. */
-export async function isGuessWikidataPendingForThread(
+function isCompanyLinkApprovalPending(jobData: unknown): boolean {
+  if (!jobData || typeof jobData !== 'object') return false
+  const approval = (jobData as { approval?: { type?: string; approved?: boolean } })
+    .approval
+  return approval?.type === 'companyLink' && approval.approved !== true
+}
+
+/**
+ * True while guessWikidata is waiting on a companyLink approval for this thread.
+ * Does not block saves for ordinary Wikidata approval delays.
+ */
+export async function isCompanyLinkResolutionPendingForThread(
   threadId: string
 ): Promise<boolean> {
   const normalizedThreadId = threadId.trim()
@@ -108,6 +118,8 @@ export async function isGuessWikidataPendingForThread(
   if (jobs.length === 0) return false
 
   for (const job of jobs) {
+    if (!isCompanyLinkApprovalPending(job.data)) continue
+
     const state = await job.getState()
     if (!GUESS_WIKIDATA_TERMINAL_STATES.has(state)) {
       return true
@@ -115,4 +127,11 @@ export async function isGuessWikidataPendingForThread(
   }
 
   return false
+}
+
+/** @deprecated Prefer isCompanyLinkResolutionPendingForThread for save gating. */
+export async function isGuessWikidataPendingForThread(
+  threadId: string
+): Promise<boolean> {
+  return isCompanyLinkResolutionPendingForThread(threadId)
 }

--- a/src/startWorkers.ts
+++ b/src/startWorkers.ts
@@ -49,25 +49,31 @@ for (const queueName of Object.values(QUEUE_NAMES)) {
         return
       }
 
-      const reportRun = await prisma.reportRun.upsert({
+      const existingReportRun = await prisma.reportRun.findUnique({
         where: { threadId },
-        create: {
-          threadId,
-          pdfUrl,
-          companyName,
-          companyId,
-          wikidataId,
-          companyReportId,
-          batchDbId,
-        },
-        update: {
-          companyName: companyName ?? undefined,
-          companyId: companyId ?? undefined,
-          wikidataId: wikidataId ?? undefined,
-          ...(companyReportId ? { companyReportId } : {}),
-          ...(batchDbId ? { batchDbId } : {}),
-        },
+        select: { id: true },
       })
+
+      const reportRun = existingReportRun
+        ? await prisma.reportRun.update({
+            where: { threadId },
+            data: {
+              companyName: companyName ?? undefined,
+              ...(companyReportId ? { companyReportId } : {}),
+              ...(batchDbId ? { batchDbId } : {}),
+            },
+          })
+        : await prisma.reportRun.create({
+            data: {
+              threadId,
+              pdfUrl,
+              companyName,
+              companyId,
+              wikidataId,
+              companyReportId,
+              batchDbId,
+            },
+          })
 
       let returnValue: Record<string, any> | null = null
       if (job.returnvalue) {

--- a/src/workers/checkDB.ts
+++ b/src/workers/checkDB.ts
@@ -7,7 +7,7 @@ import { getCompanyURL } from '../lib/saveUtils'
 import { QUEUE_NAMES } from '../queues'
 import {
   getCanonicalCompanyIdForThread,
-  isGuessWikidataPendingForThread,
+  isCompanyLinkResolutionPendingForThread,
 } from '../lib/pipelineRunCompanyId'
 import {
   extractScopeEntriesFromFollowUp,
@@ -59,8 +59,10 @@ const checkDB = new PipelineWorker(
       job.data
 
     const threadId = job.data.threadId?.trim()
-    if (threadId && (await isGuessWikidataPendingForThread(threadId))) {
-      job.log('Waiting for guessWikidata to resolve company id before API save')
+    if (threadId && (await isCompanyLinkResolutionPendingForThread(threadId))) {
+      job.log(
+        'Waiting for company link resolution on guessWikidata before API save'
+      )
       await job.moveToDelayed(Date.now() + apiConfig.jobDelay)
       return
     }

--- a/src/workers/checkDB.ts
+++ b/src/workers/checkDB.ts
@@ -2,8 +2,13 @@ import { FlowProducer } from 'bullmq'
 import { PipelineJob, PipelineWorker } from '../lib/PipelineWorker'
 import { apiFetch } from '../lib/api'
 import redis from '../config/redis'
+import apiConfig from '../config/api'
 import { getCompanyURL } from '../lib/saveUtils'
 import { QUEUE_NAMES } from '../queues'
+import {
+  getCanonicalCompanyIdForThread,
+  isGuessWikidataPendingForThread,
+} from '../lib/pipelineRunCompanyId'
 import {
   extractScopeEntriesFromFollowUp,
   mergeScope1AndScope2Results,
@@ -50,8 +55,27 @@ flow.on('error', (err) => console.error('FlowProducer connection error:', err))
 const checkDB = new PipelineWorker(
   QUEUE_NAMES.CHECK_DB,
   async (job: CheckDBJob) => {
-    const { companyName, companyId, url, sourceUrl, fiscalYear, wikidata } =
+    let { companyName, companyId, url, sourceUrl, fiscalYear, wikidata } =
       job.data
+
+    const threadId = job.data.threadId?.trim()
+    if (threadId && (await isGuessWikidataPendingForThread(threadId))) {
+      job.log('Waiting for guessWikidata to resolve company id before API save')
+      await job.moveToDelayed(Date.now() + apiConfig.jobDelay)
+      return
+    }
+
+    const canonicalCompany = await getCanonicalCompanyIdForThread(
+      threadId,
+      companyId
+    )
+    if (canonicalCompany.companyId !== companyId) {
+      job.log(
+        `Using canonical companyId=${canonicalCompany.companyId} from ${canonicalCompany.source} (job had ${companyId})`
+      )
+      companyId = canonicalCompany.companyId
+      await job.updateData({ ...job.data, companyId })
+    }
 
     const childrenEntries = await job.getChildrenEntries()
 

--- a/src/workers/guessWikidata.ts
+++ b/src/workers/guessWikidata.ts
@@ -8,7 +8,10 @@ import { ChatCompletionMessageParam } from 'openai/resources'
 import { QUEUE_NAMES } from '../queues'
 import { getWikidataEntities, searchCompany } from '@/lib/wikidata/read'
 import { apiFetch } from '../lib/api'
-import { companyMutationPath, pipelineCompanyReadPath } from '../lib/pipelineCompanyPath'
+import {
+  companyMutationPath,
+  pipelineCompanyReadPath,
+} from '../lib/pipelineCompanyPath'
 import { findCompanyByWikidataId } from '../lib/pipelineCompanyResolve'
 import type { CompanyLinkCandidate } from '../lib/companyLinkResolve'
 import { syncCanonicalReportRunCompanyId } from '../lib/pipelineRunCompanyId'
@@ -181,9 +184,10 @@ async function ensureCompanyLinkBeforeWikidataPersist(
   return false
 }
 
-function resolveCompanyIdFromCompanyLinkApproval(
-  job: GuessWikidataJob
-): { companyId: string; skipWikidataAssign: boolean } {
+function resolveCompanyIdFromCompanyLinkApproval(job: GuessWikidataJob): {
+  companyId: string
+  skipWikidataAssign: boolean
+} {
   const approved = job.getApprovedBody()
   const pipelineCompanyId = job.data.companyId
   if (!pipelineCompanyId) {

--- a/src/workers/guessWikidata.ts
+++ b/src/workers/guessWikidata.ts
@@ -8,7 +8,10 @@ import { ChatCompletionMessageParam } from 'openai/resources'
 import { QUEUE_NAMES } from '../queues'
 import { getWikidataEntities, searchCompany } from '@/lib/wikidata/read'
 import { apiFetch } from '../lib/api'
-import { companyMutationPath } from '../lib/pipelineCompanyPath'
+import { companyMutationPath, pipelineCompanyReadPath } from '../lib/pipelineCompanyPath'
+import { findCompanyByWikidataId } from '../lib/pipelineCompanyResolve'
+import type { CompanyLinkCandidate } from '../lib/companyLinkResolve'
+import { syncCanonicalReportRunCompanyId } from '../lib/pipelineRunCompanyId'
 import { buildEarlyRegistryPayload } from './saveToAPI.utils'
 import { registryService } from '../api/services/registryService'
 
@@ -103,6 +106,107 @@ ${JSON.stringify(wikidataForApproval, null, 2)}
   return null
 }
 
+async function loadCompanyLinkCandidate(
+  companyId: string
+): Promise<CompanyLinkCandidate> {
+  const company = (await apiFetch(pipelineCompanyReadPath(companyId)).catch(
+    () => null
+  )) as { id?: string; name?: string; wikidataId?: string | null } | null
+
+  return {
+    id: companyId,
+    name: company?.name ?? companyId,
+    wikidataId: company?.wikidataId ?? null,
+  }
+}
+
+/**
+ * When Wikidata is already linked to a different company, ask staff to confirm
+ * the company id before persisting. Returns false when waiting on approval.
+ */
+async function ensureCompanyLinkBeforeWikidataPersist(
+  job: GuessWikidataJob,
+  companyName: string,
+  wikidata: Wikidata
+): Promise<boolean> {
+  if (job.data.approval?.type === 'companyLink' && !job.isDataApproved()) {
+    job.log('Waiting for company link approval before Wikidata persist')
+    await job.moveToDelayed(Date.now() + apiConfig.jobDelay)
+    return false
+  }
+
+  const pipelineCompanyId = job.data.companyId
+  if (!pipelineCompanyId) {
+    throw new Error('Missing companyId on guessWikidata job')
+  }
+
+  const wikidataOwner = await findCompanyByWikidataId(wikidata.node)
+  if (!wikidataOwner || wikidataOwner.id === pipelineCompanyId) {
+    return true
+  }
+
+  job.log(
+    `Wikidata ${wikidata.node} belongs to company ${wikidataOwner.id}; pipeline company is ${pipelineCompanyId} — requesting staff confirmation`
+  )
+
+  const pipelineCompany = await loadCompanyLinkCandidate(pipelineCompanyId)
+  await job.updateData({ ...job.data, wikidata })
+
+  const metadata = {
+    source: 'wikidata-relink',
+    comment: `Wikidata ${wikidata.node} is already linked to another company. Confirm which company this report belongs to before saving.`,
+  }
+
+  await job.requestApproval(
+    'companyLink',
+    {
+      type: 'companyLink',
+      newValue: {
+        extractedName: companyName,
+        candidates: [wikidataOwner, pipelineCompany],
+        allowCreateNew: false,
+        wikidataNode: wikidata.node,
+      },
+    },
+    false,
+    metadata,
+    `Confirm company for ${wikidata.node} (${companyName})`
+  )
+
+  await job.sendMessage({
+    content: `Wikidata ${wikidata.node} is already linked to "${wikidataOwner.name}". Please confirm which company this report belongs to in Validate.`,
+  })
+
+  await job.moveToDelayed(Date.now() + apiConfig.jobDelay)
+  return false
+}
+
+function resolveCompanyIdFromCompanyLinkApproval(
+  job: GuessWikidataJob
+): { companyId: string; skipWikidataAssign: boolean } {
+  const approved = job.getApprovedBody()
+  const pipelineCompanyId = job.data.companyId
+  if (!pipelineCompanyId) {
+    throw new Error('Missing companyId on guessWikidata job')
+  }
+
+  if (approved.createNew) {
+    throw new Error(
+      'Create-new is not allowed when resolving a Wikidata company link conflict'
+    )
+  }
+
+  const selectedCompanyId =
+    typeof approved.companyId === 'string' && approved.companyId.trim()
+      ? approved.companyId.trim()
+      : pipelineCompanyId
+
+  return {
+    companyId: selectedCompanyId,
+    skipWikidataAssign: selectedCompanyId === pipelineCompanyId,
+  }
+}
+
 async function persistApprovedWikidata(
   job: GuessWikidataJob,
   companyName: string,
@@ -111,24 +215,49 @@ async function persistApprovedWikidata(
     verified?: boolean
     metadata?: { source: string; comment: string }
     verifiedByUserId?: string
+    companyId?: string
+    skipWikidataAssign?: boolean
   }
 ) {
-  const companyId = job.data.companyId
+  const companyId = options.companyId ?? job.data.companyId
   if (!companyId) {
     throw new Error('Missing companyId on guessWikidata job')
   }
 
-  await apiFetch(companyMutationPath(companyId), {
-    body: {
-      name: companyName,
-      wikidataId: wikidata.node,
-      metadata: options.metadata,
-      verified: options.verified ?? false,
-      ...(options.verifiedByUserId && {
-        verifiedByUserId: options.verifiedByUserId,
-      }),
-    },
-  })
+  if (companyId !== job.data.companyId) {
+    job.log(`Using staff-confirmed company id=${companyId}`)
+    await job.updateData({ ...job.data, companyId })
+  }
+
+  const body: Record<string, unknown> = {
+    name: companyName,
+    metadata: options.metadata,
+    verified: options.verified ?? false,
+    ...(options.verifiedByUserId && {
+      verifiedByUserId: options.verifiedByUserId,
+    }),
+  }
+
+  if (!options.skipWikidataAssign) {
+    body.wikidataId = wikidata.node
+  } else {
+    job.log(
+      `Keeping pipeline company ${companyId} without assigning Wikidata ${wikidata.node}`
+    )
+  }
+
+  await apiFetch(companyMutationPath(companyId), { body })
+
+  const threadId = job.data.threadId?.trim()
+  if (threadId) {
+    await syncCanonicalReportRunCompanyId({
+      threadId,
+      companyId,
+      pdfUrl: job.data.url,
+      companyName,
+      wikidataId: options.skipWikidataAssign ? null : wikidata.node,
+    })
+  }
 
   await backfillRegistryWikidataFromJob(job, wikidata)
 }
@@ -166,8 +295,56 @@ const guessWikidata = new PipelineWorker<GuessWikidataJob>(
     job.log('Company name: ' + companyName)
     job.log('Approval: ' + JSON.stringify(job.data.approval, null, 2))
 
+    const pendingWikidata = job.data.wikidata as Wikidata | undefined
+
+    if (
+      job.data.approval?.type === 'companyLink' &&
+      job.isDataApproved() &&
+      pendingWikidata?.node
+    ) {
+      const { companyId: confirmedCompanyId, skipWikidataAssign } =
+        resolveCompanyIdFromCompanyLinkApproval(job)
+      const metadata = job.data.approval?.metadata
+
+      await persistApprovedWikidata(job, companyName, pendingWikidata, {
+        verified: !job.data.autoApprove,
+        metadata,
+        verifiedByUserId: job.data.approval?.verifiedByUserId,
+        companyId: confirmedCompanyId,
+        skipWikidataAssign,
+      })
+
+      job.editMessage({
+        content: skipWikidataAssign
+          ? `Company link confirmed for ${companyName} (Wikidata not assigned to pipeline company)`
+          : `Company link confirmed for ${companyName}`,
+      })
+
+      return JSON.stringify(
+        {
+          status: 'approved',
+          wikidata: pendingWikidata,
+          companyId: confirmedCompanyId,
+          skipWikidataAssign,
+          message: `Company link confirmed for ${companyName}`,
+          metadata,
+        },
+        null,
+        2
+      )
+    }
+
+    if (
+      job.data.approval?.type === 'companyLink' &&
+      job.hasApproval() &&
+      !job.isDataApproved()
+    ) {
+      await job.moveToDelayed(Date.now() + apiConfig.jobDelay)
+      return
+    }
+
     // If approved, process the wikidata (takes precedence - don't override approved data)
-    if (job.isDataApproved()) {
+    if (job.data.approval?.type === 'wikidata' && job.isDataApproved()) {
       const approvedWikidata = job.getApprovedBody().wikidata as
         | Wikidata
         | undefined
@@ -176,6 +353,13 @@ const guessWikidata = new PipelineWorker<GuessWikidataJob>(
       }
 
       const metadata = job.data.approval?.metadata
+
+      const ready = await ensureCompanyLinkBeforeWikidataPersist(
+        job,
+        companyName,
+        approvedWikidata
+      )
+      if (!ready) return
 
       await persistApprovedWikidata(job, companyName, approvedWikidata, {
         // verified false when job autoApprove is on; human approver id comes from Validate rerun.
@@ -400,6 +584,13 @@ const guessWikidata = new PipelineWorker<GuessWikidataJob>(
             `Auto-approved wikidata for ${companyName}`
           )
 
+          const ready = await ensureCompanyLinkBeforeWikidataPersist(
+            job,
+            companyName,
+            wikidataForApproval
+          )
+          if (!ready) return
+
           await persistApprovedWikidata(job, companyName, wikidataForApproval, {
             verified: false,
             metadata,
@@ -444,6 +635,13 @@ const guessWikidata = new PipelineWorker<GuessWikidataJob>(
         metadata,
         `Auto-approved wikidata for ${companyName}`
       )
+
+      const ready = await ensureCompanyLinkBeforeWikidataPersist(
+        job,
+        companyName,
+        wikidataForApproval
+      )
+      if (!ready) return
 
       await persistApprovedWikidata(job, companyName, wikidataForApproval, {
         verified: false,

--- a/src/workers/guessWikidata.ts
+++ b/src/workers/guessWikidata.ts
@@ -14,6 +14,7 @@ import {
 } from '../lib/pipelineCompanyPath'
 import { findCompanyByWikidataId } from '../lib/pipelineCompanyResolve'
 import type { CompanyLinkCandidate } from '../lib/companyLinkResolve'
+import { LEGAL_ENTITY_SUFFIXES } from '../lib/companyLegalEntitySuffixes'
 import { syncCanonicalReportRunCompanyId } from '../lib/pipelineRunCompanyId'
 import { buildEarlyRegistryPayload } from './saveToAPI.utils'
 import { registryService } from '../api/services/registryService'
@@ -30,18 +31,7 @@ export class GuessWikidataJob extends PipelineJob {
   }
 }
 
-const insignificantWords = new Set([
-  'ab',
-  'the',
-  'and',
-  'inc',
-  'co',
-  'publ',
-  '(publ)',
-  '(ab)',
-  'aktiebolag',
-  'aktiebolaget',
-])
+const insignificantWords = LEGAL_ENTITY_SUFFIXES
 
 async function handleOverrideWikidataId(
   job: GuessWikidataJob,
@@ -127,10 +117,11 @@ async function loadCompanyLinkCandidate(
  * When Wikidata is already linked to a different company, ask staff to confirm
  * the company id before persisting. Returns false when waiting on approval.
  */
-async function ensureCompanyLinkBeforeWikidataPersist(
+async function requestCompanyLinkIfWikidataConflict(
   job: GuessWikidataJob,
   companyName: string,
-  wikidata: Wikidata
+  wikidata: Wikidata,
+  options?: { source?: string; comment?: string }
 ): Promise<boolean> {
   if (job.data.approval?.type === 'companyLink' && !job.isDataApproved()) {
     job.log('Waiting for company link approval before Wikidata persist')
@@ -156,8 +147,10 @@ async function ensureCompanyLinkBeforeWikidataPersist(
   await job.updateData({ ...job.data, wikidata })
 
   const metadata = {
-    source: 'wikidata-relink',
-    comment: `Wikidata ${wikidata.node} is already linked to another company. Confirm which company this report belongs to before saving.`,
+    source: options?.source ?? 'wikidata-relink',
+    comment:
+      options?.comment ??
+      `Wikidata ${wikidata.node} is already linked to another company. Confirm which company this report belongs to before saving.`,
   }
 
   await job.requestApproval(
@@ -182,6 +175,14 @@ async function ensureCompanyLinkBeforeWikidataPersist(
 
   await job.moveToDelayed(Date.now() + apiConfig.jobDelay)
   return false
+}
+
+async function ensureCompanyLinkBeforeWikidataPersist(
+  job: GuessWikidataJob,
+  companyName: string,
+  wikidata: Wikidata
+): Promise<boolean> {
+  return requestCompanyLinkIfWikidataConflict(job, companyName, wikidata)
 }
 
 function resolveCompanyIdFromCompanyLinkApproval(job: GuessWikidataJob): {
@@ -263,13 +264,18 @@ async function persistApprovedWikidata(
     })
   }
 
-  await backfillRegistryWikidataFromJob(job, wikidata)
+  await backfillRegistryWikidataFromJob(job, wikidata, {
+    skipWhenNotAssigned: options.skipWikidataAssign,
+  })
 }
 
 async function backfillRegistryWikidataFromJob(
   job: GuessWikidataJob,
-  wikidata: Wikidata
+  wikidata: Wikidata,
+  options?: { skipWhenNotAssigned?: boolean }
 ) {
+  if (options?.skipWhenNotAssigned) return
+
   const payload = buildEarlyRegistryPayload({
     companyName: job.data.companyName,
     wikidata: { node: wikidata.node },
@@ -561,6 +567,13 @@ const guessWikidata = new PipelineWorker<GuessWikidataJob>(
         `Could not parse wikidataId from json: ${wikidataForApproval}`
       )
     }
+
+    const readyBeforeApproval = await requestCompanyLinkIfWikidataConflict(
+      job,
+      companyName,
+      wikidataForApproval
+    )
+    if (!readyBeforeApproval) return
 
     try {
       const checkIfWikidataExistInProductionRes = await fetch(

--- a/src/workers/precheck.ts
+++ b/src/workers/precheck.ts
@@ -208,13 +208,20 @@ const precheck = new PipelineWorker(
     if (!companyName) {
       if (waitingForCompanyName) {
         job.log('Still waiting for companyName in job data...')
-        await job.moveToDelayed(Date.now() + 30000)
+        await job.moveToDelayed(Date.now() + apiConfig.jobDelay)
         return
       }
 
-      throw new Error(
-        'Could not identify company name from report. Re-run with companyName provided in job data.'
+      job.log(
+        'Could not identify company name from report — waiting for manual input'
       )
+      await job.updateData({ ...job.data, waitingForCompanyName: true })
+      await job.sendMessage({
+        content:
+          'Could not identify the company name from this report. Please enter the company name in Validate to continue.',
+      })
+      await job.moveToDelayed(Date.now() + apiConfig.jobDelay)
+      return
     }
 
     return processWithCompanyName(companyName)

--- a/src/workers/precheck.ts
+++ b/src/workers/precheck.ts
@@ -6,7 +6,10 @@ import { zodResponseFormat } from 'openai/helpers/zod'
 import { PipelineJob, PipelineWorker } from '../lib/PipelineWorker'
 import { z } from 'zod'
 import { QUEUE_NAMES } from '../queues'
-import { resolveOrCreatePipelineCompanyId } from '../lib/pipelineCompanyResolve'
+import apiConfig from '../config/api'
+import { apiFetch } from '../lib/api'
+import { resolvePipelineCompanyOutcome } from '../lib/pipelineCompanyResolve'
+import { syncCanonicalReportRunCompanyId } from '../lib/pipelineRunCompanyId'
 import { EXTRACT_EMISSIONS_CHILD_QUEUES } from './precheckFlow'
 import { withPipelineJobOpts } from '../lib/pipelineJobOptions'
 
@@ -26,18 +29,126 @@ const companyNameSchema = z.object({
   companyName: z.string().nullable(),
 })
 
+async function createPipelineCompany(
+  companyName: string
+): Promise<string> {
+  const created = await apiFetch('/companies/', {
+    body: { name: companyName },
+  })
+  if (!created?.id) {
+    throw new Error('Company create did not return id')
+  }
+  return created.id as string
+}
+
+async function syncRunCompanyIdFromPrecheck(
+  job: PrecheckJob,
+  companyId: string,
+  companyName: string
+) {
+  const threadId = job.data.threadId?.trim()
+  if (!threadId) return
+
+  await syncCanonicalReportRunCompanyId({
+    threadId,
+    companyId,
+    pdfUrl: job.data.url,
+    companyName,
+  })
+}
+
 async function ensurePipelineCompany(
   job: PrecheckJob,
   companyName: string
-): Promise<string> {
-  const { companyId, method } = await resolveOrCreatePipelineCompanyId(
-    job.data,
-    companyName
-  )
-  if (companyId !== job.data.companyId) {
-    await job.updateData({ ...job.data, companyId, companyName })
-    job.log(`Resolved pipeline company id=${companyId} method=${method}`)
+): Promise<string | null> {
+  if (
+    job.data.approval?.type === 'companyLink' &&
+    job.isDataApproved()
+  ) {
+    const approved = job.getApprovedBody()
+    if (approved.createNew) {
+      const companyId = await createPipelineCompany(companyName)
+      await job.updateData({ ...job.data, companyId, companyName })
+      job.log(
+        `Created new company after company-link approval id=${companyId}`
+      )
+      await syncRunCompanyIdFromPrecheck(job, companyId, companyName)
+      return companyId
+    }
+    if (typeof approved.companyId === 'string' && approved.companyId.trim()) {
+      const companyId = approved.companyId.trim()
+      await job.updateData({ ...job.data, companyId, companyName })
+      job.log(`Using staff-selected company id=${companyId}`)
+      await syncRunCompanyIdFromPrecheck(job, companyId, companyName)
+      return companyId
+    }
   }
+
+  if (
+    job.data.approval?.type === 'companyLink' &&
+    job.hasApproval() &&
+    !job.isDataApproved()
+  ) {
+    job.log('Waiting for company link approval')
+    return null
+  }
+
+  const outcome = await resolvePipelineCompanyOutcome(job.data, companyName)
+
+  if (outcome.status === 'resolved') {
+    if (outcome.companyId !== job.data.companyId) {
+      await job.updateData({
+        ...job.data,
+        companyId: outcome.companyId,
+        companyName,
+      })
+      job.log(
+        `Resolved pipeline company id=${outcome.companyId} method=${outcome.method}`
+      )
+    }
+    await syncRunCompanyIdFromPrecheck(job, outcome.companyId, companyName)
+    return outcome.companyId
+  }
+
+  if (outcome.status === 'ambiguous') {
+    job.log(
+      `Ambiguous company link for "${companyName}" — ${outcome.candidates.length} candidates`
+    )
+    job.log(
+      `Company link candidates: ${JSON.stringify(outcome.candidates, null, 2)}`
+    )
+
+    const metadata = {
+      source: 'company-name-search',
+      comment:
+        'Multiple matching companies found — please select the correct company',
+    }
+
+    await job.requestApproval(
+      'companyLink',
+      {
+        type: 'companyLink',
+        newValue: {
+          extractedName: outcome.extractedName,
+          candidates: outcome.candidates,
+        },
+      },
+      false,
+      metadata,
+      `Company link for ${companyName}`
+    )
+
+    await job.sendMessage({
+      content: `Multiple companies match "${companyName}". Please select the correct company in Validate before the pipeline continues.`,
+    })
+    await job.moveToDelayed(Date.now() + apiConfig.jobDelay)
+    return null
+  }
+
+  const companyId = await createPipelineCompany(companyName)
+  await job.updateData({ ...job.data, companyId, companyName })
+  job.log(`Created pipeline company id=${companyId}`)
+  await syncRunCompanyIdFromPrecheck(job, companyId, companyName)
   return companyId
 }
 
@@ -117,9 +228,10 @@ const precheck = new PipelineWorker(
       job.log('Company name: ' + companyName)
 
       const companyId = await ensurePipelineCompany(job, companyName)
+      if (!companyId) return
 
       const base = {
-        data: { ...baseData, companyName, companyId },
+        data: { ...job.data, companyName, companyId },
         opts: withPipelineJobOpts({
           attempts: 3,
         }),

--- a/src/workers/precheck.ts
+++ b/src/workers/precheck.ts
@@ -18,6 +18,7 @@ class PrecheckJob extends PipelineJob {
     cachedMarkdown?: string
     companyName?: string
     companyId?: string
+    lei?: string
     waitingForCompanyName?: boolean
   }
 }
@@ -83,6 +84,7 @@ async function ensurePipelineCompany(
     !job.isDataApproved()
   ) {
     job.log('Waiting for company link approval')
+    await job.moveToDelayed(Date.now() + apiConfig.jobDelay)
     return null
   }
 

--- a/src/workers/precheck.ts
+++ b/src/workers/precheck.ts
@@ -29,9 +29,7 @@ const companyNameSchema = z.object({
   companyName: z.string().nullable(),
 })
 
-async function createPipelineCompany(
-  companyName: string
-): Promise<string> {
+async function createPipelineCompany(companyName: string): Promise<string> {
   const created = await apiFetch('/companies/', {
     body: { name: companyName },
   })
@@ -61,17 +59,12 @@ async function ensurePipelineCompany(
   job: PrecheckJob,
   companyName: string
 ): Promise<string | null> {
-  if (
-    job.data.approval?.type === 'companyLink' &&
-    job.isDataApproved()
-  ) {
+  if (job.data.approval?.type === 'companyLink' && job.isDataApproved()) {
     const approved = job.getApprovedBody()
     if (approved.createNew) {
       const companyId = await createPipelineCompany(companyName)
       await job.updateData({ ...job.data, companyId, companyName })
-      job.log(
-        `Created new company after company-link approval id=${companyId}`
-      )
+      job.log(`Created new company after company-link approval id=${companyId}`)
       await syncRunCompanyIdFromPrecheck(job, companyId, companyName)
       return companyId
     }

--- a/src/workers/saveToAPI.ts
+++ b/src/workers/saveToAPI.ts
@@ -2,6 +2,7 @@ import { PipelineJob, PipelineWorker } from '../lib/PipelineWorker'
 import { apiFetch } from '../lib/api'
 import { QUEUE_NAMES } from '../queues'
 import { withCompanySaveLock } from '../lib/companySaveLock'
+import { getCanonicalCompanyIdForThread } from '../lib/pipelineRunCompanyId'
 import { syncReportRunCompanyReportId } from '../lib/reportRunPersistence'
 import { companyReportIdFromPeriodSaveResponse } from './saveToAPI.utils'
 import { companyMutationPath } from '../lib/pipelineCompanyPath'
@@ -76,8 +77,16 @@ export const saveToAPI = new PipelineWorker<SaveToApiJob>(
   QUEUE_NAMES.SAVE_TO_API,
   async (job: SaveToApiJob) => {
     try {
-      const { companyName, companyId, wikidata, body, apiSubEndpoint } =
-        job.data
+      const { companyName, wikidata, body, apiSubEndpoint } = job.data
+      const { companyId, source } = await getCanonicalCompanyIdForThread(
+        job.data.threadId,
+        job.data.companyId
+      )
+      if (companyId !== job.data.companyId) {
+        job.log(
+          `Using canonical companyId=${companyId} from ${source} for save (job had ${job.data.companyId})`
+        )
+      }
 
       // remove all null values except for emissions where we want them to be explicit
       const sanitizedBody = removeNullValuesFromGarbo(body)


### PR DESCRIPTION
## Summary

Fixes pipeline company identity resolution so reports link to the correct existing company instead of creating duplicates or failing with Wikidata 409 conflicts (e.g. Alfa Laval AB vs Alfa Laval, Q686030 already assigned).

Implements Phase 3.5 company-link resolution, multi-signal company matching (name + Wikidata + LEI), and canonical `ReportRun.companyId` persistence from precheck through API save.

**Companion PR:** [validate-frontend#262](https://github.com/Klimatbyran/validate-frontend/pull/262) — `companyLink` approval UI. **Deploy together.**

Also includes a read-only duplicate-company audit script + k8s Job, and moves the Chroma storage plan to `doc/rfc/`.

---

### Precheck — company name matching
- Fuzzy DB search collects candidates; auto-link only when **exactly one** normalized name match (legal suffixes stripped — Nordic, US, and European forms in `companyLegalEntitySuffixes.ts`).
- **Any fuzzy hit without a single exact match → `companyLink` approval** (including a lone non-exact hit — no silent create).
- Resolution order: explicit `job.data.companyId` → Wikidata Q-id → **LEI** (`job.data.lei`) → name search.
- Writes canonical `ReportRun.companyId` when resolved.
- Re-delays correctly while waiting for company-link approval.

### guessWikidata — Wikidata conflicts
- Detects Wikidata owner conflict **as soon as Q-id is selected** (before Wikidata approval), not only at persist time.
- When Q-id is on a different company → **`companyLink` approval** (no silent relink).
- Staff choose: link to Wikidata owner, or keep pipeline company without assigning the Q-id.
- Skips registry Wikidata backfill when Wikidata is not assigned.
- Updates `ReportRun.companyId` after confirmation.

### Save-time canonical company id
- **`checkDB`** waits only for pending **`companyLink`** on guessWikidata (not ordinary Wikidata approval delays), then resolves `companyId` from `ReportRun`.
- **`saveToAPI`** re-resolves from `ReportRun` as a safety net.
- **`startWorkers` `saveRun`** no longer overwrites `ReportRun.companyId` / `wikidataId` on existing rows (prevents stale sibling jobs from undoing staff-confirmed links).

### API
- Pipeline company search hits include `wikidataId` and `lei`.
- `resolveCompanyIdentifier` supports LEI lookup via `Company.lei` and `CompanyIdentifier` (LEI + WIKIDATA).

### Ops / audit tooling
- `npm run find-duplicate-companies` — scan DB for potential duplicates (normalized name, shared LEI, Wikidata conflicts on same name).
- `k8s/jobs/find-duplicate-companies.yaml` — run scan in-cluster without port-forwarding.

### Docs
- `companyLinkResolve.ts`, `pipelineRunCompanyId.ts` + tests
- Updated `COMPANY_IDENTIFIERS_PLAN.md` (Phase 3.5 shipped)
- `doc/rfc/chromadb-storage.md` — Chroma bounded-storage RFC (unrelated to company-link fix; included for review)

---

## Test plan

- [x] `npm test -- src/lib/companyLinkResolve.test.ts src/lib/pipelineCompanyResolve.test.ts src/lib/pipelineRunCompanyId.test.ts src/lib/normalizeLei.test.ts src/lib/findDuplicateCompanyGroups.test.ts`
- [ ] Deploy with [validate-frontend#262](https://github.com/Klimatbyran/validate-frontend/pull/262)
- [ ] Run Alfa Laval (or similar) where duplicate companies exist → precheck pauses with company link candidates
- [ ] Approve company link in Validate → precheck resumes with chosen `companyId`
- [ ] Wikidata already on another company → guessWikidata pauses for company link early; save lands on staff-selected company
- [ ] Re-run with explicit `companyId` or `lei` in job data → resolves without ambiguity
- [ ] Stage: `kubectl create -n garbo-stage -f k8s/jobs/find-duplicate-companies.yaml` and review duplicate scan output

## Checklist

- [ ] PR title starts with `[#issue-number]`; if no issue is applicable use: `[fix]`, `[feat]`, `[ops]`, or `[prod]`
- [x] Tests added for company link heuristics, identifier resolve, canonical id, LEI normalize, duplicate scan
- [ ] Verified locally / in staging with a real pipeline run
- [x] API change: pipeline search returns optional `wikidataId` + `lei` (backward compatible); LEI readable via pipeline company read
- [ ] No DB migration required
- [x] Observability: precheck/guessWikidata/checkDB log candidate lists and canonical id resolution

## Related

Motivated by duplicate Alfa Laval companies + Wikidata 409 (`Q686030 already in use`). Existing duplicates still need manual cleanup/merge — this PR prevents new mis-links; use `find-duplicate-companies` to size the cleanup backlog.