### PR TITLE
Company link partial match and display name rename

### DIFF
--- a/src/lib/DiffWorker.ts
+++ b/src/lib/DiffWorker.ts
@@ -58,6 +58,42 @@ export interface ChangeDescription {
   newValue
 }
 
+type JobWithApproval = {
+  data: {
+    approval?: { type?: string; approved?: boolean }
+  }
+}
+
+/** Staff approved this diff worker's own payload (not e.g. companyLink). */
+export function isApprovedForDiffType(
+  job: JobWithApproval,
+  apiSubEndpoint: string
+): boolean {
+  const approval = job.data.approval
+  return approval?.approved === true && approval?.type === apiSubEndpoint
+}
+
+/** This diff worker is waiting on its own approval gate. */
+export function isPendingApprovalForDiffType(
+  job: JobWithApproval,
+  apiSubEndpoint: string
+): boolean {
+  const approval = job.data.approval
+  return !!approval && approval.type === apiSubEndpoint && !approval.approved
+}
+
+/**
+ * Run diff computation when there is no pending approval for this endpoint.
+ * Ignores unrelated approvals already on the job (companyLink, wikidata, …).
+ */
+export function shouldRunDiffComputation(
+  job: JobWithApproval,
+  apiSubEndpoint: string
+): boolean {
+  if (isApprovedForDiffType(job, apiSubEndpoint)) return false
+  return !isPendingApprovalForDiffType(job, apiSubEndpoint)
+}
+
 export class DiffJob extends PipelineJob {
   declare data: PipelineJob['data'] & {
     companyName: string

--- a/src/lib/applyStaffCompanyLink.ts
+++ b/src/lib/applyStaffCompanyLink.ts
@@ -8,9 +8,13 @@ export type StaffCompanyLinkApprovalBody = {
 }
 
 export function staffApprovedDisplayName(
-  body: StaffCompanyLinkApprovalBody
+  body: StaffCompanyLinkApprovalBody | Record<string, unknown>
 ): string | undefined {
-  const name = body.displayName?.trim()
+  const raw =
+    'displayName' in body && typeof body.displayName === 'string'
+      ? body.displayName
+      : undefined
+  const name = raw?.trim()
   return name || undefined
 }
 

--- a/src/lib/applyStaffCompanyLink.ts
+++ b/src/lib/applyStaffCompanyLink.ts
@@ -1,0 +1,28 @@
+import { apiFetch } from './api'
+import { companyMutationPath } from './pipelineCompanyPath'
+
+export type StaffCompanyLinkApprovalBody = {
+  companyId?: string
+  createNew?: boolean
+  displayName?: string
+}
+
+export function staffApprovedDisplayName(
+  body: StaffCompanyLinkApprovalBody
+): string | undefined {
+  const name = body.displayName?.trim()
+  return name || undefined
+}
+
+/** PATCH company display name when staff sets an override during company link. */
+export async function applyStaffCompanyLinkDisplayName(
+  companyId: string,
+  displayName: string
+): Promise<string> {
+  const trimmed = displayName.trim()
+  if (!trimmed) {
+    throw new Error('Display name override is empty')
+  }
+  await apiFetch(companyMutationPath(companyId), { body: { name: trimmed } })
+  return trimmed
+}

--- a/src/lib/companyLinkResolve.test.ts
+++ b/src/lib/companyLinkResolve.test.ts
@@ -69,7 +69,11 @@ describe('companyLinkResolve', () => {
       { id: 'ica-no', name: 'ICA Norge AS' },
     ]
     const result = assessCompanyLinkResolution('ICA', candidates)
-    expect(result).toEqual({ action: 'ambiguous', candidates })
+    expect(result).toEqual({
+      action: 'ambiguous',
+      candidates,
+      partialNameMatch: true,
+    })
   })
 
   it('creates a new company when search returns no candidates', () => {

--- a/src/lib/companyLinkResolve.ts
+++ b/src/lib/companyLinkResolve.ts
@@ -40,13 +40,49 @@ export function shareCompanyNameCore(a: string, b: string): boolean {
   return coreA !== null && coreA === coreB
 }
 
+/**
+ * True when names share a core token but differ beyond legal-entity suffixes
+ * (e.g. Sampo Group vs Sampo plc). Excludes same-core unrelated pairs like
+ * Nordic Capital vs Nordic Paper.
+ */
+export function isPartialCompanyNameMatch(a: string, b: string): boolean {
+  if (!shareCompanyNameCore(a, b)) return false
+
+  const normA = normalizeCompanyNameForMatch(a)
+  const normB = normalizeCompanyNameForMatch(b)
+  if (normA === normB) return false
+
+  const core = companyNameCoreToken(a)
+  if (!core) return false
+
+  const wordsA = normA.split(/\s+/).filter(Boolean)
+  const wordsB = normB.split(/\s+/).filter(Boolean)
+  if (wordsA[0] !== core || wordsB[0] !== core) return false
+
+  const significantA = wordsA
+    .slice(1)
+    .filter((word) => !isLegalEntitySuffix(word))
+  const significantB = wordsB
+    .slice(1)
+    .filter((word) => !isLegalEntitySuffix(word))
+  if (
+    significantA.length > 0 &&
+    significantB.length > 0 &&
+    significantA.join(' ') !== significantB.join(' ')
+  ) {
+    return false
+  }
+
+  return true
+}
+
 export function pickPartialNameMatches(
   extractedName: string,
   candidates: CompanyLinkCandidate[]
 ): CompanyLinkCandidate[] {
   return candidates.filter(
     (candidate) =>
-      candidate.name && shareCompanyNameCore(extractedName, candidate.name)
+      candidate.name && isPartialCompanyNameMatch(extractedName, candidate.name)
   )
 }
 

--- a/src/lib/companyLinkResolve.ts
+++ b/src/lib/companyLinkResolve.ts
@@ -12,8 +12,43 @@ export type CompanyLinkCandidate = {
 
 export type CompanyLinkResolution =
   | { action: 'resolve'; companyId: string }
-  | { action: 'ambiguous'; candidates: CompanyLinkCandidate[] }
+  | {
+      action: 'ambiguous'
+      candidates: CompanyLinkCandidate[]
+      /** True when candidates matched on shared core token (e.g. Sampo Group vs Sampo plc). */
+      partialNameMatch?: boolean
+    }
   | { action: 'create' }
+
+/** Minimum length for the first normalized token to count as a company core name. */
+const COMPANY_CORE_TOKEN_MIN_LENGTH = 3
+
+/**
+ * First significant token after legal-suffix normalization (e.g. "sampo" from "Sampo Group").
+ * Used to surface partial name matches for staff review.
+ */
+export function companyNameCoreToken(name: string): string | null {
+  const normalized = normalizeCompanyNameForMatch(name)
+  const token = normalized.split(/\s+/).filter(Boolean)[0]
+  if (!token || token.length < COMPANY_CORE_TOKEN_MIN_LENGTH) return null
+  return token
+}
+
+export function shareCompanyNameCore(a: string, b: string): boolean {
+  const coreA = companyNameCoreToken(a)
+  const coreB = companyNameCoreToken(b)
+  return coreA !== null && coreA === coreB
+}
+
+export function pickPartialNameMatches(
+  extractedName: string,
+  candidates: CompanyLinkCandidate[]
+): CompanyLinkCandidate[] {
+  return candidates.filter(
+    (candidate) =>
+      candidate.name && shareCompanyNameCore(extractedName, candidate.name)
+  )
+}
 
 export { stripLegalEntitySuffixes }
 
@@ -31,6 +66,41 @@ export function companyNameHasDiacritics(text: string): boolean {
  * When two names match under diacritic folding, keep or upgrade to the richer
  * spelling — never replace "Nestlé" with "Nestle" on PATCH.
  */
+export type ResolveCompanyDisplayNameOptions = {
+  staffDisplayName?: string | null
+  /** Prefer the pipeline-extracted name on partial core-token matches (e.g. Sampo Group vs Sampo plc). */
+  preferIncomingOnPartialMatch?: boolean
+}
+
+/**
+ * Pick the display name for a company row: staff override wins, then partial-match
+ * upgrade rules, then diacritic-safe merge.
+ */
+export function resolveCompanyDisplayName(
+  existingName: string | null | undefined,
+  incomingName: string,
+  options?: ResolveCompanyDisplayNameOptions
+): string {
+  const staff = options?.staffDisplayName?.trim()
+  if (staff) return staff
+
+  const incoming = incomingName.trim()
+  const existing = existingName?.trim()
+
+  if (
+    options?.preferIncomingOnPartialMatch &&
+    existing &&
+    incoming &&
+    shareCompanyNameCore(existing, incoming) &&
+    normalizeCompanyNameForMatch(existing) !==
+      normalizeCompanyNameForMatch(incoming)
+  ) {
+    return incoming
+  }
+
+  return preferRicherDiacriticCompanyName(existingName, incomingName)
+}
+
 export function preferRicherDiacriticCompanyName(
   existingName: string | null | undefined,
   incomingName: string
@@ -45,6 +115,9 @@ export function preferRicherDiacriticCompanyName(
     normalizeCompanyNameForMatch(existing) !==
     normalizeCompanyNameForMatch(incoming)
   ) {
+    // Partial core-token match (e.g. Sampo Group vs Sampo plc): keep existing
+    // display name — never downgrade on a later pipeline run.
+    if (shareCompanyNameCore(existing, incoming)) return existing
     return incoming
   }
 
@@ -89,9 +162,27 @@ export function pickExactNameMatches(
 }
 
 /**
+ * True when a Wikidata label is close enough to the pipeline company name to auto-approve.
+ * Blocks subsidiary / unrelated picks (e.g. Sampo Group → If P&C Insurance).
+ */
+export function wikidataSelectionMatchesCompanyName(
+  companyName: string,
+  wikidataLabel: string
+): boolean {
+  const label = wikidataLabel.trim()
+  if (!label) return false
+
+  const candidate: CompanyLinkCandidate = { id: '_', name: label }
+  if (pickExactNameMatches(companyName, [candidate]).length > 0) return true
+  if (shareCompanyNameCore(companyName, label)) return true
+  return false
+}
+
+/**
  * Decide whether to auto-link, ask a human, or create a new company.
  * Auto-link only when exactly one candidate matches the normalized name.
- * Any fuzzy hit without a single exact match goes to staff (including a lone non-exact hit).
+ * Partial core-token matches (e.g. Sampo Group vs Sampo plc) go to staff with a focused candidate list.
+ * Any other fuzzy hit without a single exact match also goes to staff.
  */
 export function assessCompanyLinkResolution(
   extractedName: string,
@@ -107,6 +198,22 @@ export function assessCompanyLinkResolution(
 
   if (exactMatches.length === 1) {
     return { action: 'resolve', companyId: exactMatches[0].id }
+  }
+
+  if (exactMatches.length > 1) {
+    return {
+      action: 'ambiguous',
+      candidates: dedupeCompanyLinkCandidates(exactMatches),
+    }
+  }
+
+  const partialMatches = pickPartialNameMatches(extractedName, uniqueCandidates)
+  if (partialMatches.length >= 1) {
+    return {
+      action: 'ambiguous',
+      candidates: dedupeCompanyLinkCandidates(partialMatches),
+      partialNameMatch: true,
+    }
   }
 
   return { action: 'ambiguous', candidates: uniqueCandidates }

--- a/src/lib/companyLinkResolve.ts
+++ b/src/lib/companyLinkResolve.ts
@@ -252,15 +252,5 @@ export function assessCompanyLinkResolution(
     }
   }
 
-  const nameRelevant = uniqueCandidates.filter(
-    (candidate) =>
-      candidate.name &&
-      (pickExactNameMatches(extractedName, [candidate]).length > 0 ||
-        isPartialCompanyNameMatch(extractedName, candidate.name))
-  )
-  if (nameRelevant.length === 0) {
-    return { action: 'create' }
-  }
-
-  return { action: 'ambiguous', candidates: nameRelevant }
+  return { action: 'ambiguous', candidates: uniqueCandidates }
 }

--- a/src/lib/companyLinkResolve.ts
+++ b/src/lib/companyLinkResolve.ts
@@ -210,7 +210,7 @@ export function wikidataSelectionMatchesCompanyName(
 
   const candidate: CompanyLinkCandidate = { id: '_', name: label }
   if (pickExactNameMatches(companyName, [candidate]).length > 0) return true
-  if (shareCompanyNameCore(companyName, label)) return true
+  if (isPartialCompanyNameMatch(companyName, label)) return true
   return false
 }
 
@@ -252,5 +252,15 @@ export function assessCompanyLinkResolution(
     }
   }
 
-  return { action: 'ambiguous', candidates: uniqueCandidates }
+  const nameRelevant = uniqueCandidates.filter(
+    (candidate) =>
+      candidate.name &&
+      (pickExactNameMatches(extractedName, [candidate]).length > 0 ||
+        isPartialCompanyNameMatch(extractedName, candidate.name))
+  )
+  if (nameRelevant.length === 0) {
+    return { action: 'create' }
+  }
+
+  return { action: 'ambiguous', candidates: nameRelevant }
 }

--- a/src/lib/pipelineCompanyResolve.ts
+++ b/src/lib/pipelineCompanyResolve.ts
@@ -1,6 +1,7 @@
 import { apiFetch } from './api'
 import {
   assessCompanyLinkResolution,
+  companyNameCoreToken,
   type CompanyLinkCandidate,
   stripLegalEntitySuffixes,
 } from './companyLinkResolve'
@@ -36,6 +37,7 @@ export type PipelineCompanyResolveOutcome =
       status: 'ambiguous'
       extractedName: string
       candidates: CompanyLinkCandidate[]
+      partialNameMatch?: boolean
     }
   | { status: 'create'; extractedName: string }
 
@@ -96,14 +98,19 @@ async function searchCompaniesByName(
 async function collectNameSearchCandidates(
   companyName: string
 ): Promise<CompanyLinkCandidate[]> {
-  const namesToTry = [companyName]
+  const namesToTry = new Set<string>([companyName.trim()])
   const strippedName = stripLegalEntitySuffixes(companyName)
   if (strippedName !== companyName.trim()) {
-    namesToTry.push(strippedName)
+    namesToTry.add(strippedName)
+  }
+  const coreToken = companyNameCoreToken(companyName)
+  if (coreToken) {
+    namesToTry.add(coreToken)
   }
 
   const byId = new Map<string, CompanyLinkCandidate>()
   for (const query of namesToTry) {
+    if (!query) continue
     for (const hit of await searchCompaniesByName(query)) {
       byId.set(hit.id, hit)
     }
@@ -197,6 +204,7 @@ export async function resolvePipelineCompanyOutcome(
       status: 'ambiguous',
       extractedName: companyName,
       candidates: assessment.candidates,
+      partialNameMatch: assessment.partialNameMatch,
     }
   }
 
@@ -222,6 +230,7 @@ export async function resolvePipelineCompanyAfterIdentifiers(
       status: 'ambiguous'
       extractedName: string
       candidates: CompanyLinkCandidate[]
+      partialNameMatch?: boolean
     }
 > {
   const wikidataId = identifiers.wikidata?.node?.trim()
@@ -264,6 +273,7 @@ export async function resolvePipelineCompanyAfterIdentifiers(
       status: 'ambiguous',
       extractedName: companyName,
       candidates: assessment.candidates,
+      partialNameMatch: assessment.partialNameMatch,
     }
   }
 

--- a/src/lib/pipelineCompanyResolve.ts
+++ b/src/lib/pipelineCompanyResolve.ts
@@ -2,6 +2,7 @@ import { apiFetch } from './api'
 import {
   assessCompanyLinkResolution,
   companyNameCoreToken,
+  isPartialCompanyNameMatch,
   type CompanyLinkCandidate,
   stripLegalEntitySuffixes,
 } from './companyLinkResolve'
@@ -103,10 +104,6 @@ async function collectNameSearchCandidates(
   if (strippedName !== companyName.trim()) {
     namesToTry.add(strippedName)
   }
-  const coreToken = companyNameCoreToken(companyName)
-  if (coreToken) {
-    namesToTry.add(coreToken)
-  }
 
   const byId = new Map<string, CompanyLinkCandidate>()
   for (const query of namesToTry) {
@@ -115,6 +112,18 @@ async function collectNameSearchCandidates(
       byId.set(hit.id, hit)
     }
   }
+
+  // Targeted partial-match expansion: core-token search can flood unrelated
+  // prefix hits, so only merge candidates that pass partial-match rules.
+  const coreToken = companyNameCoreToken(companyName)
+  if (coreToken) {
+    for (const hit of await searchCompaniesByName(coreToken)) {
+      if (hit.name && isPartialCompanyNameMatch(companyName, hit.name)) {
+        byId.set(hit.id, hit)
+      }
+    }
+  }
+
   return [...byId.values()]
 }
 

--- a/src/workers/checkDB.ts
+++ b/src/workers/checkDB.ts
@@ -25,9 +25,14 @@ import {
   pipelineCompanyReadPath,
 } from '../lib/pipelineCompanyPath'
 import {
-  preferRicherDiacriticCompanyName,
   normalizeCompanyNameForMatch,
+  resolveCompanyDisplayName,
+  shareCompanyNameCore,
 } from '../lib/companyLinkResolve'
+import {
+  applyStaffCompanyLinkDisplayName,
+  staffApprovedDisplayName,
+} from '../lib/applyStaffCompanyLink'
 
 export class CheckDBJob extends PipelineJob {
   declare data: PipelineJob['data'] & {
@@ -104,7 +109,16 @@ const checkDB = new PipelineWorker(
       }
       if (typeof approved.companyId === 'string' && approved.companyId.trim()) {
         companyId = approved.companyId.trim()
-        await job.updateData({ ...job.data, companyId })
+        const override = staffApprovedDisplayName(approved)
+        if (override) {
+          companyName = await applyStaffCompanyLinkDisplayName(
+            companyId,
+            override
+          )
+          await job.updateData({ ...job.data, companyId, companyName })
+        } else {
+          await job.updateData({ ...job.data, companyId })
+        }
         job.log(`Using staff-selected company id=${companyId} before save`)
         if (threadId) {
           await syncCanonicalReportRunCompanyId({
@@ -209,13 +223,18 @@ const checkDB = new PipelineWorker(
               extractedName: saveResolution.extractedName,
               candidates: saveResolution.candidates,
               allowCreateNew: false,
+              ...(saveResolution.partialNameMatch && {
+                partialNameMatch: true,
+                displayName: saveResolution.extractedName,
+              }),
             },
           },
           false,
           {
             source: 'checkdb-company-resolve',
-            comment:
-              'Multiple matching companies found before save — please select the correct company',
+            comment: saveResolution.partialNameMatch
+              ? 'Partial name match — select the correct company and optionally set display name'
+              : 'Multiple matching companies found before save — please select the correct company',
           },
           `Company link before save for ${companyName}`
         )
@@ -255,9 +274,17 @@ const checkDB = new PipelineWorker(
     job.log(existingCompany)
 
     if (existingCompany) {
-      companyName = preferRicherDiacriticCompanyName(
+      const staffDisplay =
+        isCheckDbSaveTimeCompanyLinkApproval(job) && job.isDataApproved()
+          ? staffApprovedDisplayName(job.getApprovedBody())
+          : undefined
+      companyName = resolveCompanyDisplayName(
         existingCompany.name,
-        companyName
+        companyName,
+        {
+          staffDisplayName: staffDisplay,
+          preferIncomingOnPartialMatch: true,
+        }
       )
     }
 
@@ -279,8 +306,9 @@ const checkDB = new PipelineWorker(
     } else if (
       existingCompany.name &&
       companyName !== existingCompany.name.trim() &&
-      normalizeCompanyNameForMatch(existingCompany.name) ===
-        normalizeCompanyNameForMatch(companyName)
+      (normalizeCompanyNameForMatch(existingCompany.name) ===
+        normalizeCompanyNameForMatch(companyName) ||
+        shareCompanyNameCore(existingCompany.name, companyName))
     ) {
       job.log(
         `Upgrading company display name '${existingCompany.name}' → '${companyName}'`

--- a/src/workers/checkDB.ts
+++ b/src/workers/checkDB.ts
@@ -27,7 +27,6 @@ import {
 import {
   normalizeCompanyNameForMatch,
   resolveCompanyDisplayName,
-  shareCompanyNameCore,
 } from '../lib/companyLinkResolve'
 import {
   applyStaffCompanyLinkDisplayName,
@@ -283,7 +282,7 @@ const checkDB = new PipelineWorker(
         companyName,
         {
           staffDisplayName: staffDisplay,
-          preferIncomingOnPartialMatch: true,
+          preferIncomingOnPartialMatch: Boolean(staffDisplay),
         }
       )
     }
@@ -306,9 +305,8 @@ const checkDB = new PipelineWorker(
     } else if (
       existingCompany.name &&
       companyName !== existingCompany.name.trim() &&
-      (normalizeCompanyNameForMatch(existingCompany.name) ===
-        normalizeCompanyNameForMatch(companyName) ||
-        shareCompanyNameCore(existingCompany.name, companyName))
+      normalizeCompanyNameForMatch(existingCompany.name) ===
+        normalizeCompanyNameForMatch(companyName)
     ) {
       job.log(
         `Upgrading company display name '${existingCompany.name}' → '${companyName}'`

--- a/src/workers/diffBaseYear.ts
+++ b/src/workers/diffBaseYear.ts
@@ -1,5 +1,12 @@
 import apiConfig from '../config/api'
-import { ChangeDescription, DiffJob, DiffWorker } from '../lib/DiffWorker'
+import {
+  ChangeDescription,
+  DiffJob,
+  DiffWorker,
+  isApprovedForDiffType,
+  isPendingApprovalForDiffType,
+  shouldRunDiffComputation,
+} from '../lib/DiffWorker'
 import { diffChanges } from '../lib/saveUtils'
 import { QUEUE_NAMES } from '../queues'
 
@@ -11,21 +18,23 @@ export class DiffBaseYearJob extends DiffJob {
   }
 }
 
+const BASE_YEAR_ENDPOINT = 'base-year'
+
 const diffBaseYear = new DiffWorker<DiffBaseYearJob>(
   QUEUE_NAMES.DIFF_BASE_YEAR,
   async (job) => {
     const { companyName, existingCompany, baseYear, wikidata } = job.data
 
-    if (job.isDataApproved()) {
+    if (isApprovedForDiffType(job, BASE_YEAR_ENDPOINT)) {
       await job.enqueueSaveToAPI(
-        'base-year',
+        BASE_YEAR_ENDPOINT,
         companyName,
         job.getApprovedBody()
       )
       return
     }
 
-    if (!job.hasApproval()) {
+    if (shouldRunDiffComputation(job, BASE_YEAR_ENDPOINT)) {
       const { diff, requiresApproval } = await diffChanges({
         existingCompany,
         before: existingCompany?.baseYear,
@@ -39,14 +48,14 @@ const diffBaseYear = new DiffWorker<DiffBaseYearJob>(
       }
 
       await job.handleDiff(
-        'base-year',
+        BASE_YEAR_ENDPOINT,
         diff,
         change,
         typeof requiresApproval == 'boolean' ? requiresApproval : false
       )
     }
 
-    if (job.hasApproval() && !job.isDataApproved()) {
+    if (isPendingApprovalForDiffType(job, BASE_YEAR_ENDPOINT)) {
       try {
         await job.moveToDelayed(Date.now() + apiConfig.jobDelay)
       } catch (_err) {}

--- a/src/workers/diffGoals.ts
+++ b/src/workers/diffGoals.ts
@@ -1,5 +1,12 @@
 import apiConfig from '../config/api'
-import { ChangeDescription, DiffJob, DiffWorker } from '../lib/DiffWorker'
+import {
+  ChangeDescription,
+  DiffJob,
+  DiffWorker,
+  isApprovedForDiffType,
+  isPendingApprovalForDiffType,
+  shouldRunDiffComputation,
+} from '../lib/DiffWorker'
 import { diffChanges } from '../lib/saveUtils'
 import { QUEUE_NAMES } from '../queues'
 import { Goal } from '../types'
@@ -13,16 +20,22 @@ export class DiffGoalsJob extends DiffJob {
   }
 }
 
+const GOALS_ENDPOINT = 'goals'
+
 const diffGoals = new DiffWorker<DiffGoalsJob>(
   QUEUE_NAMES.DIFF_GOALS,
   async (job) => {
     const { wikidata, companyName, existingCompany, goals } = job.data
-    if (job.isDataApproved()) {
-      await job.enqueueSaveToAPI('goals', companyName, job.getApprovedBody())
+    if (isApprovedForDiffType(job, GOALS_ENDPOINT)) {
+      await job.enqueueSaveToAPI(
+        GOALS_ENDPOINT,
+        companyName,
+        job.getApprovedBody()
+      )
       return
     }
 
-    if (!job.hasApproval()) {
+    if (shouldRunDiffComputation(job, GOALS_ENDPOINT)) {
       const { diff, requiresApproval } = await diffChanges({
         existingCompany,
         before: existingCompany?.goals,
@@ -38,14 +51,14 @@ const diffGoals = new DiffWorker<DiffGoalsJob>(
       }
 
       await job.handleDiff(
-        'goals',
+        GOALS_ENDPOINT,
         diff,
         change,
         typeof requiresApproval == 'boolean' ? requiresApproval : false
       )
     }
 
-    if (job.hasApproval() && !job.isDataApproved()) {
+    if (isPendingApprovalForDiffType(job, GOALS_ENDPOINT)) {
       await job.moveToDelayed(Date.now() + apiConfig.jobDelay)
     }
   }

--- a/src/workers/diffIndustry.ts
+++ b/src/workers/diffIndustry.ts
@@ -1,5 +1,12 @@
 import apiConfig from '../config/api'
-import { DiffJob, ChangeDescription, DiffWorker } from '../lib/DiffWorker'
+import {
+  DiffJob,
+  ChangeDescription,
+  DiffWorker,
+  isApprovedForDiffType,
+  isPendingApprovalForDiffType,
+  shouldRunDiffComputation,
+} from '../lib/DiffWorker'
 import { diffChanges } from '../lib/saveUtils'
 import { QUEUE_NAMES } from '../queues'
 
@@ -12,17 +19,23 @@ export class DiffIndustryJob extends DiffJob {
   }
 }
 
+const INDUSTRY_ENDPOINT = 'industry'
+
 const diffIndustry = new DiffWorker<DiffIndustryJob>(
   QUEUE_NAMES.DIFF_INDUSTRY,
   async (job) => {
     const { wikidata, companyName, existingCompany, industry } = job.data
 
-    if (job.isDataApproved()) {
-      await job.enqueueSaveToAPI('industry', companyName, job.getApprovedBody())
+    if (isApprovedForDiffType(job, INDUSTRY_ENDPOINT)) {
+      await job.enqueueSaveToAPI(
+        INDUSTRY_ENDPOINT,
+        companyName,
+        job.getApprovedBody()
+      )
       return
     }
 
-    if (!job.hasApproval()) {
+    if (shouldRunDiffComputation(job, INDUSTRY_ENDPOINT)) {
       const { diff, requiresApproval } = await diffChanges({
         existingCompany,
         before: existingCompany?.industry,
@@ -36,14 +49,14 @@ const diffIndustry = new DiffWorker<DiffIndustryJob>(
       }
 
       await job.handleDiff(
-        'industry',
+        INDUSTRY_ENDPOINT,
         diff,
         change,
         typeof requiresApproval == 'boolean' ? requiresApproval : false
       )
     }
 
-    if (job.hasApproval() && !job.isDataApproved()) {
+    if (isPendingApprovalForDiffType(job, INDUSTRY_ENDPOINT)) {
       await job.moveToDelayed(Date.now() + apiConfig.jobDelay)
     }
   }

--- a/src/workers/diffInitiatives.ts
+++ b/src/workers/diffInitiatives.ts
@@ -1,5 +1,12 @@
 import apiConfig from '../config/api'
-import { ChangeDescription, DiffJob, DiffWorker } from '../lib/DiffWorker'
+import {
+  ChangeDescription,
+  DiffJob,
+  DiffWorker,
+  isApprovedForDiffType,
+  isPendingApprovalForDiffType,
+  shouldRunDiffComputation,
+} from '../lib/DiffWorker'
 import { defaultMetadata, diffChanges } from '../lib/saveUtils'
 import { QUEUE_NAMES } from '../queues'
 import { Initiative } from '../types'
@@ -12,6 +19,8 @@ export class DiffInitiativesJob extends DiffJob {
     initiatives: Initiative[]
   }
 }
+
+const INITIATIVES_ENDPOINT = 'initiatives'
 
 const diffInitiatives = new DiffWorker<DiffInitiativesJob>(
   QUEUE_NAMES.DIFF_INITIATIVES,
@@ -26,16 +35,16 @@ const diffInitiatives = new DiffWorker<DiffInitiativesJob>(
     } = job.data
     const metadata = defaultMetadata(url)
 
-    if (job.isDataApproved()) {
+    if (isApprovedForDiffType(job, INITIATIVES_ENDPOINT)) {
       await job.enqueueSaveToAPI(
-        'initiatives',
+        INITIATIVES_ENDPOINT,
         companyName,
         job.getApprovedBody()
       )
       return
     }
 
-    if (!job.hasApproval()) {
+    if (shouldRunDiffComputation(job, INITIATIVES_ENDPOINT)) {
       const { diff, requiresApproval } = await diffChanges({
         existingCompany,
         before: existingCompany?.initiatives,
@@ -51,14 +60,14 @@ const diffInitiatives = new DiffWorker<DiffInitiativesJob>(
       }
 
       await job.handleDiff(
-        'initiatives',
+        INITIATIVES_ENDPOINT,
         diff,
         change,
         typeof requiresApproval == 'boolean' ? requiresApproval : false
       )
     }
 
-    if (job.hasApproval() && !job.isDataApproved()) {
+    if (isPendingApprovalForDiffType(job, INITIATIVES_ENDPOINT)) {
       await job.moveToDelayed(Date.now() + apiConfig.jobDelay)
     }
   }

--- a/src/workers/diffReportingPeriods.ts
+++ b/src/workers/diffReportingPeriods.ts
@@ -1,7 +1,14 @@
 import { canonicalPublicReportUrl, diffChanges } from '../lib/saveUtils'
 import { getReportingPeriodDates } from '../lib/reportingPeriodDates'
 import { QUEUE_NAMES } from '../queues'
-import { ChangeDescription, DiffWorker, DiffJob } from '../lib/DiffWorker'
+import {
+  ChangeDescription,
+  DiffWorker,
+  DiffJob,
+  isApprovedForDiffType,
+  isPendingApprovalForDiffType,
+  shouldRunDiffComputation,
+} from '../lib/DiffWorker'
 import apiConfig from '../config/api'
 import { apiFetch } from '../lib/api'
 import { pipelineCompanyReadPath } from '../lib/pipelineCompanyPath'
@@ -40,6 +47,8 @@ async function fetchFreshExistingCompany(companyId: string) {
   return apiFetch(pipelineCompanyReadPath(companyId)).catch(() => null)
 }
 
+const REPORTING_PERIODS_ENDPOINT = 'reporting-periods'
+
 const diffReportingPeriods = new DiffWorker<DiffReportingPeriodsJob>(
   QUEUE_NAMES.DIFF_REPORTING_PERIODS,
   async (job) => {
@@ -67,7 +76,7 @@ const diffReportingPeriods = new DiffWorker<DiffReportingPeriodsJob>(
         ? trimmedUrl
         : undefined)
 
-    if (job.isDataApproved()) {
+    if (isApprovedForDiffType(job, REPORTING_PERIODS_ENDPOINT)) {
       const approvedBody = job.getApprovedBody() ?? {}
       const periods = Array.isArray(approvedBody.reportingPeriods)
         ? approvedBody.reportingPeriods
@@ -77,7 +86,7 @@ const diffReportingPeriods = new DiffWorker<DiffReportingPeriodsJob>(
         periods
       )
 
-      await job.enqueueSaveToAPI('reporting-periods', companyName, {
+      await job.enqueueSaveToAPI(REPORTING_PERIODS_ENDPOINT, companyName, {
         ...approvedBody,
         ...saveBodyExtras,
         ...(job.data.replaceAllEmissions && { replaceAllEmissions: true }),
@@ -89,7 +98,7 @@ const diffReportingPeriods = new DiffWorker<DiffReportingPeriodsJob>(
       return
     }
 
-    if (!job.hasApproval()) {
+    if (shouldRunDiffComputation(job, REPORTING_PERIODS_ENDPOINT)) {
       const { companyId, wikidata } = job.data
       const freshCompany =
         (await fetchFreshExistingCompany(companyId)) ??
@@ -222,7 +231,7 @@ const diffReportingPeriods = new DiffWorker<DiffReportingPeriodsJob>(
         isNewReportIdentity && updatedReportingPeriods.length > 0
 
       await job.handleDiff(
-        'reporting-periods',
+        REPORTING_PERIODS_ENDPOINT,
         diff,
         change,
         typeof requiresApproval == 'boolean' ? requiresApproval : false,
@@ -230,7 +239,7 @@ const diffReportingPeriods = new DiffWorker<DiffReportingPeriodsJob>(
       )
     }
 
-    if (job.hasApproval() && !job.isDataApproved()) {
+    if (isPendingApprovalForDiffType(job, REPORTING_PERIODS_ENDPOINT)) {
       await job.moveToDelayed(Date.now() + apiConfig.jobDelay)
     }
   }

--- a/src/workers/guessWikidata.ts
+++ b/src/workers/guessWikidata.ts
@@ -18,7 +18,10 @@ import {
   resolveInternalCompanyId,
 } from '../lib/pipelineCompanyResolve'
 import type { CompanyLinkCandidate } from '../lib/companyLinkResolve'
-import { preferRicherDiacriticCompanyName } from '../lib/companyLinkResolve'
+import {
+  preferRicherDiacriticCompanyName,
+  wikidataSelectionMatchesCompanyName,
+} from '../lib/companyLinkResolve'
 import { LEGAL_ENTITY_SUFFIXES } from '../lib/companyLegalEntitySuffixes'
 import { syncCanonicalReportRunCompanyId } from '../lib/pipelineRunCompanyId'
 import { buildEarlyRegistryPayload } from './saveToAPI.utils'
@@ -648,48 +651,63 @@ const guessWikidata = new PipelineWorker<GuessWikidataJob>(
         const checkIfWikidataExistInProduction =
           await checkIfWikidataExistInProductionRes.json()
         if (checkIfWikidataExistInProduction.wikidataId) {
-          // Auto-approve since company exists in production
-          const metadata = {
-            source: 'production-database',
-            comment: 'Company found in production database',
-          }
-
-          await job.requestApproval(
-            'wikidata',
-            {
-              type: 'wikidata',
-              newValue: { wikidata: wikidataForApproval },
-            },
-            true,
-            metadata,
-            `Auto-approved wikidata for ${companyName}`
-          )
-
-          const ready = await ensureCompanyLinkBeforeWikidataPersist(
-            job,
+          const labelMatches = wikidataSelectionMatchesCompanyName(
             companyName,
-            wikidataForApproval
+            wikidataForApproval.label
           )
-          if (!ready) return
+          if (!labelMatches) {
+            job.log(
+              `Wikidata label "${wikidataForApproval.label}" does not match company "${companyName}" — skipping production auto-approve`
+            )
+          } else {
+            // Auto-approve since company exists in production
+            const metadata = {
+              source: 'production-database',
+              comment: 'Company found in production database',
+            }
 
-          await persistApprovedWikidata(job, companyName, wikidataForApproval, {
-            verified: false,
-            metadata,
-          })
-
-          job.sendMessage({
-            content: `🚀 Company found in production database, we will approve automatically: ${companyName}`,
-          })
-          return JSON.stringify(
-            {
-              status: 'approved',
-              wikidata: wikidataForApproval,
-              message: `Auto-approved wikidata for ${companyName} (found in production database)`,
+            await job.requestApproval(
+              'wikidata',
+              {
+                type: 'wikidata',
+                newValue: { wikidata: wikidataForApproval },
+              },
+              true,
               metadata,
-            },
-            null,
-            2
-          )
+              `Auto-approved wikidata for ${companyName}`
+            )
+
+            const ready = await ensureCompanyLinkBeforeWikidataPersist(
+              job,
+              companyName,
+              wikidataForApproval
+            )
+            if (!ready) return
+
+            await persistApprovedWikidata(
+              job,
+              companyName,
+              wikidataForApproval,
+              {
+                verified: false,
+                metadata,
+              }
+            )
+
+            job.sendMessage({
+              content: `🚀 Company found in production database, we will approve automatically: ${companyName}`,
+            })
+            return JSON.stringify(
+              {
+                status: 'approved',
+                wikidata: wikidataForApproval,
+                message: `Auto-approved wikidata for ${companyName} (found in production database)`,
+                metadata,
+              },
+              null,
+              2
+            )
+          }
         }
       }
     } catch (_error) {
@@ -705,7 +723,12 @@ const guessWikidata = new PipelineWorker<GuessWikidataJob>(
       comment: 'Wikidata found via search and LLM selection',
     }
 
-    if (job.data.autoApprove) {
+    const labelMatchesForAutoApprove = wikidataSelectionMatchesCompanyName(
+      companyName,
+      wikidataForApproval.label
+    )
+
+    if (job.data.autoApprove && labelMatchesForAutoApprove) {
       await job.requestApproval(
         'wikidata',
         {
@@ -745,6 +768,12 @@ const guessWikidata = new PipelineWorker<GuessWikidataJob>(
       )
     }
 
+    if (job.data.autoApprove && !labelMatchesForAutoApprove) {
+      job.log(
+        `Wikidata label "${wikidataForApproval.label}" does not match company "${companyName}" — requiring manual approval despite autoApprove`
+      )
+    }
+
     // Create approval request using standard pattern
     await job.requestApproval(
       'wikidata',
@@ -754,7 +783,9 @@ const guessWikidata = new PipelineWorker<GuessWikidataJob>(
       },
       false, // requires manual approval
       metadata,
-      `Wikidata selection for ${companyName}`
+      job.data.autoApprove && !labelMatchesForAutoApprove
+        ? `Wikidata mismatch for ${companyName} (selected: ${wikidataForApproval.label})`
+        : `Wikidata selection for ${companyName}`
     )
 
     await job.sendMessage({

--- a/src/workers/precheck.ts
+++ b/src/workers/precheck.ts
@@ -72,7 +72,11 @@ async function resolveOrCreateCompanyForPrecheck(
   const outcome = await findOrCreatePipelineCompanyLocked(job.data, companyName)
 
   if (outcome.status === 'ambiguous') {
-    return { status: 'ambiguous', candidates: outcome.candidates }
+    return {
+      status: 'ambiguous',
+      candidates: outcome.candidates,
+      partialNameMatch: outcome.partialNameMatch,
+    }
   }
 
   if (outcome.companyId !== job.data.companyId) {

--- a/src/workers/precheck.ts
+++ b/src/workers/precheck.ts
@@ -14,6 +14,10 @@ import {
 } from '../lib/pipelineCompanyResolve'
 import { findOrCreatePipelineCompanyLocked } from '../lib/pipelineCompanyCreate'
 import { syncCanonicalReportRunCompanyId } from '../lib/pipelineRunCompanyId'
+import {
+  applyStaffCompanyLinkDisplayName,
+  staffApprovedDisplayName,
+} from '../lib/applyStaffCompanyLink'
 import { EXTRACT_EMISSIONS_CHILD_QUEUES } from './precheckFlow'
 import { withPipelineJobOpts } from '../lib/pipelineJobOptions'
 
@@ -53,6 +57,7 @@ async function resolveOrCreateCompanyForPrecheck(
   | {
       status: 'ambiguous'
       candidates: import('../lib/companyLinkResolve').CompanyLinkCandidate[]
+      partialNameMatch?: boolean
     }
   | null
 > {
@@ -111,17 +116,22 @@ async function ensurePipelineCompany(
           )
         }
       }
-      const companyId = await createPipelineCompany(companyName)
-      await job.updateData({ ...job.data, companyId, companyName })
+      const createName = staffApprovedDisplayName(approved) ?? companyName
+      const companyId = await createPipelineCompany(createName)
+      await job.updateData({ ...job.data, companyId, companyName: createName })
       job.log(`Created new company after company-link approval id=${companyId}`)
-      await syncRunCompanyIdFromPrecheck(job, companyId, companyName)
+      await syncRunCompanyIdFromPrecheck(job, companyId, createName)
       return companyId
     }
     if (typeof approved.companyId === 'string' && approved.companyId.trim()) {
       const companyId = approved.companyId.trim()
-      await job.updateData({ ...job.data, companyId, companyName })
+      const override = staffApprovedDisplayName(approved)
+      const finalName = override
+        ? await applyStaffCompanyLinkDisplayName(companyId, override)
+        : companyName
+      await job.updateData({ ...job.data, companyId, companyName: finalName })
       job.log(`Using staff-selected company id=${companyId}`)
-      await syncRunCompanyIdFromPrecheck(job, companyId, companyName)
+      await syncRunCompanyIdFromPrecheck(job, companyId, finalName)
       return companyId
     }
   }
@@ -163,8 +173,9 @@ async function ensurePipelineCompany(
 
     const metadata = {
       source: 'company-name-search',
-      comment:
-        'Multiple matching companies found — please select the correct company',
+      comment: outcome.partialNameMatch
+        ? 'Partial name match — select the correct company and optionally set display name'
+        : 'Multiple matching companies found — please select the correct company',
     }
 
     await job.requestApproval(
@@ -174,6 +185,11 @@ async function ensurePipelineCompany(
         newValue: {
           extractedName: outcome.extractedName,
           candidates: outcome.candidates,
+          ...(outcome.partialNameMatch && {
+            partialNameMatch: true,
+            displayName: outcome.extractedName,
+            allowCreateNew: false,
+          }),
         },
       },
       false,
@@ -201,13 +217,19 @@ async function ensurePipelineCompany(
         newValue: {
           extractedName: companyName,
           candidates: locked.candidates,
+          ...(locked.partialNameMatch && {
+            partialNameMatch: true,
+            displayName: companyName,
+            allowCreateNew: false,
+          }),
         },
       },
       false,
       {
         source: 'company-name-search',
-        comment:
-          'Multiple matching companies found — please select the correct company',
+        comment: locked.partialNameMatch
+          ? 'Partial name match — select the correct company and optionally set display name'
+          : 'Multiple matching companies found — please select the correct company',
       },
       `Company link for ${companyName}`
     )
@@ -251,7 +273,16 @@ const precheck = new PipelineWorker(
         [
           {
             role: 'user',
-            content: `What is the name of the company? Respond only with the company name, leave null if you cannot find it. We will search Wikidata for this name. The following is an extract from a PDF:
+            content: `What is the name of the company this report belongs to? We will search Wikidata for this name.
+
+Rules:
+- Prefer the legal/reporting entity named on the cover page or report title.
+- If the report covers multiple companies (group, consolidated, or holding structure), return the ultimate parent / reporting entity — not a subsidiary listed only in the scope section.
+- If the report is clearly about a single subsidiary or division, return that entity instead.
+
+Respond only with the company name, or null if you cannot find it.
+
+Extract from this PDF:
             
             ${chunk}
             `,


### PR DESCRIPTION
## Summary
- Detect partial company name matches (shared core token) and route them to staff company-link approval instead of auto-linking or blocking the pipeline.
- Persist staff-chosen display names when approving partial matches and re-resolve company identity at save time.
- Ensure pending `companyLink` approvals do not block diff workers from running.

## Related PRs
- pipeline-api: (create alongside)
- validate-frontend: (create alongside)

## Test plan
- [ ] Upload a report for a company with a partial name match (e.g. Sampo Group → Sampo plc) and confirm staff approval UI appears
- [ ] Approve with a custom display name and verify the company name is updated in Garbo
- [ ] Confirm diff workers continue while company link is pending approval
- [ ] Run existing company link resolution tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes company identity resolution, display names, and Wikidata auto-approval gates—incorrect linking could attach reports to the wrong company, though staff approval and stricter matching reduce that risk.
> 
> **Overview**
> Improves **company linking** when names only partially align (shared core token, e.g. Sampo Group vs Sampo plc): resolution now sends a narrower candidate list to staff with `partialNameMatch`, can **create** when search hits are not name-relevant, and expands search via core-token queries filtered by partial-match rules.
> 
> Staff can set a **display name** on company-link approval (`applyStaffCompanyLinkDisplayName`); **precheck** and **checkDB** persist it and use `resolveCompanyDisplayName` so partial matches do not overwrite existing names on later runs.
> 
> **Diff workers** use endpoint-scoped approval checks (`shouldRunDiffComputation`, etc.) so a pending `companyLink` (or other type) on the job no longer blocks diff computation for goals, reporting periods, etc.
> 
> **Wikidata** production/`autoApprove` paths require the selected label to match the pipeline company name (`wikidataSelectionMatchesCompanyName`), avoiding wrong-entity auto-approval.
> 
> **Precheck** LLM company-name extraction prompt favors the reporting/parent entity over subsidiaries when the report is group-level.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09d9070f14be9c1d87c11a3ea354271f6e886699. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->