### PR TITLE
Allow create-new on partial company name match

### DIFF
--- a/src/workers/checkDB.ts
+++ b/src/workers/checkDB.ts
@@ -221,7 +221,6 @@ const checkDB = new PipelineWorker(
             newValue: {
               extractedName: saveResolution.extractedName,
               candidates: saveResolution.candidates,
-              allowCreateNew: false,
               ...(saveResolution.partialNameMatch && {
                 partialNameMatch: true,
                 displayName: saveResolution.extractedName,

--- a/src/workers/precheck.ts
+++ b/src/workers/precheck.ts
@@ -192,7 +192,6 @@ async function ensurePipelineCompany(
           ...(outcome.partialNameMatch && {
             partialNameMatch: true,
             displayName: outcome.extractedName,
-            allowCreateNew: false,
           }),
         },
       },
@@ -224,7 +223,6 @@ async function ensurePipelineCompany(
           ...(locked.partialNameMatch && {
             partialNameMatch: true,
             displayName: companyName,
-            allowCreateNew: false,
           }),
         },
       },


### PR DESCRIPTION
## Summary
- Stop forcing `allowCreateNew: false` on partial name match company-link approvals in `precheck` and `checkDB`
- Staff can create a separate company when core-name similarity is a false positive (e.g. Wise Group AB vs Wise plc)
- Wikidata relink approvals still disallow create-new (unchanged)

## Context
Stage testing showed partial match blocked the create-new path for unrelated companies that share a core token like Wise.

## Test plan
- [ ] Deploy with validate-frontend PR
- [ ] Upload Wise Group report when Wise plc exists — partial match UI shows **Create new company**
- [ ] Approve create-new — new company row created, pipeline completes
- [ ] Sampo Group vs Sampo plc — link + display name path still works

## Related
- validate-frontend: companion PR for UI warning + parsing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small approval-payload change in two workers; Wikidata and save-time create-new guards are unchanged.
> 
> **Overview**
> **Partial name match** company-link approvals from `precheck` and `checkDB` no longer set `allowCreateNew: false` on the approval payload. Validate can show **Create new company** when core-name similarity looks like a false positive (e.g. Wise Group AB vs Wise plc), instead of forcing a pick among candidates only.
> 
> **Wikidata relink** company-link approvals in `guessWikidata` still pass `allowCreateNew: false` — unchanged. `checkDB` still rejects an approved `createNew` at save-time (`checkdb-company-resolve`); create-new remains handled in precheck when staff approve it there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5efbd5eeb5640ce0919fd7c6538f576a3079570d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->