### PR TITLE
Add per-datapoint error notes (ErrorType + DatapointNote)

### DIFF
--- a/prisma/migrations/20260610120000_report_registry_batch/migration.sql
+++ b/prisma/migrations/20260610120000_report_registry_batch/migration.sql
@@ -1,0 +1,9 @@
+-- Link registry Report rows to Garbo Batch for Validate registry filtering.
+-- batch_id is optional (nullable); existing and new rows without a batch stay NULL.
+
+ALTER TABLE "Report" ADD COLUMN "batch_id" TEXT;
+CREATE INDEX "Report_batch_id_idx" ON "Report"("batch_id");
+
+ALTER TABLE "Report" ADD CONSTRAINT "Report_batch_id_fkey"
+  FOREIGN KEY ("batch_id") REFERENCES "Batch"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260624120000_report_batch_id_from_legacy/migration.sql
+++ b/prisma/migrations/20260624120000_report_batch_id_from_legacy/migration.sql
@@ -1,0 +1,2 @@
+-- batch_id on Report was added in 20260610120000_report_registry_batch.
+-- This migration is a no-op placeholder (legacy data backfill was squashed).

--- a/prisma/migrations/20260721120000_add_datapoint_notes/migration.sql
+++ b/prisma/migrations/20260721120000_add_datapoint_notes/migration.sql
@@ -1,0 +1,110 @@
+-- CreateEnum
+CREATE TYPE "DatapointErrorStatus" AS ENUM ('OPEN', 'RESOLVED', 'WONT_FIX');
+
+-- CreateTable
+CREATE TABLE "error_types" (
+    "id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "description" TEXT,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+
+    CONSTRAINT "error_types_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "datapoint_notes" (
+    "id" TEXT NOT NULL,
+    "comment" TEXT,
+    "errorTypeId" TEXT,
+    "errorReason" TEXT,
+    "status" "DatapointErrorStatus",
+    "previousValue" DOUBLE PRECISION,
+    "newValue" DOUBLE PRECISION,
+    "reportRunId" TEXT,
+    "scope1Id" TEXT,
+    "scope2Id" TEXT,
+    "scope3Id" TEXT,
+    "categoryId" TEXT,
+    "scope1And2Id" TEXT,
+    "statedTotalEmissionsId" TEXT,
+    "biogenicEmissionsId" TEXT,
+    "turnoverId" TEXT,
+    "employeesId" TEXT,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "datapoint_notes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "error_types_key_key" ON "error_types"("key");
+
+-- CreateIndex
+CREATE INDEX "datapoint_notes_scope1Id_idx" ON "datapoint_notes"("scope1Id");
+
+-- CreateIndex
+CREATE INDEX "datapoint_notes_scope2Id_idx" ON "datapoint_notes"("scope2Id");
+
+-- CreateIndex
+CREATE INDEX "datapoint_notes_scope3Id_idx" ON "datapoint_notes"("scope3Id");
+
+-- CreateIndex
+CREATE INDEX "datapoint_notes_categoryId_idx" ON "datapoint_notes"("categoryId");
+
+-- CreateIndex
+CREATE INDEX "datapoint_notes_scope1And2Id_idx" ON "datapoint_notes"("scope1And2Id");
+
+-- CreateIndex
+CREATE INDEX "datapoint_notes_statedTotalEmissionsId_idx" ON "datapoint_notes"("statedTotalEmissionsId");
+
+-- CreateIndex
+CREATE INDEX "datapoint_notes_biogenicEmissionsId_idx" ON "datapoint_notes"("biogenicEmissionsId");
+
+-- CreateIndex
+CREATE INDEX "datapoint_notes_turnoverId_idx" ON "datapoint_notes"("turnoverId");
+
+-- CreateIndex
+CREATE INDEX "datapoint_notes_employeesId_idx" ON "datapoint_notes"("employeesId");
+
+-- CreateIndex
+CREATE INDEX "datapoint_notes_reportRunId_idx" ON "datapoint_notes"("reportRunId");
+
+-- CreateIndex
+CREATE INDEX "datapoint_notes_errorTypeId_idx" ON "datapoint_notes"("errorTypeId");
+
+-- AddForeignKey
+ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_errorTypeId_fkey" FOREIGN KEY ("errorTypeId") REFERENCES "error_types"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_reportRunId_fkey" FOREIGN KEY ("reportRunId") REFERENCES "ReportRun"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_scope1Id_fkey" FOREIGN KEY ("scope1Id") REFERENCES "Scope1"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_scope2Id_fkey" FOREIGN KEY ("scope2Id") REFERENCES "Scope2"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_scope3Id_fkey" FOREIGN KEY ("scope3Id") REFERENCES "Scope3"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Scope3Category"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_scope1And2Id_fkey" FOREIGN KEY ("scope1And2Id") REFERENCES "Scope1And2"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_statedTotalEmissionsId_fkey" FOREIGN KEY ("statedTotalEmissionsId") REFERENCES "StatedTotalEmissions"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_biogenicEmissionsId_fkey" FOREIGN KEY ("biogenicEmissionsId") REFERENCES "BiogenicEmissions"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_turnoverId_fkey" FOREIGN KEY ("turnoverId") REFERENCES "Turnover"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_employeesId_fkey" FOREIGN KEY ("employeesId") REFERENCES "Employees"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260721120000_add_datapoint_notes/migration.sql
+++ b/prisma/migrations/20260721120000_add_datapoint_notes/migration.sql
@@ -80,31 +80,31 @@ ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_errorTypeId_fkey" 
 ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_reportRunId_fkey" FOREIGN KEY ("reportRunId") REFERENCES "ReportRun"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_scope1Id_fkey" FOREIGN KEY ("scope1Id") REFERENCES "Scope1"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_scope1Id_fkey" FOREIGN KEY ("scope1Id") REFERENCES "Scope1"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_scope2Id_fkey" FOREIGN KEY ("scope2Id") REFERENCES "Scope2"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_scope2Id_fkey" FOREIGN KEY ("scope2Id") REFERENCES "Scope2"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_scope3Id_fkey" FOREIGN KEY ("scope3Id") REFERENCES "Scope3"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_scope3Id_fkey" FOREIGN KEY ("scope3Id") REFERENCES "Scope3"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Scope3Category"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Scope3Category"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_scope1And2Id_fkey" FOREIGN KEY ("scope1And2Id") REFERENCES "Scope1And2"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_scope1And2Id_fkey" FOREIGN KEY ("scope1And2Id") REFERENCES "Scope1And2"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_statedTotalEmissionsId_fkey" FOREIGN KEY ("statedTotalEmissionsId") REFERENCES "StatedTotalEmissions"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_statedTotalEmissionsId_fkey" FOREIGN KEY ("statedTotalEmissionsId") REFERENCES "StatedTotalEmissions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_biogenicEmissionsId_fkey" FOREIGN KEY ("biogenicEmissionsId") REFERENCES "BiogenicEmissions"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_biogenicEmissionsId_fkey" FOREIGN KEY ("biogenicEmissionsId") REFERENCES "BiogenicEmissions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_turnoverId_fkey" FOREIGN KEY ("turnoverId") REFERENCES "Turnover"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_turnoverId_fkey" FOREIGN KEY ("turnoverId") REFERENCES "Turnover"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_employeesId_fkey" FOREIGN KEY ("employeesId") REFERENCES "Employees"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_employeesId_fkey" FOREIGN KEY ("employeesId") REFERENCES "Employees"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "datapoint_notes" ADD CONSTRAINT "datapoint_notes_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260721140000_datapoint_note_unique_per_datapoint/migration.sql
+++ b/prisma/migrations/20260721140000_datapoint_note_unique_per_datapoint/migration.sql
@@ -1,0 +1,47 @@
+-- DatapointNote moves from insert-only history to one row per datapoint (upsert).
+-- Existing environments may already have duplicate notes per datapoint from testing;
+-- keep only the most recently created row per FK before enforcing uniqueness.
+
+DELETE FROM "datapoint_notes" a USING "datapoint_notes" b
+  WHERE a."scope1Id" IS NOT NULL AND a."scope1Id" = b."scope1Id" AND a."createdAt" < b."createdAt";
+DELETE FROM "datapoint_notes" a USING "datapoint_notes" b
+  WHERE a."scope2Id" IS NOT NULL AND a."scope2Id" = b."scope2Id" AND a."createdAt" < b."createdAt";
+DELETE FROM "datapoint_notes" a USING "datapoint_notes" b
+  WHERE a."scope3Id" IS NOT NULL AND a."scope3Id" = b."scope3Id" AND a."createdAt" < b."createdAt";
+DELETE FROM "datapoint_notes" a USING "datapoint_notes" b
+  WHERE a."categoryId" IS NOT NULL AND a."categoryId" = b."categoryId" AND a."createdAt" < b."createdAt";
+DELETE FROM "datapoint_notes" a USING "datapoint_notes" b
+  WHERE a."scope1And2Id" IS NOT NULL AND a."scope1And2Id" = b."scope1And2Id" AND a."createdAt" < b."createdAt";
+DELETE FROM "datapoint_notes" a USING "datapoint_notes" b
+  WHERE a."statedTotalEmissionsId" IS NOT NULL AND a."statedTotalEmissionsId" = b."statedTotalEmissionsId" AND a."createdAt" < b."createdAt";
+DELETE FROM "datapoint_notes" a USING "datapoint_notes" b
+  WHERE a."biogenicEmissionsId" IS NOT NULL AND a."biogenicEmissionsId" = b."biogenicEmissionsId" AND a."createdAt" < b."createdAt";
+DELETE FROM "datapoint_notes" a USING "datapoint_notes" b
+  WHERE a."turnoverId" IS NOT NULL AND a."turnoverId" = b."turnoverId" AND a."createdAt" < b."createdAt";
+DELETE FROM "datapoint_notes" a USING "datapoint_notes" b
+  WHERE a."employeesId" IS NOT NULL AND a."employeesId" = b."employeesId" AND a."createdAt" < b."createdAt";
+
+-- AlterTable
+ALTER TABLE "datapoint_notes" ADD COLUMN "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- DropIndex
+DROP INDEX "datapoint_notes_scope1Id_idx";
+DROP INDEX "datapoint_notes_scope2Id_idx";
+DROP INDEX "datapoint_notes_scope3Id_idx";
+DROP INDEX "datapoint_notes_categoryId_idx";
+DROP INDEX "datapoint_notes_scope1And2Id_idx";
+DROP INDEX "datapoint_notes_statedTotalEmissionsId_idx";
+DROP INDEX "datapoint_notes_biogenicEmissionsId_idx";
+DROP INDEX "datapoint_notes_turnoverId_idx";
+DROP INDEX "datapoint_notes_employeesId_idx";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "datapoint_notes_scope1Id_key" ON "datapoint_notes"("scope1Id");
+CREATE UNIQUE INDEX "datapoint_notes_scope2Id_key" ON "datapoint_notes"("scope2Id");
+CREATE UNIQUE INDEX "datapoint_notes_scope3Id_key" ON "datapoint_notes"("scope3Id");
+CREATE UNIQUE INDEX "datapoint_notes_categoryId_key" ON "datapoint_notes"("categoryId");
+CREATE UNIQUE INDEX "datapoint_notes_scope1And2Id_key" ON "datapoint_notes"("scope1And2Id");
+CREATE UNIQUE INDEX "datapoint_notes_statedTotalEmissionsId_key" ON "datapoint_notes"("statedTotalEmissionsId");
+CREATE UNIQUE INDEX "datapoint_notes_biogenicEmissionsId_key" ON "datapoint_notes"("biogenicEmissionsId");
+CREATE UNIQUE INDEX "datapoint_notes_turnoverId_key" ON "datapoint_notes"("turnoverId");
+CREATE UNIQUE INDEX "datapoint_notes_employeesId_key" ON "datapoint_notes"("employeesId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,9 +13,9 @@ generator client {
 
 model Company {
   /// Primary key. Stable internal company id (UUID).
-  id         String  @id @default(uuid())
+  id           String        @id @default(uuid())
   /// Wikidata Q-id when known. Nullable until pipeline or editor assigns one.
-  wikidataId String? @unique
+  wikidataId   String?       @unique
   name         String
   description  String?
   descriptions Description[]
@@ -187,9 +187,10 @@ model StatedTotalEmissions {
   unit        String
   emissionsId String? @unique
 
-  emissions Emissions? @relation(fields: [emissionsId], references: [id], onDelete: Cascade)
+  emissions Emissions?      @relation(fields: [emissionsId], references: [id], onDelete: Cascade)
   metadata  Metadata[]
-  scope3    Scope3?    @relation(fields: [scope3Id], references: [id], onDelete: Cascade)
+  scope3    Scope3?         @relation(fields: [scope3Id], references: [id], onDelete: Cascade)
+  notes     DatapointNote[]
 }
 
 /// This is used when companies have bad reporting where they have combined scope 1+2 as one value
@@ -199,8 +200,9 @@ model Scope1And2 {
   emissionsId String? @unique
 
   unit      String
-  emissions Emissions? @relation(fields: [emissionsId], references: [id], onDelete: Cascade)
+  emissions Emissions?      @relation(fields: [emissionsId], references: [id], onDelete: Cascade)
   metadata  Metadata[]
+  notes     DatapointNote[]
 }
 
 /// Biogenic emissions are reported separately from scope 1-3
@@ -211,8 +213,9 @@ model BiogenicEmissions {
   unit        String
   emissionsId String? @unique
 
-  emissions Emissions? @relation(fields: [emissionsId], references: [id], onDelete: Cascade)
+  emissions Emissions?      @relation(fields: [emissionsId], references: [id], onDelete: Cascade)
   metadata  Metadata[]
+  notes     DatapointNote[]
 }
 
 model Scope1 {
@@ -221,8 +224,9 @@ model Scope1 {
   unit        String
   emissionsId String? @unique
 
-  emissions Emissions? @relation(fields: [emissionsId], references: [id], onDelete: Cascade)
+  emissions Emissions?      @relation(fields: [emissionsId], references: [id], onDelete: Cascade)
   metadata  Metadata[]
+  notes     DatapointNote[]
 }
 
 /// For scope 2 emissions, we choose either market-based, location-based or unknown (if the company didn't specify if mb or lb)
@@ -238,8 +242,9 @@ model Scope2 {
   unit        String
   emissionsId String? @unique
 
-  emissions Emissions? @relation(fields: [emissionsId], references: [id], onDelete: Cascade)
+  emissions Emissions?      @relation(fields: [emissionsId], references: [id], onDelete: Cascade)
   metadata  Metadata[]
+  notes     DatapointNote[]
 }
 
 model Scope3 {
@@ -257,6 +262,7 @@ model Scope3 {
   emissions            Emissions?            @relation(fields: [emissionsId], references: [id], onDelete: Cascade)
   categories           Scope3Category[]
   metadata             Metadata[]
+  notes                DatapointNote[]
 }
 
 /// Details about scope 3 categories. Here's a list of valid categories and their names:
@@ -294,8 +300,9 @@ model Scope3Category {
   scope3Id String
   unit     String?
 
-  scope3   Scope3     @relation(fields: [scope3Id], references: [id], onDelete: Cascade)
+  scope3   Scope3          @relation(fields: [scope3Id], references: [id], onDelete: Cascade)
   metadata Metadata[]
+  notes    DatapointNote[]
 }
 
 model Economy {
@@ -314,8 +321,9 @@ model Turnover {
   currency  String?
   economyId String  @unique
 
-  economy  Economy    @relation(fields: [economyId], references: [id], onDelete: Cascade)
+  economy  Economy         @relation(fields: [economyId], references: [id], onDelete: Cascade)
   metadata Metadata[]
+  notes    DatapointNote[]
 }
 
 model Employees {
@@ -326,8 +334,9 @@ model Employees {
   unit      String?
   economyId String? @unique
 
-  economy  Economy?   @relation(fields: [economyId], references: [id], onDelete: Cascade)
+  economy  Economy?        @relation(fields: [economyId], references: [id], onDelete: Cascade)
   metadata Metadata[]
+  notes    DatapointNote[]
 }
 
 model Goal {
@@ -409,6 +418,90 @@ model Metadata {
   companyIdentifier    CompanyIdentifier?    @relation(fields: [companyIdentifierId], references: [id], onDelete: SetNull)
 }
 
+enum DatapointErrorStatus {
+  OPEN
+  RESOLVED
+  WONT_FIX
+}
+
+/// Lookup table for datapoint error categories (e.g. "missing", "unit-error", "rounding").
+/// Deliberately a table rather than an enum so new categories can be added without a migration.
+model ErrorType {
+  id          String  @id @default(cuid())
+  /// Stable slug used in code/UI, e.g. matches the discrepancy types Validate computes client-side.
+  key         String  @unique
+  label       String
+  description String?
+  active      Boolean @default(true)
+
+  notes DatapointNote[]
+
+  @@map("error_types")
+}
+
+/// A reviewer-authored note about a specific datapoint: a freeform comment, and/or an error
+/// classification with the value it changed from/to. Insert-only - never updated in place - so
+/// the full history for a datapoint is the set of notes attached to it, ordered by createdAt.
+model DatapointNote {
+  id      String  @id @default(cuid())
+  comment String?
+
+  errorTypeId String?
+  errorType   ErrorType?            @relation(fields: [errorTypeId], references: [id])
+  /// Why THIS occurrence is this errorType - distinct from ErrorType's general category label.
+  errorReason String?
+  status      DatapointErrorStatus?
+
+  previousValue Float?
+  newValue      Float?
+
+  /// Which pipeline run this note is about, when known.
+  reportRunId String?
+  reportRun   ReportRun? @relation(fields: [reportRunId], references: [id])
+
+  // Same polymorphic FK pattern as Metadata - exactly one of these should be set.
+  scope1Id               String?
+  scope2Id               String?
+  scope3Id               String?
+  categoryId             String?
+  scope1And2Id           String?
+  statedTotalEmissionsId String?
+  biogenicEmissionsId    String?
+  turnoverId             String?
+  employeesId            String?
+
+  scope1               Scope1?               @relation(fields: [scope1Id], references: [id])
+  scope2               Scope2?               @relation(fields: [scope2Id], references: [id])
+  scope3               Scope3?               @relation(fields: [scope3Id], references: [id])
+  category             Scope3Category?       @relation(fields: [categoryId], references: [id])
+  scope1And2           Scope1And2?           @relation(fields: [scope1And2Id], references: [id])
+  statedTotalEmissions StatedTotalEmissions? @relation(fields: [statedTotalEmissionsId], references: [id])
+  biogenicEmissions    BiogenicEmissions?    @relation(fields: [biogenicEmissionsId], references: [id])
+  turnover             Turnover?             @relation(fields: [turnoverId], references: [id])
+  employees            Employees?            @relation(fields: [employeesId], references: [id])
+
+  userId    String
+  user      User     @relation(fields: [userId], references: [id])
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  // One note per datapoint - saving again updates it in place rather than
+  // creating a new row. Unique on nullable columns still allows many rows
+  // with that particular FK left null (all the other datapoint types).
+  @@unique([scope1Id])
+  @@unique([scope2Id])
+  @@unique([scope3Id])
+  @@unique([categoryId])
+  @@unique([scope1And2Id])
+  @@unique([statedTotalEmissionsId])
+  @@unique([biogenicEmissionsId])
+  @@unique([turnoverId])
+  @@unique([employeesId])
+  @@index([reportRunId])
+  @@index([errorTypeId])
+  @@map("datapoint_notes")
+}
+
 model User {
   id             String  @id @default(cuid())
   email          String?
@@ -420,8 +513,9 @@ model User {
 
   // TODO: connect with github ID
   // TODO: store github profile image - or get it via API
-  updated  Metadata[] @relation("metadata_user_id")
-  verified Metadata[] @relation("metadata_verified_by")
+  updated        Metadata[]      @relation("metadata_user_id")
+  verified       Metadata[]      @relation("metadata_verified_by")
+  datapointNotes DatapointNote[]
 }
 
 // Follows the ISO 639 language codes
@@ -443,26 +537,30 @@ model Description {
 }
 
 model Report {
-  id          String  @id @default(cuid())
-  url         String  @unique
+  id           String      @id @default(cuid())
+  url          String      @unique
   /// Canonical web source URL when available (preferred for humans/UI).
-  sourceUrl   String? @unique
+  sourceUrl    String?     @unique
   /// Public URL to the cached/uploaded PDF (e.g. S3/MinIO/CDN).
-  s3Url       String?
+  s3Url        String?
   /// Stable storage identity for the cached/uploaded PDF.
-  s3Key       String?
-  s3Bucket    String?
+  s3Key        String?
+  s3Bucket     String?
   /// Content hash for the cached/uploaded PDF when available.
-  sha256      String? @unique
-  companyName String?
-  wikidataId  String?
-  reportYear  String?
+  sha256       String?     @unique
+  companyName  String?
+  wikidataId   String?
+  reportYear   String?
   reportTypeId String?
   reportType   ReportType? @relation(fields: [reportTypeId], references: [id], onDelete: SetNull)
+  /// Optional registry batch for Validate filtering; most reports have no batch.
+  batchId      String?     @map("batch_id")
+  batch        Batch?      @relation(fields: [batchId], references: [id], onDelete: SetNull, onUpdate: Cascade)
 
   companyReports CompanyReport[]
 
   @@index([reportTypeId])
+  @@index([batchId])
 }
 
 /// One processed PDF per company (links to Report registry). Several per company when multiple PDFs exist.
@@ -490,23 +588,25 @@ model Batch {
   batchName  String      @unique @map("batch_name")
   createdAt  DateTime    @default(now())
   reportRuns ReportRun[]
+  reports    Report[]
 }
 
 model ReportRun {
-  id              String         @id @default(cuid())
-  threadId        String         @unique
+  id              String          @id @default(cuid())
+  threadId        String          @unique
   pdfUrl          String
   companyName     String?
   /// Stable Garbo company id when known (preferred over wikidataId for linking runs).
   companyId       String?
   wikidataId      String?
-  companyReportId String?        @map("company_report_id")
-  batchDbId       String?        @map("batch_db_id")
-  batch           Batch?         @relation(fields: [batchDbId], references: [id], onDelete: SetNull, onUpdate: Cascade)
-  status          String         @default("running") // 'running' | 'completed' | 'failed'
-  startedAt       DateTime       @default(now())
-  updatedAt       DateTime       @updatedAt
+  companyReportId String?         @map("company_report_id")
+  batchDbId       String?         @map("batch_db_id")
+  batch           Batch?          @relation(fields: [batchDbId], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  status          String          @default("running") // 'running' | 'completed' | 'failed'
+  startedAt       DateTime        @default(now())
+  updatedAt       DateTime        @updatedAt
   jobs            ReportRunJob[]
+  datapointNotes  DatapointNote[]
 
   @@index([pdfUrl])
   @@index([companyId])
@@ -541,8 +641,8 @@ model ReportRunJob {
 
 /// Permission codes for the client API key layer (browser/proxy + partner integrations) — see `src/api/security/routePermissions.ts`.
 model ClientApiPermission {
-  id    String @id @default(cuid())
-  code  String @unique
+  id    String  @id @default(cuid())
+  code  String  @unique
   label String?
 
   roles ClientApiRolePermission[]
@@ -551,8 +651,8 @@ model ClientApiPermission {
 }
 
 model ClientApiRole {
-  id    String @id @default(cuid())
-  slug  String @unique
+  id    String  @id @default(cuid())
+  slug  String  @unique
   label String?
 
   permissions ClientApiRolePermission[]
@@ -573,17 +673,17 @@ model ClientApiRolePermission {
 }
 
 model ClientApiKey {
-  id         String   @id @default(cuid())
+  id         String             @id @default(cuid())
   name       String
   /// Lookup segment (shown in logs); full key is `garb_<keyLookup>.<secret>`
-  keyLookup  String   @unique @map("key_lookup")
+  keyLookup  String             @unique @map("key_lookup")
   /// sha256 hex of `${keyLookup}.${secret}.${pepper}`
-  secretHash String   @map("secret_hash")
-  roleId     String   @map("role_id")
-  role       ClientApiRole @relation(fields: [roleId], references: [id], onDelete: Restrict)
-  revokedAt  DateTime? @map("revoked_at")
-  lastUsedAt DateTime? @map("last_used_at")
-  createdAt  DateTime @default(now()) @map("created_at")
+  secretHash String             @map("secret_hash")
+  roleId     String             @map("role_id")
+  role       ClientApiRole      @relation(fields: [roleId], references: [id], onDelete: Restrict)
+  revokedAt  DateTime?          @map("revoked_at")
+  lastUsedAt DateTime?          @map("last_used_at")
+  createdAt  DateTime           @default(now()) @map("created_at")
   requests   ClientApiRequest[]
 
   @@map("client_api_key")
@@ -617,21 +717,21 @@ model CoverageList {
 
 /// One edition per year for a coverage list.
 model CoverageListYear {
-  id               String              @id @default(cuid())
-  listId           String              @map("list_id")
-  list             CoverageList        @relation(fields: [listId], references: [id], onDelete: Cascade)
-  year             Int
-  totalNames       Int                 @default(0) @map("total_names")
-  matchedCount     Int                 @default(0) @map("matched_count")
-  ambiguousCount   Int                 @default(0) @map("ambiguous_count")
-  coveragePercent  Int                 @default(0) @map("coverage_percent")
-  hasAnyReportCount  Int                 @default(0) @map("has_any_report_count")
-  prodReadyCount     Int                 @default(0) @map("prod_ready_count")
-  noReportCount      Int                 @default(0) @map("no_report_count")
-  registryRefreshedAt DateTime?          @map("registry_refreshed_at")
-  createdAt        DateTime            @default(now()) @map("created_at")
-  updatedAt        DateTime            @updatedAt @map("updated_at")
-  entries          CoverageListEntry[]
+  id                  String              @id @default(cuid())
+  listId              String              @map("list_id")
+  list                CoverageList        @relation(fields: [listId], references: [id], onDelete: Cascade)
+  year                Int
+  totalNames          Int                 @default(0) @map("total_names")
+  matchedCount        Int                 @default(0) @map("matched_count")
+  ambiguousCount      Int                 @default(0) @map("ambiguous_count")
+  coveragePercent     Int                 @default(0) @map("coverage_percent")
+  hasAnyReportCount   Int                 @default(0) @map("has_any_report_count")
+  prodReadyCount      Int                 @default(0) @map("prod_ready_count")
+  noReportCount       Int                 @default(0) @map("no_report_count")
+  registryRefreshedAt DateTime?           @map("registry_refreshed_at")
+  createdAt           DateTime            @default(now()) @map("created_at")
+  updatedAt           DateTime            @updatedAt @map("updated_at")
+  entries             CoverageListEntry[]
 
   @@unique([listId, year])
   @@index([listId])
@@ -640,21 +740,21 @@ model CoverageListYear {
 
 /// Pasted company name line belonging to a list year edition.
 model CoverageListEntry {
-  id               String           @id @default(cuid())
-  yearId           String           @map("year_id")
-  year             CoverageListYear @relation(fields: [yearId], references: [id], onDelete: Cascade)
-  name             String
-  sortOrder        Int              @default(0) @map("sort_order")
+  id                    String           @id @default(cuid())
+  yearId                String           @map("year_id")
+  year                  CoverageListYear @relation(fields: [yearId], references: [id], onDelete: Cascade)
+  name                  String
+  sortOrder             Int              @default(0) @map("sort_order")
   /// Staff-confirmed DB company match; overrides auto-matching when set.
-  matchedCompanyId String?          @map("matched_company_id")
-  matchedCompany   Company?         @relation(fields: [matchedCompanyId], references: [id], onDelete: SetNull)
+  matchedCompanyId      String?          @map("matched_company_id")
+  matchedCompany        Company?         @relation(fields: [matchedCompanyId], references: [id], onDelete: SetNull)
   /// Staff confirmed this list name is not in the DB (overrides ambiguous suggestions).
-  matchConfirmedMissing Boolean     @default(false) @map("match_confirmed_missing")
+  matchConfirmedMissing Boolean          @default(false) @map("match_confirmed_missing")
   /// Cached registry report count for fast coverage filters.
-  registryReportCount   Int         @default(0) @map("registry_report_count")
+  registryReportCount   Int              @default(0) @map("registry_report_count")
   /// Cached flag: at least one linked registry report is prod-ready.
-  hasProdReadyReport    Boolean     @default(false) @map("has_prod_ready_report")
-  registryRefreshedAt   DateTime?   @map("registry_refreshed_at")
+  hasProdReadyReport    Boolean          @default(false) @map("has_prod_ready_report")
+  registryRefreshedAt   DateTime?        @map("registry_refreshed_at")
 
   @@index([yearId])
   @@index([matchedCompanyId])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -470,15 +470,15 @@ model DatapointNote {
   turnoverId             String?
   employeesId            String?
 
-  scope1               Scope1?               @relation(fields: [scope1Id], references: [id])
-  scope2               Scope2?               @relation(fields: [scope2Id], references: [id])
-  scope3               Scope3?               @relation(fields: [scope3Id], references: [id])
-  category             Scope3Category?       @relation(fields: [categoryId], references: [id])
-  scope1And2           Scope1And2?           @relation(fields: [scope1And2Id], references: [id])
-  statedTotalEmissions StatedTotalEmissions? @relation(fields: [statedTotalEmissionsId], references: [id])
-  biogenicEmissions    BiogenicEmissions?    @relation(fields: [biogenicEmissionsId], references: [id])
-  turnover             Turnover?             @relation(fields: [turnoverId], references: [id])
-  employees            Employees?            @relation(fields: [employeesId], references: [id])
+  scope1               Scope1?               @relation(fields: [scope1Id], references: [id], onDelete: Cascade)
+  scope2               Scope2?               @relation(fields: [scope2Id], references: [id], onDelete: Cascade)
+  scope3               Scope3?               @relation(fields: [scope3Id], references: [id], onDelete: Cascade)
+  category             Scope3Category?       @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  scope1And2           Scope1And2?           @relation(fields: [scope1And2Id], references: [id], onDelete: Cascade)
+  statedTotalEmissions StatedTotalEmissions? @relation(fields: [statedTotalEmissionsId], references: [id], onDelete: Cascade)
+  biogenicEmissions    BiogenicEmissions?    @relation(fields: [biogenicEmissionsId], references: [id], onDelete: Cascade)
+  turnover             Turnover?             @relation(fields: [turnoverId], references: [id], onDelete: Cascade)
+  employees            Employees?            @relation(fields: [employeesId], references: [id], onDelete: Cascade)
 
   userId    String
   user      User     @relation(fields: [userId], references: [id])


### PR DESCRIPTION
## Summary

Adds the schema support for the Errors Browser's new "Add reason" feature (see the companion PR in `api`): reviewers can attach a freetext error reason + status to any individual datapoint (scope1/scope2/scope3 category/etc), either as a production correction or a stage-vs-prod benchmark note.

- `ErrorType` — a lookup table (not an enum) so new error categories can be added later without a migration. Currently unused by the app logic; `DatapointNote.errorReason` is freetext for now, with `errorTypeId` reserved for when recurring reasons get promoted to formal categories.
- `DatapointNote` — one row per datapoint (enforced via `@@unique` per polymorphic FK, same pattern as the existing `Metadata` model), with `comment`, `errorReason`, `status` (`OPEN` / `RESOLVED` / `WONT_FIX`), and `previousValue`/`newValue` (only populated when a reviewer marks a note `RESOLVED` — never auto-filled). Upsert semantics: saving again updates the existing note rather than accumulating duplicates.
- Cascade deletes: each `DatapointNote`'s FK to its datapoint (Scope1, Scope2, Scope3Category, etc.) is `onDelete: Cascade`, so notes don't get orphaned with dangling nulled FKs if the underlying scope/economy row is deleted.
- `Report.batchId` + `Batch.reports` — unrelated pre-existing drift between this repo and `api`'s migration history, reconciled here (see migration comments) so both repos' `_prisma_migrations` ledgers agree without disturbing already-applied stage/prod state.

## Migrations

- `20260721120000_add_datapoint_notes` — creates `error_types`, `datapoint_notes`, FKs, indexes.
- `20260721140000_datapoint_note_unique_per_datapoint` — dedup + adds `updatedAt`, replaces plain indexes with the per-datapoint unique constraints.
- `20260610120000_report_registry_batch`, `20260624120000_report_batch_id_from_legacy` — baselined (byte-identical, checksum-verified against `api`'s originals) so `prisma migrate deploy`/`status` recognizes them as already-applied rather than re-running or conflicting.

## Test plan

- [ ] `prisma migrate deploy` runs clean against a fresh local DB
- [ ] `prisma migrate status` shows no drift/pending migrations after deploy on stage
- [ ] Companion `api` PR's Errors Browser reason dialog can save/read notes end-to-end against this schema

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core emissions/economy tables via new FKs and a data-deleting dedupe migration; wrong deploy order or ledger mismatch could affect stage/prod migrate status, though app logic in this repo is schema-only.
> 
> **Overview**
> Adds **per-datapoint reviewer notes** for Validate / Errors Browser: new `error_types` lookup, `datapoint_notes` with optional `errorTypeId`, freetext `errorReason`, `DatapointErrorStatus` (`OPEN` / `RESOLVED` / `WONT_FIX`), optional `previousValue`/`newValue`, optional `reportRunId`, and polymorphic links to scope/economy datapoints (same pattern as `Metadata`). Emissions and economy models gain `notes` relations; notes cascade when the underlying datapoint row is deleted.
> 
> A follow-up migration **dedupes** existing test duplicates (keeps newest per FK), adds `updatedAt`, and replaces non-unique indexes with **one note per datapoint** unique constraints so saves upsert in place.
> 
> Also wires registry **`Report.batch_id`** → `Batch` (with index) for batch-scoped registry filtering, and baselines two older migrations (including a no-op placeholder) so this repo’s Prisma migration history matches `api` without re-applying stage/prod changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3643b879a2d4aa1dab7e867c15a6ca908aabf590. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->