### PR TITLE
[Prod] Patch Version Bump v6.0.8

### DIFF
--- a/k8s/overlays/production/kustomization.yaml
+++ b/k8s/overlays/production/kustomization.yaml
@@ -7,4 +7,4 @@ patches:
   - path: ingress-patch.yaml
 images:
   - name: ghcr.io/klimatbyran/garbo
-    newTag: '6.0.7' # {"$imagepolicy": "flux-system:garbo:tag"}
+    newTag: '6.0.8' # {"$imagepolicy": "flux-system:garbo:tag"}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo",
-  "version": "6.0.8-rc.1",
+  "version": "6.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo",
-      "version": "6.0.8-rc.1",
+      "version": "6.0.8",
       "hasInstallScript": true,
       "license": "MIT License",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garbo",
-  "version": "6.0.8-rc.1",
+  "version": "6.0.8",
   "description": "",
   "type": "module",
   "exports": {


### PR DESCRIPTION
# Production Release PR

## Release Type

- [x] Patch version bump

### Rollback Version

v6.0.7

## Environment Promotion

Promotes coverage registry cache migration and related API support from staging to production.

## What''s Being Released

- DB migration `20260714120000_coverage_registry_cache` (cached registry report status columns)
- Prerequisite for unearth-api coverage list performance release (#1372)

## Deployment Notes

**Deploy Garbo before unearth-api v1.6.2.**

1. Merge this PR
2. Verify migration init container: `kubectl -n garbo logs deploy/garbo -c db-migration --tail=20`
3. Expect: `20260714120000_coverage_registry_cache` applied
4. Then merge API prod PR and run coverage registry backfill

## Checklist

- [x] Version updated (`6.0.8`)
- [x] QA verified in staging
- [x] Rollback version recorded (v6.0.7)
- [x] Title follows: `[Prod] Patch Version Bump v6.0.8`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Prod promotion with a required DB migration and ordering dependency on unearth-api; incorrect deploy order could break coverage list/backfill until Garbo is live.
> 
> **Overview**
> Production release PR that **sets Garbo to `6.0.8`** (down from `6.0.9-rc.0` in `package.json` and `package-lock.json`) for the prod promotion.
> 
> Per release notes, this tag ships the **`20260714120000_coverage_registry_cache`** DB migration (cached registry report status) and must be deployed **before** unearth-api v1.6.2 and the coverage registry backfill. Rollback target is **v6.0.7**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d492648649038eb7232b1114ccb6028aad4910c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->