### PR TITLE
[Prod] Patch Version Bump v6.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo",
-  "version": "6.0.9-rc.3",
+  "version": "6.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo",
-      "version": "6.0.9-rc.3",
+      "version": "6.0.9",
       "hasInstallScript": true,
       "license": "MIT License",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garbo",
-  "version": "6.0.9-rc.3",
+  "version": "6.0.9",
   "description": "",
   "type": "module",
   "exports": {


### PR DESCRIPTION
# 🚀 Production Release PR

> **Title format:** `[Prod] Major/Minor/Patch Version Bump vX.X.X`

## 📦 Release Type

_Select the appropriate release type by marking with an `x`._

- [ ] Major version bump
- [ ] Minor version bump
- [x] Patch version bump

### Rollback Version

_Note the relevant rollback version to enable quick rollback if necessary._

v6.0.8

## 🔁 Environment Promotion

This release promotes changes **from `staging` to `production`** (see `k8s/overlays/staging` and `k8s/overlays/production`).

## 📋 What's Being Released

_Provide a summary of the features, fixes, or updates included in this production release._

- Add cached coverage registry status columns (additive schema for Validate coverage list filters) (#1372)
- Fix region input schema after territorial data rename so `/api/regions` doesn't 500 (#1375)
- Fix crash in `getWikidataEntities` on empty search results (#1379)
- Prevent duplicate companies during pipeline runs via re-resolve + advisory lock (#1380)

## 🗂 Deployment Notes (optional)

_Anything to watch out for: DB migrations, feature flags, long-running jobs, cache warmup, etc._

- #1372 includes DB migration `20260714120000_coverage_registry_cache`; deploy/migrate this before the paired `unearth-api` PR #65
- #1380 should be deployed alongside the paired `pipeline-api` and `validate-frontend` PRs for the full duplicate-prevention flow

## ✅ Checklist

- [x] Version number is updated correctly (code/package and/or k8s image tag)
- [ ] All relevant changes have been QA-tested in staging
- [x] Rollback version has been updated
- [x] Title follows the required format: `[Prod] Major/Minor/Patch Version Bump vX.X.X`

---

_This template is for versioned production releases only. For other PR types, please select a different template._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Production release bundles a DB migration and coordinated multi-service deploys for duplicate prevention, though this diff is only a version bump.
> 
> **Overview**
> This PR **finalizes the v6.0.9 production patch** by changing the package version from `6.0.9-rc.3` to `6.0.9` in `package.json` and `package-lock.json`—no application code changes in the diff itself.
> 
> It is the **staging → production** promotion for fixes already listed in the release notes: cached coverage registry status columns for Validate filters (#1372), region input schema fix for `/api/regions` (#1375), `getWikidataEntities` crash on empty search (#1379), and duplicate-company prevention during pipeline runs (#1380).
> 
> **Deploy:** apply migration `20260714120000_coverage_registry_cache` before **unearth-api** PR #65; ship #1380 together with the paired **pipeline-api** and **validate-frontend** PRs. Rollback target: **v6.0.8**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3cdd2917ed4540adee61ec13274023f03d71c3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->