### PR TITLE
Add cached coverage registry status columns

### DIFF
--- a/prisma/migrations/20260714120000_coverage_registry_cache/migration.sql
+++ b/prisma/migrations/20260714120000_coverage_registry_cache/migration.sql
@@ -1,0 +1,16 @@
+ALTER TABLE "coverage_list_years"
+ADD COLUMN "has_any_report_count" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN "prod_ready_count" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN "no_report_count" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN "registry_refreshed_at" TIMESTAMP(3);
+
+ALTER TABLE "coverage_list_entries"
+ADD COLUMN "registry_report_count" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN "has_prod_ready_report" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "registry_refreshed_at" TIMESTAMP(3);
+
+CREATE INDEX "coverage_list_entries_year_id_registry_report_count_idx"
+ON "coverage_list_entries"("year_id", "registry_report_count");
+
+CREATE INDEX "coverage_list_entries_year_id_has_prod_ready_report_idx"
+ON "coverage_list_entries"("year_id", "has_prod_ready_report");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -625,6 +625,10 @@ model CoverageListYear {
   matchedCount     Int                 @default(0) @map("matched_count")
   ambiguousCount   Int                 @default(0) @map("ambiguous_count")
   coveragePercent  Int                 @default(0) @map("coverage_percent")
+  hasAnyReportCount  Int                 @default(0) @map("has_any_report_count")
+  prodReadyCount     Int                 @default(0) @map("prod_ready_count")
+  noReportCount      Int                 @default(0) @map("no_report_count")
+  registryRefreshedAt DateTime?          @map("registry_refreshed_at")
   createdAt        DateTime            @default(now()) @map("created_at")
   updatedAt        DateTime            @updatedAt @map("updated_at")
   entries          CoverageListEntry[]
@@ -646,8 +650,15 @@ model CoverageListEntry {
   matchedCompany   Company?         @relation(fields: [matchedCompanyId], references: [id], onDelete: SetNull)
   /// Staff confirmed this list name is not in the DB (overrides ambiguous suggestions).
   matchConfirmedMissing Boolean     @default(false) @map("match_confirmed_missing")
+  /// Cached registry report count for fast coverage filters.
+  registryReportCount   Int         @default(0) @map("registry_report_count")
+  /// Cached flag: at least one linked registry report is prod-ready.
+  hasProdReadyReport    Boolean     @default(false) @map("has_prod_ready_report")
+  registryRefreshedAt   DateTime?   @map("registry_refreshed_at")
 
   @@index([yearId])
   @@index([matchedCompanyId])
+  @@index([yearId, registryReportCount])
+  @@index([yearId, hasProdReadyReport])
   @@map("coverage_list_entries")
 }


### PR DESCRIPTION
## Summary

- Adds migration `20260714120000_coverage_registry_cache`
- Caches registry report counts and prod-ready flags on `coverage_list_years` and `coverage_list_entries`
- Supports fast server-side registry filters in Validate coverage list performance work

## Paired release

- **Blocks:** [unearth-api PR #65](https://github.com/UnearthData/api/pull/65) — do not deploy API until this migration is applied on the target environment
- **Frontend:** [validate-frontend PR #268](https://github.com/Klimatbyran/validate-frontend/pull/268) — deploy after API

## Rollout order (stage)

1. Merge + deploy **this Garbo PR** to stage (`npm run migrate` via Garbo job)
2. Merge + deploy **API #65** to stage
3. Run backfill once on stage API pod/job:
   `node --import dotenv/config --import tsx scripts/backfill-coverage-year-registry.ts`
4. Merge + deploy **frontend #268** to stage

## Rollback

- Roll back API/frontend first; columns are additive with defaults and safe to leave in place
- To remove columns: new down migration (not included here)

## Checklist

- [x] Migration + `schema.prisma` updated
- [ ] QA on stage after migrate
- [ ] API #65 deployed only after stage migrate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive schema-only change with NOT NULL defaults; no existing query or app logic changed in this PR, though deploy must precede the dependent API.
> 
> **Overview**
> Adds an additive migration and matching Prisma fields so **Validate coverage** can filter by registry report status without heavy joins at query time.
> 
> **`coverage_list_years`** gains rolled-up counters (`has_any_report_count`, `prod_ready_count`, `no_report_count`) plus `registry_refreshed_at`. **`coverage_list_entries`** gains per-line `registry_report_count`, `has_prod_ready_report`, and `registry_refreshed_at`, with composite indexes on `(year_id, registry_report_count)` and `(year_id, has_prod_ready_report)` for server-side filters.
> 
> All new columns use safe defaults (`0` / `false`); population is expected via the paired API backfill after deploy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f257e86acf8bb3b07bbba5b246d8f2edf32fa2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->