### PR TITLE
Validate LEI checksum and fail invalid extractions without blocking saves

### DIFF
--- a/src/lib/normalizeLei.ts
+++ b/src/lib/normalizeLei.ts
@@ -1,12 +1,54 @@
 const LEI_PATTERN = /^[A-Z0-9]{20}$/
 
-/** Normalize a Legal Entity Identifier to uppercase 20-char form, or null if invalid. */
-export function normalizeLei(value: string | undefined | null): string | null {
-  const trimmed = value?.trim().toUpperCase()
-  if (!trimmed || !LEI_PATTERN.test(trimmed)) return null
-  return trimmed
+/** ISO 17442 mod-97-10 checksum (LEI check characters 19–20). */
+export function isValidLeiChecksum(lei: string): boolean {
+  let m = 0
+  for (let i = 0; i < lei.length; i++) {
+    const c = lei.charCodeAt(i)
+    if (c >= 48 && c <= 57) {
+      m = (m * 10 + c - 48) % 97
+    } else if (c >= 65 && c <= 90) {
+      m = (m * 100 + c - 55) % 97
+    } else {
+      return false
+    }
+  }
+  return m === 1
 }
 
 export function isLeiFormat(value: string): boolean {
   return LEI_PATTERN.test(value.trim().toUpperCase())
+}
+
+/** True when value is a 20-char LEI with a valid mod-97 checksum. */
+export function isValidLei(value: string): boolean {
+  const normalized = value.trim().toUpperCase()
+  if (!LEI_PATTERN.test(normalized)) return false
+  return isValidLeiChecksum(normalized)
+}
+
+/** Normalize a Legal Entity Identifier to uppercase 20-char form, or null if invalid. */
+export function normalizeLei(value: string | undefined | null): string | null {
+  const trimmed = value?.trim().toUpperCase()
+  if (!trimmed || !isValidLei(trimmed)) return null
+  return trimmed
+}
+
+/** Merge LEI from a pipeline child job with any LEI already on the parent job. */
+export function resolvePipelineLei(
+  childLei: unknown,
+  jobLei?: string | null
+): {
+  mergedLei: string | null
+  ignoredInvalidChildLei?: string
+} {
+  const extractedLei = normalizeLei(
+    typeof childLei === 'string' || childLei === null ? childLei : undefined
+  )
+  const mergedLei = extractedLei ?? normalizeLei(jobLei) ?? null
+  const ignoredInvalidChildLei =
+    typeof childLei === 'string' && childLei.trim() && !extractedLei
+      ? childLei.trim()
+      : undefined
+  return { mergedLei, ignoredInvalidChildLei }
 }

--- a/src/workers/checkDB.ts
+++ b/src/workers/checkDB.ts
@@ -32,6 +32,7 @@ import {
   applyStaffCompanyLinkDisplayName,
   staffApprovedDisplayName,
 } from '../lib/applyStaffCompanyLink'
+import { resolvePipelineLei } from '../lib/normalizeLei'
 
 export class CheckDBJob extends PipelineJob {
   declare data: PipelineJob['data'] & {
@@ -180,9 +181,15 @@ const checkDB = new PipelineWorker(
       extractScopeEntriesFromFollowUp(legacyScope12)
     )
 
-    const extractedLei =
-      typeof lei === 'string' && lei.trim() ? lei.trim() : undefined
-    const mergedLei = extractedLei ?? job.data.lei?.trim()
+    const { mergedLei, ignoredInvalidChildLei } = resolvePipelineLei(
+      lei,
+      job.data.lei
+    )
+    if (ignoredInvalidChildLei) {
+      job.log(
+        `Ignoring invalid LEI from extractLEI child: '${ignoredInvalidChildLei}'`
+      )
+    }
     const wikidataNode =
       wikidata?.node?.trim() ??
       job.data.wikidata?.node?.trim() ??

--- a/src/workers/checkDB.ts
+++ b/src/workers/checkDB.ts
@@ -212,7 +212,7 @@ const checkDB = new PipelineWorker(
 
     if (!staffResolvedCompanyLink) {
       const saveResolution = await resolvePipelineCompanyAfterIdentifiers(
-        { wikidata: mergedWikidata, lei: mergedLei },
+        { wikidata: mergedWikidata, lei: mergedLei ?? undefined },
         companyName,
         companyId
       )

--- a/src/workers/extractEmissions.ts
+++ b/src/workers/extractEmissions.ts
@@ -191,6 +191,10 @@ const extractEmissions = new PipelineWorker<ExtractEmissionsJob>(
             companyId,
             ...(wikidataId && { wikidataId }),
           },
+          opts: withPipelineJobOpts({
+            attempts: 3,
+            failParentOnFailure: false,
+          }),
         },
       },
       {

--- a/src/workers/extractLEI.ts
+++ b/src/workers/extractLEI.ts
@@ -11,6 +11,10 @@ import {
   buildLeiPrompt,
   inferPreferSwedishLeiFromUrls,
 } from '../lib/reportLeiPreference'
+import { isValidLei } from '../lib/normalizeLei'
+
+const INVALID_LEI_MESSAGE =
+  'Invalid LEI: value does not match the required 20-character format with a valid checksum. LEI will not be saved.'
 
 export class LEIJob extends PipelineJob {
   declare data: PipelineJob['data'] & {
@@ -115,11 +119,29 @@ const extractLEI = new PipelineWorker<LEIJob>(
       lei = await selectLeiFromGleif(job, companyName)
     }
 
-    if (lei) {
-      job.log(`✅ Found LEI for '${companyName}': ${lei}`)
+    if (!lei) {
+      job.log(`No LEI found for '${companyName}'.`)
+      return {
+        lei: null,
+        companyId,
+        ...(wikidataId && { wikidataId }),
+      }
     }
 
-    return { lei, companyId, ...(wikidataId && { wikidataId }) }
+    if (!isValidLei(lei)) {
+      job.log(`❌ ${INVALID_LEI_MESSAGE} Received: '${lei}'`)
+      await job.sendMessage(
+        `❌ ${INVALID_LEI_MESSAGE} (received '${lei}' for ${companyName})`
+      )
+      throw new Error(`${INVALID_LEI_MESSAGE} Received: '${lei}'`)
+    }
+
+    job.log(`✅ Found LEI for '${companyName}': ${lei}`)
+    return {
+      lei: lei.trim().toUpperCase(),
+      companyId,
+      ...(wikidataId && { wikidataId }),
+    }
   }
 )
 


### PR DESCRIPTION
## Summary
- Add ISO 17442 mod-97-10 LEI validation in `normalizeLei` and use it when merging pipeline LEI values in `checkDB`.
- `extractLEI` completes successfully with `lei: null` when no LEI is found, but fails (red job) when a value has invalid format or checksum.
- Set `failParentOnFailure: false` on the extractLEI child job so checkDB and saves continue.

## Related PRs
- pipeline-api: LEI validation non-blocking run status
- validate-frontend: LEI validation non-blocking Jobbstatus step status

## Test plan
- [ ] Run a report where no LEI exists — extractLEI job green, LEI saved as null
- [ ] Run a report where extractLEI gets an invalid/placeholder LEI — extractLEI red, run still completes, LEI null in API
- [ ] Run a report with a valid LEI — extractLEI green, LEI saved correctly