### PR TITLE
Fix company ID resolution and ReportRun sync follow-ups

### DIFF
--- a/src/lib/pipelineCompanyResolve.test.ts
+++ b/src/lib/pipelineCompanyResolve.test.ts
@@ -17,6 +17,7 @@ let resolveOrCreatePipelineCompanyId: typeof import('./pipelineCompanyResolve').
 let resolvePipelineCompanyOutcome: typeof import('./pipelineCompanyResolve').resolvePipelineCompanyOutcome
 let findCompanyByWikidataId: typeof import('./pipelineCompanyResolve').findCompanyByWikidataId
 let findCompanyByLei: typeof import('./pipelineCompanyResolve').findCompanyByLei
+let resolveInternalCompanyId: typeof import('./pipelineCompanyResolve').resolveInternalCompanyId
 
 beforeAll(async () => {
   ;({
@@ -24,6 +25,7 @@ beforeAll(async () => {
     resolvePipelineCompanyOutcome,
     findCompanyByWikidataId,
     findCompanyByLei,
+    resolveInternalCompanyId,
   } = await import('./pipelineCompanyResolve'))
 })
 
@@ -33,12 +35,38 @@ describe('resolveOrCreatePipelineCompanyId', () => {
   })
 
   it('returns job.data.companyId when already set', async () => {
+    const companyId = '11111111-1111-4111-8111-111111111111'
     const result = await resolveOrCreatePipelineCompanyId(
-      { companyId: 'existing-id' },
+      { companyId },
       'Acme AB'
     )
-    expect(result).toEqual({ companyId: 'existing-id', method: 'job_data' })
+    expect(result).toEqual({ companyId, method: 'job_data' })
     expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  it('resolves job.data.companyId when it is a wikidata Q-id', async () => {
+    mockApiFetch.mockImplementation(async (path: unknown) => {
+      if (
+        typeof path === 'string' &&
+        path.includes('/pipeline/companies/Q999')
+      ) {
+        return {
+          id: '11111111-1111-4111-8111-111111111111',
+          name: 'Acme',
+          wikidataId: 'Q999',
+        }
+      }
+      throw new Error(`unexpected path ${String(path)}`)
+    })
+
+    const result = await resolveOrCreatePipelineCompanyId(
+      { companyId: 'Q999' },
+      'Acme AB'
+    )
+    expect(result).toEqual({
+      companyId: '11111111-1111-4111-8111-111111111111',
+      method: 'job_data',
+    })
   })
 
   it('resolves by wikidata before creating', async () => {
@@ -159,6 +187,39 @@ describe('resolveOrCreatePipelineCompanyId', () => {
     })
   })
 
+  it('returns null when wikidata lookup fails', async () => {
+    mockApiFetch.mockRejectedValue(new Error('timeout'))
+
+    await expect(findCompanyByWikidataId('Q686030')).resolves.toBeNull()
+  })
+
+  it('returns null when wikidata lookup returns a record without id', async () => {
+    mockApiFetch.mockResolvedValue({ name: 'Alfa Laval', wikidataId: 'Q686030' })
+
+    await expect(findCompanyByWikidataId('Q686030')).resolves.toBeNull()
+  })
+
+  it('falls through to name search when wikidata lookup fails', async () => {
+    mockApiFetch.mockImplementation(async (path: unknown) => {
+      if (path === '/pipeline/companies/Q123') {
+        throw new Error('upstream 500')
+      }
+      if (
+        typeof path === 'string' &&
+        path.includes('/pipeline/companies/search')
+      ) {
+        return [{ id: 'exact', name: 'Acme AB' }]
+      }
+      throw new Error(`unexpected path ${String(path)}`)
+    })
+
+    const result = await resolveOrCreatePipelineCompanyId(
+      { wikidata: { node: 'Q123' } },
+      'Acme AB'
+    )
+    expect(result).toEqual({ companyId: 'exact', method: 'exact_name' })
+  })
+
   it('creates a company when no match is found', async () => {
     mockApiFetch.mockImplementation(
       async (path: unknown, init?: { body?: unknown }) => {
@@ -230,5 +291,37 @@ describe('resolvePipelineCompanyOutcome', () => {
       extractedName: 'Totally Different Name',
       candidates: [{ id: 'alfa-1', name: 'Alfa Laval', wikidataId: 'Q686030' }],
     })
+  })
+})
+
+describe('resolveInternalCompanyId', () => {
+  beforeEach(() => {
+    mockApiFetch.mockReset()
+  })
+
+  it('returns a UUID unchanged', async () => {
+    const companyId = '11111111-1111-4111-8111-111111111111'
+    await expect(resolveInternalCompanyId(companyId)).resolves.toBe(companyId)
+    expect(mockApiFetch).not.toHaveBeenCalled()
+  })
+
+  it('resolves a wikidata Q-id to the internal company UUID', async () => {
+    mockApiFetch.mockImplementation(async (path: unknown) => {
+      if (
+        typeof path === 'string' &&
+        path.includes('/pipeline/companies/Q686030')
+      ) {
+        return {
+          id: '22222222-2222-4222-8222-222222222222',
+          name: 'Alfa Laval',
+          wikidataId: 'Q686030',
+        }
+      }
+      throw new Error(`unexpected path ${String(path)}`)
+    })
+
+    await expect(resolveInternalCompanyId('Q686030')).resolves.toBe(
+      '22222222-2222-4222-8222-222222222222'
+    )
   })
 })

--- a/src/lib/pipelineCompanyResolve.test.ts
+++ b/src/lib/pipelineCompanyResolve.test.ts
@@ -194,7 +194,10 @@ describe('resolveOrCreatePipelineCompanyId', () => {
   })
 
   it('returns null when wikidata lookup returns a record without id', async () => {
-    mockApiFetch.mockResolvedValue({ name: 'Alfa Laval', wikidataId: 'Q686030' })
+    mockApiFetch.mockResolvedValue({
+      name: 'Alfa Laval',
+      wikidataId: 'Q686030',
+    })
 
     await expect(findCompanyByWikidataId('Q686030')).resolves.toBeNull()
   })

--- a/src/lib/pipelineCompanyResolve.ts
+++ b/src/lib/pipelineCompanyResolve.ts
@@ -7,6 +7,9 @@ import {
 import { normalizeLei } from './normalizeLei'
 import { pipelineCompanyReadPath } from './pipelineCompanyPath'
 
+const COMPANY_UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 type PipelineCompanyRef = {
   companyId?: string
   companyName?: string
@@ -43,11 +46,35 @@ type PipelineCompanyRecord = {
   lei?: string | null
 }
 
+/** Resolve wikidata Q-id / LEI / UUID prefix to the internal Company.id used for mutations. */
+export async function resolveInternalCompanyId(
+  identifier: string
+): Promise<string> {
+  const trimmed = identifier.trim()
+  if (!trimmed) {
+    throw new Error('Empty company identifier')
+  }
+  if (COMPANY_UUID_RE.test(trimmed)) {
+    return trimmed
+  }
+
+  const company = (await apiFetch(pipelineCompanyReadPath(trimmed)).catch(
+    () => null
+  )) as PipelineCompanyRecord | null
+
+  const internalId = company?.id?.trim()
+  if (!internalId) {
+    throw new Error(
+      `Could not resolve internal company id for identifier: ${trimmed}`
+    )
+  }
+  return internalId
+}
+
 function toCompanyLinkCandidate(
-  record: PipelineCompanyRecord,
-  fallbackId?: string
+  record: PipelineCompanyRecord
 ): CompanyLinkCandidate | null {
-  const id = record.id ?? fallbackId
+  const id = record.id?.trim()
   if (!id) return null
   return {
     id,
@@ -91,7 +118,9 @@ async function findCompanyByIdentifier(
     () => null
   )) as PipelineCompanyRecord | null
 
-  return toCompanyLinkCandidate(existing ?? {}, identifier)
+  if (!existing) return null
+
+  return toCompanyLinkCandidate(existing)
 }
 
 /** Look up which company already owns a Wikidata Q-id in the current API. */
@@ -120,9 +149,10 @@ export async function resolvePipelineCompanyOutcome(
   companyName: string
 ): Promise<PipelineCompanyResolveOutcome> {
   if (jobData.companyId?.trim()) {
+    const companyId = await resolveInternalCompanyId(jobData.companyId)
     return {
       status: 'resolved',
-      companyId: jobData.companyId.trim(),
+      companyId,
       method: 'job_data',
     }
   }

--- a/src/lib/reportRunPersistence.ts
+++ b/src/lib/reportRunPersistence.ts
@@ -12,6 +12,23 @@ export function companyIdFromJobData(data: unknown): string | null {
   return typeof id === 'string' && id.trim() ? id.trim() : null
 }
 
+/** Fields to sync onto an existing ReportRun from the latest job snapshot. */
+export function reportRunSyncFieldsFromJob(input: {
+  companyName?: string | null
+  companyId?: string | null
+  wikidataId?: string | null
+  companyReportId?: string | null
+  batchDbId?: string | null
+}) {
+  return {
+    companyName: input.companyName ?? undefined,
+    ...(input.companyId ? { companyId: input.companyId } : {}),
+    ...(input.wikidataId ? { wikidataId: input.wikidataId } : {}),
+    ...(input.companyReportId ? { companyReportId: input.companyReportId } : {}),
+    ...(input.batchDbId ? { batchDbId: input.batchDbId } : {}),
+  }
+}
+
 /**
  * Resolve `job.data.batchId` to a stable Garbo `Batch.id` for `ReportRun.batchDbId`.
  *

--- a/src/lib/reportRunPersistence.ts
+++ b/src/lib/reportRunPersistence.ts
@@ -24,7 +24,9 @@ export function reportRunSyncFieldsFromJob(input: {
     companyName: input.companyName ?? undefined,
     ...(input.companyId ? { companyId: input.companyId } : {}),
     ...(input.wikidataId ? { wikidataId: input.wikidataId } : {}),
-    ...(input.companyReportId ? { companyReportId: input.companyReportId } : {}),
+    ...(input.companyReportId
+      ? { companyReportId: input.companyReportId }
+      : {}),
     ...(input.batchDbId ? { batchDbId: input.batchDbId } : {}),
   }
 }

--- a/src/startWorkers.ts
+++ b/src/startWorkers.ts
@@ -7,6 +7,7 @@ import {
   resolveReportBatchDbId,
   companyReportIdFromJobData,
   companyIdFromJobData,
+  reportRunSyncFieldsFromJob,
 } from './lib/reportRunPersistence'
 import { DEFAULT_PIPELINE_JOB_OPTIONS } from './lib/pipelineJobOptions'
 import { requestPipelineRunPrune } from './lib/pipelineApiPrune'
@@ -57,11 +58,13 @@ for (const queueName of Object.values(QUEUE_NAMES)) {
       const reportRun = existingReportRun
         ? await prisma.reportRun.update({
             where: { threadId },
-            data: {
-              companyName: companyName ?? undefined,
-              ...(companyReportId ? { companyReportId } : {}),
-              ...(batchDbId ? { batchDbId } : {}),
-            },
+            data: reportRunSyncFieldsFromJob({
+              companyName,
+              companyId,
+              wikidataId,
+              companyReportId,
+              batchDbId,
+            }),
           })
         : await prisma.reportRun.create({
             data: {

--- a/src/workers/guessWikidata.ts
+++ b/src/workers/guessWikidata.ts
@@ -13,7 +13,10 @@ import {
   companyMutationPath,
   pipelineCompanyReadPath,
 } from '../lib/pipelineCompanyPath'
-import { findCompanyByWikidataId, resolveInternalCompanyId } from '../lib/pipelineCompanyResolve'
+import {
+  findCompanyByWikidataId,
+  resolveInternalCompanyId,
+} from '../lib/pipelineCompanyResolve'
 import type { CompanyLinkCandidate } from '../lib/companyLinkResolve'
 import { LEGAL_ENTITY_SUFFIXES } from '../lib/companyLegalEntitySuffixes'
 import { syncCanonicalReportRunCompanyId } from '../lib/pipelineRunCompanyId'

--- a/src/workers/guessWikidata.ts
+++ b/src/workers/guessWikidata.ts
@@ -13,7 +13,7 @@ import {
   companyMutationPath,
   pipelineCompanyReadPath,
 } from '../lib/pipelineCompanyPath'
-import { findCompanyByWikidataId } from '../lib/pipelineCompanyResolve'
+import { findCompanyByWikidataId, resolveInternalCompanyId } from '../lib/pipelineCompanyResolve'
 import type { CompanyLinkCandidate } from '../lib/companyLinkResolve'
 import { LEGAL_ENTITY_SUFFIXES } from '../lib/companyLegalEntitySuffixes'
 import { syncCanonicalReportRunCompanyId } from '../lib/pipelineRunCompanyId'
@@ -109,9 +109,13 @@ async function loadCompanyLinkCandidate(
     () => null
   )) as { id?: string; name?: string; wikidataId?: string | null } | null
 
+  const resolvedId = company?.id?.trim()
+    ? company.id.trim()
+    : await resolveInternalCompanyId(companyId)
+
   return {
-    id: companyId,
-    name: company?.name ?? companyId,
+    id: resolvedId,
+    name: company?.name ?? resolvedId,
     wikidataId: company?.wikidataId ?? null,
   }
 }
@@ -137,13 +141,16 @@ async function requestCompanyLinkIfWikidataConflict(
     throw new Error('Missing companyId on guessWikidata job')
   }
 
+  const resolvedPipelineCompanyId =
+    await resolveInternalCompanyId(pipelineCompanyId)
+
   const wikidataOwner = await findCompanyByWikidataId(wikidata.node)
-  if (!wikidataOwner || wikidataOwner.id === pipelineCompanyId) {
+  if (!wikidataOwner || wikidataOwner.id === resolvedPipelineCompanyId) {
     return true
   }
 
   job.log(
-    `Wikidata ${wikidata.node} belongs to company ${wikidataOwner.id}; pipeline company is ${pipelineCompanyId} — requesting staff confirmation`
+    `Wikidata ${wikidata.node} belongs to company ${wikidataOwner.id}; pipeline company is ${resolvedPipelineCompanyId} — requesting staff confirmation`
   )
 
   const pipelineCompany = await loadCompanyLinkCandidate(pipelineCompanyId)
@@ -188,15 +195,14 @@ async function ensureCompanyLinkBeforeWikidataPersist(
   return requestCompanyLinkIfWikidataConflict(job, companyName, wikidata)
 }
 
-function resolveCompanyIdFromCompanyLinkApproval(job: GuessWikidataJob): {
+async function resolveCompanyIdFromCompanyLinkApproval(
+  job: GuessWikidataJob
+): Promise<{
   companyId: string
   skipWikidataAssign: boolean
-} {
+}> {
   const approved = job.getApprovedBody()
-  const pipelineCompanyId = job.data.companyId
-  if (!pipelineCompanyId) {
-    throw new Error('Missing companyId on guessWikidata job')
-  }
+  const pipelineCompanyId = await resolveInternalCompanyId(job.data.companyId)
 
   if (approved.createNew) {
     throw new Error(
@@ -204,10 +210,11 @@ function resolveCompanyIdFromCompanyLinkApproval(job: GuessWikidataJob): {
     )
   }
 
-  const selectedCompanyId =
+  const selectedRaw =
     typeof approved.companyId === 'string' && approved.companyId.trim()
       ? approved.companyId.trim()
       : pipelineCompanyId
+  const selectedCompanyId = await resolveInternalCompanyId(selectedRaw)
 
   return {
     companyId: selectedCompanyId,
@@ -227,7 +234,9 @@ async function persistApprovedWikidata(
     skipWikidataAssign?: boolean
   }
 ) {
-  const companyId = options.companyId ?? job.data.companyId
+  const companyId = await resolveInternalCompanyId(
+    options.companyId ?? job.data.companyId
+  )
   if (!companyId) {
     throw new Error('Missing companyId on guessWikidata job')
   }
@@ -304,12 +313,19 @@ const guessWikidata = new PipelineWorker<GuessWikidataJob>(
   async (job: GuessWikidataJob) => {
     const {
       companyName,
-      companyId,
+      companyId: rawCompanyId,
       overrideWikidataId,
       wikidataSearchLanguage,
     } = job.data
     if (!companyName) throw new Error('No company name was provided')
-    if (!companyId) throw new Error('No companyId was provided')
+    if (!rawCompanyId) throw new Error('No companyId was provided')
+
+    const companyId = await resolveInternalCompanyId(rawCompanyId)
+    if (companyId !== rawCompanyId) {
+      job.log(`Normalized pipeline companyId ${rawCompanyId} -> ${companyId}`)
+      await job.updateData({ ...job.data, companyId })
+    }
+
     job.log('Company name: ' + companyName)
     job.log('Approval: ' + JSON.stringify(job.data.approval, null, 2))
 
@@ -321,7 +337,7 @@ const guessWikidata = new PipelineWorker<GuessWikidataJob>(
       pendingWikidata?.node
     ) {
       const { companyId: confirmedCompanyId, skipWikidataAssign } =
-        resolveCompanyIdFromCompanyLinkApproval(job)
+        await resolveCompanyIdFromCompanyLinkApproval(job)
       const metadata = job.data.approval?.metadata
 
       await persistApprovedWikidata(job, companyName, pendingWikidata, {

--- a/tests/reportRunPersistence.test.ts
+++ b/tests/reportRunPersistence.test.ts
@@ -1,6 +1,7 @@
 import {
   companyReportIdFromJobData,
   companyIdFromJobData,
+  reportRunSyncFieldsFromJob,
 } from '../src/lib/reportRunPersistence'
 
 describe('companyReportIdFromJobData', () => {
@@ -28,5 +29,37 @@ describe('companyIdFromJobData', () => {
     expect(companyIdFromJobData({})).toBeNull()
     expect(companyIdFromJobData({ companyId: '  ' })).toBeNull()
     expect(companyIdFromJobData(null)).toBeNull()
+  })
+})
+
+describe('reportRunSyncFieldsFromJob', () => {
+  it('includes companyId and wikidataId when present', () => {
+    expect(
+      reportRunSyncFieldsFromJob({
+        companyName: 'Alfa Laval',
+        companyId: '11111111-1111-4111-8111-111111111111',
+        wikidataId: 'Q686030',
+        companyReportId: 'cr-1',
+        batchDbId: 'batch-1',
+      })
+    ).toEqual({
+      companyName: 'Alfa Laval',
+      companyId: '11111111-1111-4111-8111-111111111111',
+      wikidataId: 'Q686030',
+      companyReportId: 'cr-1',
+      batchDbId: 'batch-1',
+    })
+  })
+
+  it('omits empty companyId and wikidataId so stale values are not cleared', () => {
+    expect(
+      reportRunSyncFieldsFromJob({
+        companyName: 'Alfa Laval',
+        companyId: null,
+        wikidataId: null,
+      })
+    ).toEqual({
+      companyName: 'Alfa Laval',
+    })
   })
 })


### PR DESCRIPTION
## Summary
- Add `resolveInternalCompanyId` so pipeline workers normalize Wikidata Q-ids and LEIs to internal company UUIDs before API mutations.
- Fix `guessWikidata` company-link approval and persist paths that previously sent Q-ids to `/companies/:id` and failed validation.
- Stop creating ghost company candidates when identifier lookups fail (timeouts, 500s, or records without `id`).
- Sync `companyId` and `wikidataId` when updating existing `ReportRun` rows in `startWorkers`, so canonical company IDs from later pipeline stages are not left stale.

## Test plan
- [x] `npm test -- src/lib/pipelineCompanyResolve.test.ts tests/reportRunPersistence.test.ts`
- [ ] Restart garbo workers locally and approve a Wikidata company-link conflict — persist should succeed with a UUID
- [ ] Run a pipeline thread where precheck resolves company ID after the first job — confirm `ReportRun.companyId` updates on later job completion


Made with [Cursor](https://cursor.com)