### PR TITLE
Fix crash in getWikidataEntities on empty search results

### DIFF
--- a/src/lib/wikidata/read.ts
+++ b/src/lib/wikidata/read.ts
@@ -64,6 +64,10 @@ export async function getLEINumber(
 }
 
 export async function getWikidataEntities(ids: `Q${number}`[]) {
+  if (ids.length === 0) {
+    return []
+  }
+
   const url = wbk.getEntities({
     ids,
     props: ['info', 'claims', 'descriptions', 'labels'],
@@ -76,6 +80,10 @@ export async function getWikidataEntities(ids: `Q${number}`[]) {
       expectedContentType: 'application/json',
       context: 'Wikidata entities',
     })
+
+  if (!entities) {
+    return []
+  }
 
   return Object.values(entities) as (Entity & {
     labels: { [lang: string]: { language: string; value: string } }


### PR DESCRIPTION
## Summary
- `getWikidataEntities` threw `TypeError: Cannot convert undefined or null to object` whenever it was called with an empty `ids` array (or Wikidata otherwise returned a response without an `entities` key).
- This was consistently triggered from `guessWikidata.ts:530`, whose `searchResults.map(...)` produces an empty array once company search exhausts its retries with no match — a legitimate, expected outcome that the surrounding code already has graceful "not found" handling for (job log, user-facing message, `{status: 'not_found'}` return). The crash happened *before* that handling could run.
- `guessWikidata` runs as a sibling of `extractEmissions` in the precheck flow (not a dependency), so this never blocked report saving — but it did fail the job loudly/noisily instead of completing with the intended graceful outcome, burning BullMQ retries and generating false-alarm errors.

## Fix
`getWikidataEntities` now returns `[]` instead of throwing when:
- called with an empty `ids` array (skips the network call entirely), or
- the Wikidata API response doesn't include an `entities` key for any other reason

This matches the existing defensive pattern already used by `getLEINumber` and `getClaims` in the same file.

## Test plan
- [x] `npx prettier --check src/lib/wikidata/read.ts`
- [x] `npx tsc --noEmit` — no new type errors
- [ ] Verify a `guessWikidata` job for a company with no Wikidata match now completes with the `❌ Hittade inte Wikidata för...` message instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive guard in a Wikidata read helper; behavior change only avoids crashes on already-handled empty outcomes.
> 
> **Overview**
> **`getWikidataEntities`** no longer throws when Wikidata lookup has nothing to fetch or the API omits `entities`. It returns `[]` if `ids` is empty (skipping the HTTP call) and if the parsed response has no `entities`, aligning with **`getLEINumber`** and **`getClaims`** in the same module.
> 
> That lets **`guessWikidata`** finish the expected “no match” path—logging and returning not-found—instead of crashing with `Object.values(undefined)` when search yields no IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 174e7db6e58f70fa91c5c1644f3f09db9986367f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->