### PR TITLE
Fix region input schema after territorial data rename

### DIFF
--- a/src/api/schemas/response.ts
+++ b/src/api/schemas/response.ts
@@ -624,26 +624,21 @@ export const RegionalSectorEmissionsSchema = z.object({
  * Regional data schemas
  */
 export const InputRegionalDataSchema = z.array(
-  z
-    .object({
-      region: z.string(),
-      logoUrl: z.string().nullable().optional(),
-      emissions: InputYearlyDataSchema,
-      total_trend: z.number(),
-      emissions_slope: z.number().optional(),
-      totalCarbonLaw: z.number(),
-      approximatedHistoricalEmission: InputYearlyDataSchema,
-      trend: InputYearlyDataSchema,
-      historicalEmissionChangePercent: z.number(),
-      meetsParis: z.string().transform((val) => val === 'True'),
-      municipalities: z.array(z.string()),
-    })
-    .transform((data) => ({
-      ...data,
-      totalTrend: data.total_trend,
-      total_trend: undefined,
-      emissions_slope: undefined,
-    }))
+  z.object({
+    region: z.string(),
+    logoUrl: z.string().nullable().optional(),
+    emissions: InputYearlyDataSchema,
+    totalTrend: z.number(),
+    emissionsSlope: z.number().optional(),
+    totalCarbonLaw: z.number(),
+    approximatedHistoricalEmission: InputYearlyDataSchema,
+    trend: InputYearlyDataSchema,
+    historicalEmissionChangePercent: z.number(),
+    meetsParis: z.string().transform((val) => val === 'True'),
+    municipalities: z.array(z.string()),
+    electricVehiclePerChargePoints: z.number().nullable().optional(),
+    totalConsumptionEmission: z.number().optional(),
+  })
 )
 
 export const RegionalDataSchema = z.object({


### PR DESCRIPTION
## Summary
- Align `InputRegionalDataSchema` with current `region-data.json` from the territorial pipeline (`totalTrend` / `emissionsSlope` instead of `total_trend` / `emissions_slope`).
- Same fix as the companion unearth-api PR so garbo-served `/api/regions` does not 500 on parse.

## Test plan
- [ ] Load regional data via `regionalService.getRegions()` / `getRegionalKpis()` locally without Zod errors
- [ ] `GET /api/regions/` and `/api/regions/kpis` return 200 where this API is deployed


Made with [Cursor](https://cursor.com)