### PR TITLE
Prevent duplicate companies during pipeline runs

### DIFF
--- a/src/lib/pipelineCompanyAdvisoryLock.ts
+++ b/src/lib/pipelineCompanyAdvisoryLock.ts
@@ -1,0 +1,28 @@
+import { createHash } from 'crypto'
+
+import { prisma } from './prisma'
+
+/** Stable bigint key for Postgres advisory locks from a normalized company name. */
+export function advisoryLockKeyForNormalizedName(
+  normalizedName: string
+): bigint {
+  const hash = createHash('sha256').update(normalizedName).digest()
+  return hash.readBigInt64BE(0)
+}
+
+/**
+ * Runs fn while holding a transaction-scoped advisory lock for the normalized name.
+ * Prevents concurrent pipeline runs from creating duplicate name-only companies.
+ */
+export async function withNormalizedCompanyNameLock<T>(
+  normalizedName: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  const key = advisoryLockKeyForNormalizedName(
+    normalizedName.length > 0 ? normalizedName : 'unknown'
+  )
+  return prisma.$transaction(async (tx) => {
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(${key})`
+    return fn()
+  })
+}

--- a/src/lib/pipelineCompanyAdvisoryLock.ts
+++ b/src/lib/pipelineCompanyAdvisoryLock.ts
@@ -30,6 +30,7 @@ export async function withNormalizedCompanyNameLock<T>(
   const timeoutMs = options.timeoutMs ?? 120_000
   return prisma.$transaction(
     async (tx) => {
+      await tx.$executeRaw`SELECT set_config('statement_timeout', ${String(timeoutMs)}, true)`
       await tx.$executeRaw`SELECT pg_advisory_xact_lock(${key})`
       return fn()
     },

--- a/src/lib/pipelineCompanyAdvisoryLock.ts
+++ b/src/lib/pipelineCompanyAdvisoryLock.ts
@@ -10,19 +10,29 @@ export function advisoryLockKeyForNormalizedName(
   return hash.readBigInt64BE(0)
 }
 
+type AdvisoryLockOptions = {
+  /** Prisma interactive transaction timeout (ms). Create path may include HTTP calls. */
+  timeoutMs?: number
+}
+
 /**
  * Runs fn while holding a transaction-scoped advisory lock for the normalized name.
  * Prevents concurrent pipeline runs from creating duplicate name-only companies.
  */
 export async function withNormalizedCompanyNameLock<T>(
   normalizedName: string,
-  fn: () => Promise<T>
+  fn: () => Promise<T>,
+  options: AdvisoryLockOptions = {}
 ): Promise<T> {
   const key = advisoryLockKeyForNormalizedName(
     normalizedName.length > 0 ? normalizedName : 'unknown'
   )
-  return prisma.$transaction(async (tx) => {
-    await tx.$executeRaw`SELECT pg_advisory_xact_lock(${key})`
-    return fn()
-  })
+  const timeoutMs = options.timeoutMs ?? 120_000
+  return prisma.$transaction(
+    async (tx) => {
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(${key})`
+      return fn()
+    },
+    { timeout: timeoutMs }
+  )
 }

--- a/src/lib/pipelineCompanyCreate.test.ts
+++ b/src/lib/pipelineCompanyCreate.test.ts
@@ -34,7 +34,7 @@ describe('findOrCreatePipelineCompanyLocked', () => {
     mockWithLock.mockClear()
   })
 
-  it('reuses an existing company found inside the advisory lock', async () => {
+  it('reuses an existing company without taking the advisory lock', async () => {
     mockApiFetch.mockImplementation(async (path: unknown) => {
       if (
         typeof path === 'string' &&
@@ -55,7 +55,7 @@ describe('findOrCreatePipelineCompanyLocked', () => {
       companyId: 'existing-meta',
       method: 'exact_name',
     })
-    expect(mockWithLock).toHaveBeenCalledTimes(1)
+    expect(mockWithLock).not.toHaveBeenCalled()
     expect(mockApiFetch).not.toHaveBeenCalledWith(
       '/companies/',
       expect.anything()
@@ -85,5 +85,6 @@ describe('findOrCreatePipelineCompanyLocked', () => {
       companyId: 'new-company',
       method: 'created',
     })
+    expect(mockWithLock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/lib/pipelineCompanyCreate.test.ts
+++ b/src/lib/pipelineCompanyCreate.test.ts
@@ -1,0 +1,89 @@
+import {
+  jest,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  beforeAll,
+} from '@jest/globals'
+
+const mockApiFetch = jest.fn<(...args: unknown[]) => Promise<unknown>>()
+const mockWithLock = jest.fn(
+  async (_normalized: string, fn: () => Promise<unknown>) => fn()
+)
+
+jest.unstable_mockModule('./api', () => ({
+  apiFetch: mockApiFetch,
+}))
+
+jest.unstable_mockModule('./pipelineCompanyAdvisoryLock', () => ({
+  withNormalizedCompanyNameLock: mockWithLock,
+}))
+
+let findOrCreatePipelineCompanyLocked: typeof import('./pipelineCompanyCreate').findOrCreatePipelineCompanyLocked
+
+beforeAll(async () => {
+  ;({ findOrCreatePipelineCompanyLocked } = await import(
+    './pipelineCompanyCreate'
+  ))
+})
+
+describe('findOrCreatePipelineCompanyLocked', () => {
+  beforeEach(() => {
+    mockApiFetch.mockReset()
+    mockWithLock.mockClear()
+  })
+
+  it('reuses an existing company found inside the advisory lock', async () => {
+    mockApiFetch.mockImplementation(async (path: unknown) => {
+      if (
+        typeof path === 'string' &&
+        path.includes('/pipeline/companies/search')
+      ) {
+        return [{ id: 'existing-meta', name: 'Meta Platforms, Inc.' }]
+      }
+      throw new Error(`unexpected path ${String(path)}`)
+    })
+
+    const result = await findOrCreatePipelineCompanyLocked(
+      {},
+      'Meta Platforms, Inc.'
+    )
+
+    expect(result).toEqual({
+      status: 'resolved',
+      companyId: 'existing-meta',
+      method: 'exact_name',
+    })
+    expect(mockWithLock).toHaveBeenCalledTimes(1)
+    expect(mockApiFetch).not.toHaveBeenCalledWith(
+      '/companies/',
+      expect.anything()
+    )
+  })
+
+  it('creates only when no match exists inside the lock', async () => {
+    mockApiFetch.mockImplementation(
+      async (path: unknown, init?: { body?: unknown }) => {
+        if (
+          typeof path === 'string' &&
+          path.includes('/pipeline/companies/search')
+        ) {
+          return []
+        }
+        if (path === '/companies/' && init?.body) {
+          return { id: 'new-company' }
+        }
+        throw new Error(`unexpected path ${String(path)}`)
+      }
+    )
+
+    const result = await findOrCreatePipelineCompanyLocked({}, 'Brand New Co')
+
+    expect(result).toEqual({
+      status: 'resolved',
+      companyId: 'new-company',
+      method: 'created',
+    })
+  })
+})

--- a/src/lib/pipelineCompanyCreate.ts
+++ b/src/lib/pipelineCompanyCreate.ts
@@ -44,19 +44,36 @@ export async function findOrCreatePipelineCompanyLocked(
 ): Promise<FindOrCreatePipelineCompanyResult> {
   const normalized = normalizeCompanyNameForMatch(companyName)
 
-  return withNormalizedCompanyNameLock(normalized, async () => {
-    const outcome = await resolvePipelineCompanyOutcome(jobData, companyName)
+  const outcome = await resolvePipelineCompanyOutcome(jobData, companyName)
 
-    if (outcome.status === 'resolved') {
+  if (outcome.status === 'resolved') {
+    return {
+      status: 'resolved',
+      companyId: outcome.companyId,
+      method: outcome.method,
+    }
+  }
+
+  if (outcome.status === 'ambiguous') {
+    return outcome
+  }
+
+  return withNormalizedCompanyNameLock(normalized, async () => {
+    const lockedOutcome = await resolvePipelineCompanyOutcome(
+      jobData,
+      companyName
+    )
+
+    if (lockedOutcome.status === 'resolved') {
       return {
         status: 'resolved',
-        companyId: outcome.companyId,
-        method: outcome.method,
+        companyId: lockedOutcome.companyId,
+        method: lockedOutcome.method,
       }
     }
 
-    if (outcome.status === 'ambiguous') {
-      return outcome
+    if (lockedOutcome.status === 'ambiguous') {
+      return lockedOutcome
     }
 
     const companyId = await createPipelineCompanyByName(companyName)

--- a/src/lib/pipelineCompanyCreate.ts
+++ b/src/lib/pipelineCompanyCreate.ts
@@ -1,0 +1,69 @@
+import { apiFetch } from './api'
+import { normalizeCompanyNameForMatch } from './companyLinkResolve'
+import { withNormalizedCompanyNameLock } from './pipelineCompanyAdvisoryLock'
+import {
+  resolvePipelineCompanyOutcome,
+  type CompanyResolutionMethod,
+  type PipelineCompanyResolveOutcome,
+} from './pipelineCompanyResolve'
+
+type PipelineCompanyRef = {
+  companyId?: string
+  companyName?: string
+  wikidata?: { node?: string }
+  lei?: string
+}
+
+export type FindOrCreatePipelineCompanyResult =
+  | {
+      status: 'resolved'
+      companyId: string
+      method: CompanyResolutionMethod
+    }
+  | Extract<PipelineCompanyResolveOutcome, { status: 'ambiguous' }>
+
+async function createPipelineCompanyByName(
+  companyName: string
+): Promise<string> {
+  const created = await apiFetch('/companies/', {
+    body: { name: companyName },
+  })
+  if (!created?.id) {
+    throw new Error('Company create did not return id')
+  }
+  return created.id as string
+}
+
+/**
+ * Resolve an existing company or create one under a normalized-name advisory lock.
+ * Re-runs resolution inside the lock so concurrent precheck jobs share one row.
+ */
+export async function findOrCreatePipelineCompanyLocked(
+  jobData: PipelineCompanyRef,
+  companyName: string
+): Promise<FindOrCreatePipelineCompanyResult> {
+  const normalized = normalizeCompanyNameForMatch(companyName)
+
+  return withNormalizedCompanyNameLock(normalized, async () => {
+    const outcome = await resolvePipelineCompanyOutcome(jobData, companyName)
+
+    if (outcome.status === 'resolved') {
+      return {
+        status: 'resolved',
+        companyId: outcome.companyId,
+        method: outcome.method,
+      }
+    }
+
+    if (outcome.status === 'ambiguous') {
+      return outcome
+    }
+
+    const companyId = await createPipelineCompanyByName(companyName)
+    return {
+      status: 'resolved',
+      companyId,
+      method: 'created',
+    }
+  })
+}

--- a/src/lib/pipelineCompanyResolve.test.ts
+++ b/src/lib/pipelineCompanyResolve.test.ts
@@ -328,3 +328,88 @@ describe('resolveInternalCompanyId', () => {
     )
   })
 })
+
+describe('resolvePipelineCompanyAfterIdentifiers', () => {
+  let resolvePipelineCompanyAfterIdentifiers: typeof import('./pipelineCompanyResolve').resolvePipelineCompanyAfterIdentifiers
+
+  beforeAll(async () => {
+    ;({ resolvePipelineCompanyAfterIdentifiers } = await import(
+      './pipelineCompanyResolve'
+    ))
+  })
+
+  beforeEach(() => {
+    mockApiFetch.mockReset()
+  })
+
+  it('prefers wikidata owner over fallback precheck UUID', async () => {
+    mockApiFetch.mockImplementation(async (path: unknown) => {
+      if (path === '/pipeline/companies/Q380') {
+        return { id: 'canonical-meta', name: 'Meta', wikidataId: 'Q380' }
+      }
+      throw new Error(`unexpected path ${String(path)}`)
+    })
+
+    const result = await resolvePipelineCompanyAfterIdentifiers(
+      { wikidata: { node: 'Q380' } },
+      'Meta Platforms',
+      'orphan-uuid'
+    )
+
+    expect(result).toEqual({
+      status: 'resolved',
+      companyId: 'canonical-meta',
+      method: 'wikidata',
+    })
+  })
+
+  it('resolves by LEI when wikidata is missing', async () => {
+    mockApiFetch.mockImplementation(async (path: unknown) => {
+      if (path === '/pipeline/companies/5493001KJTIIGC8Y1R12') {
+        return {
+          id: 'from-lei',
+          name: 'Acme',
+          lei: '5493001KJTIIGC8Y1R12',
+        }
+      }
+      throw new Error(`unexpected path ${String(path)}`)
+    })
+
+    const result = await resolvePipelineCompanyAfterIdentifiers(
+      { lei: '5493001KJTIIGC8Y1R12' },
+      'Acme AB',
+      'orphan-uuid'
+    )
+
+    expect(result).toEqual({
+      status: 'resolved',
+      companyId: 'from-lei',
+      method: 'lei',
+    })
+  })
+
+  it('falls back to precheck UUID when no identifier match exists', async () => {
+    mockApiFetch.mockImplementation(async (path: unknown) => {
+      if (
+        typeof path === 'string' &&
+        path.includes('/pipeline/companies/search')
+      ) {
+        return []
+      }
+      throw new Error(`unexpected path ${String(path)}`)
+    })
+
+    const fallback = '11111111-1111-4111-8111-111111111111'
+    const result = await resolvePipelineCompanyAfterIdentifiers(
+      {},
+      'Brand New Co',
+      fallback
+    )
+
+    expect(result).toEqual({
+      status: 'resolved',
+      companyId: fallback,
+      method: 'job_data',
+    })
+  })
+})

--- a/src/lib/pipelineCompanyResolve.ts
+++ b/src/lib/pipelineCompanyResolve.ts
@@ -203,6 +203,82 @@ export async function resolvePipelineCompanyOutcome(
   return { status: 'create', extractedName: companyName }
 }
 
+type IdentifierFirstResolveInput = {
+  wikidata?: { node?: string }
+  lei?: string
+}
+
+/**
+ * Second-pass resolution for checkDB: prefer Wikidata and LEI over the precheck UUID.
+ * Does not short-circuit on job.data.companyId — that id is passed as fallback only.
+ */
+export async function resolvePipelineCompanyAfterIdentifiers(
+  identifiers: IdentifierFirstResolveInput,
+  companyName: string,
+  fallbackCompanyId: string
+): Promise<
+  | { status: 'resolved'; companyId: string; method: CompanyResolutionMethod }
+  | {
+      status: 'ambiguous'
+      extractedName: string
+      candidates: CompanyLinkCandidate[]
+    }
+> {
+  const wikidataId = identifiers.wikidata?.node?.trim()
+  if (wikidataId) {
+    const byWikidata = await findCompanyByWikidataId(wikidataId)
+    if (byWikidata?.id) {
+      return {
+        status: 'resolved',
+        companyId: byWikidata.id,
+        method: 'wikidata',
+      }
+    }
+  }
+
+  const normalizedLei = normalizeLei(identifiers.lei)
+  if (normalizedLei) {
+    const byLei = await findCompanyByLei(normalizedLei)
+    if (byLei?.id) {
+      return {
+        status: 'resolved',
+        companyId: byLei.id,
+        method: 'lei',
+      }
+    }
+  }
+
+  const candidates = await collectNameSearchCandidates(companyName)
+  const assessment = assessCompanyLinkResolution(companyName, candidates)
+
+  if (assessment.action === 'resolve') {
+    return {
+      status: 'resolved',
+      companyId: assessment.companyId,
+      method: 'exact_name',
+    }
+  }
+
+  if (assessment.action === 'ambiguous') {
+    return {
+      status: 'ambiguous',
+      extractedName: companyName,
+      candidates: assessment.candidates,
+    }
+  }
+
+  const fallback = fallbackCompanyId.trim()
+  if (!fallback) {
+    throw new Error('Missing fallback company id for pipeline save resolution')
+  }
+
+  return {
+    status: 'resolved',
+    companyId: await resolveInternalCompanyId(fallback),
+    method: 'job_data',
+  }
+}
+
 /**
  * Resolve the stable Garbo company id for a pipeline run.
  * Prefer explicit job data, then identifiers, then exact name match, else create.

--- a/src/lib/pipelineRunCompanyId.ts
+++ b/src/lib/pipelineRunCompanyId.ts
@@ -137,6 +137,31 @@ function wikidataNodeFromJobData(data: unknown): string | undefined {
   return node || undefined
 }
 
+type GuessWikidataJobApproval = {
+  type?: string
+  approved?: boolean
+  data?: { newValue?: { wikidata?: { node?: string } } }
+}
+
+function wikidataNodeFromConfirmedGuessJob(
+  jobData: unknown,
+  approval: GuessWikidataJobApproval | undefined
+): string | undefined {
+  if (approval?.type === 'wikidata' && approval.approved === true) {
+    const fromApproval = approval.data?.newValue?.wikidata?.node?.trim()
+    if (fromApproval) return fromApproval
+  }
+
+  return wikidataNodeFromJobData(jobData)
+}
+
+function guessJobBlocksSaveTimeWikidata(
+  approval: GuessWikidataJobApproval | undefined
+): boolean {
+  if (!approval?.type || approval.approved === true) return false
+  return approval.type === 'wikidata' || approval.type === 'companyLink'
+}
+
 /** Best-effort Wikidata Q-id from guessWikidata jobs on this pipeline thread. */
 export async function getWikidataNodeForThread(
   threadId: string | undefined
@@ -146,14 +171,11 @@ export async function getWikidataNodeForThread(
 
   const jobs = await listGuessWikidataJobsForThread(normalizedThreadId)
   for (const job of jobs) {
-    const fromData = wikidataNodeFromJobData(job.data)
-    if (fromData) return fromData
+    const approval = job.data?.approval as GuessWikidataJobApproval | undefined
+    if (guessJobBlocksSaveTimeWikidata(approval)) continue
 
-    const approval = job.data?.approval as
-      | { data?: { newValue?: { wikidata?: { node?: string } } } }
-      | undefined
-    const fromApproval = approval?.data?.newValue?.wikidata?.node?.trim()
-    if (fromApproval) return fromApproval
+    const node = wikidataNodeFromConfirmedGuessJob(job.data, approval)
+    if (node) return node
   }
 
   return undefined

--- a/src/lib/pipelineRunCompanyId.ts
+++ b/src/lib/pipelineRunCompanyId.ts
@@ -130,6 +130,35 @@ export async function isCompanyLinkResolutionPendingForThread(
   return false
 }
 
+function wikidataNodeFromJobData(data: unknown): string | undefined {
+  if (!data || typeof data !== 'object') return undefined
+  const wikidata = (data as { wikidata?: { node?: string } }).wikidata
+  const node = wikidata?.node?.trim()
+  return node || undefined
+}
+
+/** Best-effort Wikidata Q-id from guessWikidata jobs on this pipeline thread. */
+export async function getWikidataNodeForThread(
+  threadId: string | undefined
+): Promise<string | undefined> {
+  const normalizedThreadId = threadId?.trim()
+  if (!normalizedThreadId) return undefined
+
+  const jobs = await listGuessWikidataJobsForThread(normalizedThreadId)
+  for (const job of jobs) {
+    const fromData = wikidataNodeFromJobData(job.data)
+    if (fromData) return fromData
+
+    const approval = job.data?.approval as
+      | { data?: { newValue?: { wikidata?: { node?: string } } } }
+      | undefined
+    const fromApproval = approval?.data?.newValue?.wikidata?.node?.trim()
+    if (fromApproval) return fromApproval
+  }
+
+  return undefined
+}
+
 /** @deprecated Prefer isCompanyLinkResolutionPendingForThread for save gating. */
 export async function isGuessWikidataPendingForThread(
   threadId: string

--- a/src/workers/checkDB.ts
+++ b/src/workers/checkDB.ts
@@ -91,10 +91,7 @@ const checkDB = new PipelineWorker(
       await job.updateData({ ...job.data, companyId })
     }
 
-    if (
-      isCheckDbSaveTimeCompanyLinkApproval(job) &&
-      job.isDataApproved()
-    ) {
+    if (isCheckDbSaveTimeCompanyLinkApproval(job) && job.isDataApproved()) {
       const approved = job.getApprovedBody()
       if (approved.createNew) {
         throw new Error(

--- a/src/workers/checkDB.ts
+++ b/src/workers/checkDB.ts
@@ -7,8 +7,11 @@ import { getCompanyURL } from '../lib/saveUtils'
 import { QUEUE_NAMES } from '../queues'
 import {
   getCanonicalCompanyIdForThread,
+  getWikidataNodeForThread,
   isCompanyLinkResolutionPendingForThread,
+  syncCanonicalReportRunCompanyId,
 } from '../lib/pipelineRunCompanyId'
+import { resolvePipelineCompanyAfterIdentifiers } from '../lib/pipelineCompanyResolve'
 import {
   extractScopeEntriesFromFollowUp,
   mergeScope1AndScope2Results,
@@ -55,8 +58,8 @@ flow.on('error', (err) => console.error('FlowProducer connection error:', err))
 const checkDB = new PipelineWorker(
   QUEUE_NAMES.CHECK_DB,
   async (job: CheckDBJob) => {
-    let { companyName, companyId, url, sourceUrl, fiscalYear, wikidata } =
-      job.data
+    const { companyName, url, sourceUrl, fiscalYear } = job.data
+    let { companyId, wikidata } = job.data
 
     const threadId = job.data.threadId?.trim()
     if (threadId && (await isCompanyLinkResolutionPendingForThread(threadId))) {
@@ -77,6 +80,39 @@ const checkDB = new PipelineWorker(
       )
       companyId = canonicalCompany.companyId
       await job.updateData({ ...job.data, companyId })
+    }
+
+    if (job.data.approval?.type === 'companyLink' && job.isDataApproved()) {
+      const approved = job.getApprovedBody()
+      if (approved.createNew) {
+        throw new Error(
+          'Create-new is not allowed when resolving company link before save'
+        )
+      }
+      if (typeof approved.companyId === 'string' && approved.companyId.trim()) {
+        companyId = approved.companyId.trim()
+        await job.updateData({ ...job.data, companyId })
+        job.log(`Using staff-selected company id=${companyId} before save`)
+        if (threadId) {
+          await syncCanonicalReportRunCompanyId({
+            threadId,
+            companyId,
+            pdfUrl: url,
+            companyName,
+            wikidataId: wikidata?.node ?? null,
+          })
+        }
+      }
+    }
+
+    if (
+      job.data.approval?.type === 'companyLink' &&
+      job.hasApproval() &&
+      !job.isDataApproved()
+    ) {
+      job.log('Waiting for company link approval before API save')
+      await job.moveToDelayed(Date.now() + apiConfig.jobDelay)
+      return
     }
 
     const childrenEntries = await job.getChildrenEntries()
@@ -117,6 +153,77 @@ const checkDB = new PipelineWorker(
       extractScopeEntriesFromFollowUp(scope2),
       extractScopeEntriesFromFollowUp(legacyScope12)
     )
+
+    const extractedLei =
+      typeof lei === 'string' && lei.trim() ? lei.trim() : undefined
+    const mergedLei = extractedLei ?? job.data.lei?.trim()
+    const wikidataNode =
+      wikidata?.node?.trim() ??
+      job.data.wikidata?.node?.trim() ??
+      (threadId ? await getWikidataNodeForThread(threadId) : undefined)
+    const mergedWikidata = wikidataNode ? { node: wikidataNode } : wikidata
+
+    if (mergedLei && mergedLei !== job.data.lei) {
+      await job.updateData({ ...job.data, lei: mergedLei })
+    }
+    if (
+      mergedWikidata?.node &&
+      mergedWikidata.node !== job.data.wikidata?.node
+    ) {
+      await job.updateData({ ...job.data, wikidata: mergedWikidata })
+      wikidata = mergedWikidata
+    }
+
+    const saveResolution = await resolvePipelineCompanyAfterIdentifiers(
+      { wikidata: mergedWikidata, lei: mergedLei },
+      companyName,
+      companyId
+    )
+
+    if (saveResolution.status === 'ambiguous') {
+      job.log(
+        `Ambiguous company link at save for "${companyName}" — ${saveResolution.candidates.length} candidates`
+      )
+      await job.requestApproval(
+        'companyLink',
+        {
+          type: 'companyLink',
+          newValue: {
+            extractedName: saveResolution.extractedName,
+            candidates: saveResolution.candidates,
+          },
+        },
+        false,
+        {
+          source: 'checkdb-company-resolve',
+          comment:
+            'Multiple matching companies found before save — please select the correct company',
+        },
+        `Company link before save for ${companyName}`
+      )
+      await job.moveToDelayed(Date.now() + apiConfig.jobDelay)
+      return
+    }
+
+    if (
+      saveResolution.status === 'resolved' &&
+      saveResolution.companyId !== companyId
+    ) {
+      job.log(
+        `Re-resolved company for save id=${saveResolution.companyId} method=${saveResolution.method} (was ${companyId})`
+      )
+      companyId = saveResolution.companyId
+      await job.updateData({ ...job.data, companyId })
+      if (threadId) {
+        await syncCanonicalReportRunCompanyId({
+          threadId,
+          companyId,
+          pdfUrl: url,
+          companyName,
+          wikidataId: wikidata?.node ?? null,
+        })
+      }
+    }
 
     job.sendMessage(`🤖 Checking if ${companyName} already exists in API...`)
     const existingCompany = await apiFetch(

--- a/src/workers/checkDB.ts
+++ b/src/workers/checkDB.ts
@@ -174,55 +174,65 @@ const checkDB = new PipelineWorker(
       wikidata = mergedWikidata
     }
 
-    const saveResolution = await resolvePipelineCompanyAfterIdentifiers(
-      { wikidata: mergedWikidata, lei: mergedLei },
-      companyName,
-      companyId
-    )
+    const staffResolvedCompanyLink =
+      job.data.approval?.type === 'companyLink' && job.isDataApproved()
 
-    if (saveResolution.status === 'ambiguous') {
-      job.log(
-        `Ambiguous company link at save for "${companyName}" — ${saveResolution.candidates.length} candidates`
+    if (!staffResolvedCompanyLink) {
+      const saveResolution = await resolvePipelineCompanyAfterIdentifiers(
+        { wikidata: mergedWikidata, lei: mergedLei },
+        companyName,
+        companyId
       )
-      await job.requestApproval(
-        'companyLink',
-        {
-          type: 'companyLink',
-          newValue: {
-            extractedName: saveResolution.extractedName,
-            candidates: saveResolution.candidates,
+
+      if (saveResolution.status === 'ambiguous') {
+        job.log(
+          `Ambiguous company link at save for "${companyName}" — ${saveResolution.candidates.length} candidates`
+        )
+        await job.requestApproval(
+          'companyLink',
+          {
+            type: 'companyLink',
+            newValue: {
+              extractedName: saveResolution.extractedName,
+              candidates: saveResolution.candidates,
+              allowCreateNew: false,
+            },
           },
-        },
-        false,
-        {
-          source: 'checkdb-company-resolve',
-          comment:
-            'Multiple matching companies found before save — please select the correct company',
-        },
-        `Company link before save for ${companyName}`
-      )
-      await job.moveToDelayed(Date.now() + apiConfig.jobDelay)
-      return
-    }
-
-    if (
-      saveResolution.status === 'resolved' &&
-      saveResolution.companyId !== companyId
-    ) {
-      job.log(
-        `Re-resolved company for save id=${saveResolution.companyId} method=${saveResolution.method} (was ${companyId})`
-      )
-      companyId = saveResolution.companyId
-      await job.updateData({ ...job.data, companyId })
-      if (threadId) {
-        await syncCanonicalReportRunCompanyId({
-          threadId,
-          companyId,
-          pdfUrl: url,
-          companyName,
-          wikidataId: wikidata?.node ?? null,
-        })
+          false,
+          {
+            source: 'checkdb-company-resolve',
+            comment:
+              'Multiple matching companies found before save — please select the correct company',
+          },
+          `Company link before save for ${companyName}`
+        )
+        await job.moveToDelayed(Date.now() + apiConfig.jobDelay)
+        return
       }
+
+      if (
+        saveResolution.status === 'resolved' &&
+        saveResolution.companyId !== companyId
+      ) {
+        job.log(
+          `Re-resolved company for save id=${saveResolution.companyId} method=${saveResolution.method} (was ${companyId})`
+        )
+        companyId = saveResolution.companyId
+        await job.updateData({ ...job.data, companyId })
+        if (threadId) {
+          await syncCanonicalReportRunCompanyId({
+            threadId,
+            companyId,
+            pdfUrl: url,
+            companyName,
+            wikidataId: wikidata?.node ?? null,
+          })
+        }
+      }
+    } else {
+      job.log(
+        `Skipping save-time company re-resolve — staff already selected companyId=${companyId}`
+      )
     }
 
     job.sendMessage(`🤖 Checking if ${companyName} already exists in API...`)

--- a/src/workers/checkDB.ts
+++ b/src/workers/checkDB.ts
@@ -55,6 +55,15 @@ export class CheckDBJob extends PipelineJob {
 const flow = new FlowProducer({ connection: redis })
 flow.on('error', (err) => console.error('FlowProducer connection error:', err))
 
+const CHECKDB_COMPANY_LINK_SOURCE = 'checkdb-company-resolve'
+
+function isCheckDbSaveTimeCompanyLinkApproval(job: CheckDBJob): boolean {
+  const approval = job.data.approval
+  if (approval?.type !== 'companyLink') return false
+  const source = (approval.metadata as { source?: string } | undefined)?.source
+  return source === CHECKDB_COMPANY_LINK_SOURCE
+}
+
 const checkDB = new PipelineWorker(
   QUEUE_NAMES.CHECK_DB,
   async (job: CheckDBJob) => {
@@ -82,7 +91,10 @@ const checkDB = new PipelineWorker(
       await job.updateData({ ...job.data, companyId })
     }
 
-    if (job.data.approval?.type === 'companyLink' && job.isDataApproved()) {
+    if (
+      isCheckDbSaveTimeCompanyLinkApproval(job) &&
+      job.isDataApproved()
+    ) {
       const approved = job.getApprovedBody()
       if (approved.createNew) {
         throw new Error(
@@ -106,7 +118,7 @@ const checkDB = new PipelineWorker(
     }
 
     if (
-      job.data.approval?.type === 'companyLink' &&
+      isCheckDbSaveTimeCompanyLinkApproval(job) &&
       job.hasApproval() &&
       !job.isDataApproved()
     ) {
@@ -175,7 +187,7 @@ const checkDB = new PipelineWorker(
     }
 
     const staffResolvedCompanyLink =
-      job.data.approval?.type === 'companyLink' && job.isDataApproved()
+      isCheckDbSaveTimeCompanyLinkApproval(job) && job.isDataApproved()
 
     if (!staffResolvedCompanyLink) {
       const saveResolution = await resolvePipelineCompanyAfterIdentifiers(
@@ -408,13 +420,13 @@ const checkDB = new PipelineWorker(
               },
             }
           : null,
-        lei
+        mergedLei
           ? {
               ...base,
               queueName: QUEUE_NAMES.DIFF_LEI,
               data: {
                 ...base.data,
-                lei,
+                lei: mergedLei,
               },
             }
           : null,

--- a/src/workers/diffLEI.ts
+++ b/src/workers/diffLEI.ts
@@ -1,5 +1,7 @@
 import { PipelineJob, PipelineWorker } from '../lib/PipelineWorker'
 import { enqueueSaveToAPIWithParentFallback } from '../lib/DiffWorker'
+import { findCompanyByLei } from '../lib/pipelineCompanyResolve'
+import { syncCanonicalReportRunCompanyId } from '../lib/pipelineRunCompanyId'
 import { QUEUE_NAMES } from '../queues'
 
 export class DiffLEIJob extends PipelineJob {
@@ -43,7 +45,34 @@ function compareLei(
 const diffLEI = new PipelineWorker<DiffLEIJob>(
   QUEUE_NAMES.DIFF_LEI,
   async (job: DiffLEIJob) => {
-    const { companyName, lei, existingCompany } = job.data
+    const { companyName, lei } = job.data
+    let { companyId, existingCompany } = job.data
+
+    if (lei?.trim()) {
+      const leiOwner = await findCompanyByLei(lei)
+      if (leiOwner?.id && leiOwner.id !== companyId) {
+        job.log(
+          `LEI ${lei} belongs to company ${leiOwner.id}; switching from ${companyId}`
+        )
+        companyId = leiOwner.id
+        await job.updateData({ ...job.data, companyId })
+        const threadId = job.data.threadId?.trim()
+        if (threadId) {
+          await syncCanonicalReportRunCompanyId({
+            threadId,
+            companyId,
+            pdfUrl: job.data.url,
+            companyName,
+            wikidataId: job.data.wikidata?.node ?? null,
+          })
+        }
+        existingCompany = {
+          ...existingCompany,
+          id: companyId,
+          lei: leiOwner.lei,
+        }
+      }
+    }
 
     const currentLei = existingCompany?.lei
 

--- a/src/workers/diffLEI.ts
+++ b/src/workers/diffLEI.ts
@@ -1,7 +1,5 @@
 import { PipelineJob, PipelineWorker } from '../lib/PipelineWorker'
 import { enqueueSaveToAPIWithParentFallback } from '../lib/DiffWorker'
-import { findCompanyByLei } from '../lib/pipelineCompanyResolve'
-import { syncCanonicalReportRunCompanyId } from '../lib/pipelineRunCompanyId'
 import { QUEUE_NAMES } from '../queues'
 
 export class DiffLEIJob extends PipelineJob {
@@ -45,34 +43,7 @@ function compareLei(
 const diffLEI = new PipelineWorker<DiffLEIJob>(
   QUEUE_NAMES.DIFF_LEI,
   async (job: DiffLEIJob) => {
-    const { companyName, lei } = job.data
-    let { companyId, existingCompany } = job.data
-
-    if (lei?.trim()) {
-      const leiOwner = await findCompanyByLei(lei)
-      if (leiOwner?.id && leiOwner.id !== companyId) {
-        job.log(
-          `LEI ${lei} belongs to company ${leiOwner.id}; switching from ${companyId}`
-        )
-        companyId = leiOwner.id
-        await job.updateData({ ...job.data, companyId })
-        const threadId = job.data.threadId?.trim()
-        if (threadId) {
-          await syncCanonicalReportRunCompanyId({
-            threadId,
-            companyId,
-            pdfUrl: job.data.url,
-            companyName,
-            wikidataId: job.data.wikidata?.node ?? null,
-          })
-        }
-        existingCompany = {
-          ...existingCompany,
-          id: companyId,
-          lei: leiOwner.lei,
-        }
-      }
-    }
+    const { companyName, lei, existingCompany } = job.data
 
     const currentLei = existingCompany?.lei
 

--- a/src/workers/guessWikidata.ts
+++ b/src/workers/guessWikidata.ts
@@ -152,6 +152,28 @@ async function requestCompanyLinkIfWikidataConflict(
     return true
   }
 
+  if (job.data.autoApprove) {
+    job.log(
+      `autoApprove: relinking pipeline company ${resolvedPipelineCompanyId} → wikidata owner ${wikidataOwner.id} (${wikidata.node})`
+    )
+    await job.updateData({
+      ...job.data,
+      companyId: wikidataOwner.id,
+      wikidata,
+    })
+    const threadId = job.data.threadId?.trim()
+    if (threadId) {
+      await syncCanonicalReportRunCompanyId({
+        threadId,
+        companyId: wikidataOwner.id,
+        pdfUrl: job.data.url,
+        companyName,
+        wikidataId: wikidata.node,
+      })
+    }
+    return true
+  }
+
   job.log(
     `Wikidata ${wikidata.node} belongs to company ${wikidataOwner.id}; pipeline company is ${resolvedPipelineCompanyId} — requesting staff confirmation`
   )

--- a/src/workers/precheck.ts
+++ b/src/workers/precheck.ts
@@ -23,6 +23,7 @@ class PrecheckJob extends PipelineJob {
     companyName?: string
     companyId?: string
     lei?: string
+    wikidata?: { node?: string }
     waitingForCompanyName?: boolean
   }
 }

--- a/src/workers/precheck.ts
+++ b/src/workers/precheck.ts
@@ -8,7 +8,11 @@ import { z } from 'zod'
 import { QUEUE_NAMES } from '../queues'
 import apiConfig from '../config/api'
 import { apiFetch } from '../lib/api'
-import { resolvePipelineCompanyOutcome } from '../lib/pipelineCompanyResolve'
+import {
+  resolvePipelineCompanyOutcome,
+  findCompanyByWikidataId,
+} from '../lib/pipelineCompanyResolve'
+import { findOrCreatePipelineCompanyLocked } from '../lib/pipelineCompanyCreate'
 import { syncCanonicalReportRunCompanyId } from '../lib/pipelineRunCompanyId'
 import { EXTRACT_EMISSIONS_CHILD_QUEUES } from './precheckFlow'
 import { withPipelineJobOpts } from '../lib/pipelineJobOptions'
@@ -40,6 +44,40 @@ async function createPipelineCompany(companyName: string): Promise<string> {
   return created.id as string
 }
 
+async function resolveOrCreateCompanyForPrecheck(
+  job: PrecheckJob,
+  companyName: string
+): Promise<
+  | { status: 'resolved'; companyId: string }
+  | {
+      status: 'ambiguous'
+      candidates: import('../lib/companyLinkResolve').CompanyLinkCandidate[]
+    }
+  | null
+> {
+  if (
+    job.data.approval?.type === 'companyLink' &&
+    job.hasApproval() &&
+    !job.isDataApproved()
+  ) {
+    return null
+  }
+
+  const outcome = await findOrCreatePipelineCompanyLocked(job.data, companyName)
+
+  if (outcome.status === 'ambiguous') {
+    return { status: 'ambiguous', candidates: outcome.candidates }
+  }
+
+  if (outcome.companyId !== job.data.companyId) {
+    job.log(
+      `Resolved pipeline company id=${outcome.companyId} method=${outcome.method}`
+    )
+  }
+
+  return { status: 'resolved', companyId: outcome.companyId }
+}
+
 async function syncRunCompanyIdFromPrecheck(
   job: PrecheckJob,
   companyId: string,
@@ -63,6 +101,15 @@ async function ensurePipelineCompany(
   if (job.data.approval?.type === 'companyLink' && job.isDataApproved()) {
     const approved = job.getApprovedBody()
     if (approved.createNew) {
+      const wikidataId = job.data.wikidata?.node?.trim()
+      if (wikidataId) {
+        const wikidataOwner = await findCompanyByWikidataId(wikidataId)
+        if (wikidataOwner?.id) {
+          throw new Error(
+            `Cannot create new company: Wikidata ${wikidataId} already belongs to ${wikidataOwner.id}`
+          )
+        }
+      }
       const companyId = await createPipelineCompany(companyName)
       await job.updateData({ ...job.data, companyId, companyName })
       job.log(`Created new company after company-link approval id=${companyId}`)
@@ -140,9 +187,36 @@ async function ensurePipelineCompany(
     return null
   }
 
-  const companyId = await createPipelineCompany(companyName)
+  const locked = await resolveOrCreateCompanyForPrecheck(job, companyName)
+  if (!locked) return null
+  if (locked.status === 'ambiguous') {
+    job.log(
+      `Ambiguous company link for "${companyName}" — ${locked.candidates.length} candidates`
+    )
+    await job.requestApproval(
+      'companyLink',
+      {
+        type: 'companyLink',
+        newValue: {
+          extractedName: companyName,
+          candidates: locked.candidates,
+        },
+      },
+      false,
+      {
+        source: 'company-name-search',
+        comment:
+          'Multiple matching companies found — please select the correct company',
+      },
+      `Company link for ${companyName}`
+    )
+    await job.moveToDelayed(Date.now() + apiConfig.jobDelay)
+    return null
+  }
+
+  const companyId = locked.companyId
   await job.updateData({ ...job.data, companyId, companyName })
-  job.log(`Created pipeline company id=${companyId}`)
+  job.log(`Created or reused pipeline company id=${companyId}`)
   await syncRunCompanyIdFromPrecheck(job, companyId, companyName)
   return companyId
 }


### PR DESCRIPTION
## Summary
- Re-resolve canonical company in checkDB by wikidata, LEI, and exact name before any API save
- Add precheck advisory lock and find-or-create helper to prevent concurrent name-only duplicates
- Auto-relink to wikidata owner when autoApprove and Q-id is already taken
- Repoint LEI saves when LEI belongs to another company

## Test plan
- [x] Local: concurrent Meta reports create one company (name + lock)
- [x] Local: sequential reports attach to same Company.id
- [ ] Stage: run report for company with existing wikidataId + autoApprove — no duplicate row
- [ ] Stage: checkDB logs show re-resolve by wikidata when Q-id known

Deploy with pipeline-api and validate-frontend PRs for full flow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core company resolution, save gating, and concurrent create behavior; mis-resolution could attach reports or emissions to the wrong company id.
> 
> **Overview**
> This PR tightens **canonical company identity** across precheck, Wikidata guessing, and **checkDB** so concurrent runs and late-discovered identifiers do not create duplicate companies or save to the wrong row.
> 
> **Precheck** now uses **`findOrCreatePipelineCompanyLocked`**, which resolves first without a lock when a match exists, then takes a **Postgres transaction advisory lock** keyed by normalized name before re-resolving and creating via the API. Staff **create-new** after company-link approval is blocked when the Wikidata Q-id already belongs to another company.
> 
> **checkDB** adds a **save-time second pass** via **`resolvePipelineCompanyAfterIdentifiers`**: Wikidata and LEI win over the precheck UUID, with exact name search and ambiguous cases routed to **companyLink** approval (`checkdb-company-resolve`, no create-new). Merged LEI/Wikidata from extraction and **`getWikidataNodeForThread`** feed that pass; canonical **`reportRun`** company id is synced when the id changes.
> 
> **guessWikidata** with **`autoApprove`** now **auto-relinks** to the company that already owns the Q-id and syncs the thread canonical id, instead of always waiting on staff when the Wikidata owner differs.
> 
> Tests cover the locked find-or-create helper and identifier-first save resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b76573ce36cb70ac8a8c713a976b482bc8a46edd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->