### PR TITLE
Preserve separate report shells after company merge

### DIFF
--- a/src/api/services/companyReportService.ts
+++ b/src/api/services/companyReportService.ts
@@ -175,14 +175,6 @@ class CompanyReportService {
       return row.id
     }
 
-    const existing = await prisma.companyReport.findFirst({
-      where: { companyId, registryReportId: null },
-      orderBy: { createdAt: 'desc' },
-      select: { id: true },
-    })
-
-    if (existing) return existing.id
-
     const created = await prisma.companyReport.create({
       data: { companyId, registryReportId: null },
       select: { id: true },
@@ -253,14 +245,6 @@ class CompanyReportService {
   }
 
   async getOrCreateFallbackCompanyReportId(companyId: string): Promise<string> {
-    const existing = await prisma.companyReport.findFirst({
-      where: { companyId },
-      orderBy: [{ reportYear: 'desc' }, { createdAt: 'desc' }],
-      select: { id: true },
-    })
-
-    if (existing) return existing.id
-
     return this.findOrCreateCompanyReport(companyId, null)
   }
 
@@ -316,7 +300,7 @@ class CompanyReportService {
       company.id
     )
     console.warn(
-      '[companyReportService] Inferred companyReportId from latest CompanyReport for company',
+      '[companyReportService] Created new CompanyReport shell (no report identity on save)',
       { companyId: company.id, companyReportId }
     )
     return { companyReportId, inferred: true }

--- a/src/lib/reportSaveIdentity.ts
+++ b/src/lib/reportSaveIdentity.ts
@@ -13,6 +13,7 @@ type JobReportFields = {
   pdfCache?: { publicUrl?: string; sha256?: string }
   documentReportYear?: string | number
   registryReportId?: string
+  companyReportId?: string
 }
 
 function trimOptional(value: unknown): string | undefined {
@@ -116,6 +117,9 @@ export function buildReportingPeriodsApiBodyExtras(
     reportSha256: identity.reportSha256,
     ...(trimOptional(jobData.registryReportId) && {
       registryReportId: trimOptional(jobData.registryReportId),
+    }),
+    ...(trimOptional(jobData.companyReportId) && {
+      companyReportId: trimOptional(jobData.companyReportId),
     }),
   }
 }

--- a/tests/companyReportService.test.ts
+++ b/tests/companyReportService.test.ts
@@ -78,11 +78,11 @@ describe('companyReportService', () => {
     )
   })
 
-  it('falls back to the latest CompanyReport when no report identity', async () => {
-    const findFirst = jest
-      .spyOn(prisma.companyReport, 'findFirst')
+  it('creates a new CompanyReport shell when no report identity', async () => {
+    const create = jest
+      .spyOn(prisma.companyReport, 'create')
       .mockResolvedValueOnce({
-        id: 'cr-legacy',
+        id: 'cr-new',
       } as never)
 
     const result = await companyReportService.resolveCompanyReportIdForSave(
@@ -90,10 +90,10 @@ describe('companyReportService', () => {
       [{ year: '2024' }]
     )
 
-    expect(result).toEqual({ companyReportId: 'cr-legacy', inferred: true })
-    expect(findFirst).toHaveBeenCalledWith(
+    expect(result).toEqual({ companyReportId: 'cr-new', inferred: true })
+    expect(create).toHaveBeenCalledWith(
       expect.objectContaining({
-        orderBy: [{ reportYear: 'desc' }, { createdAt: 'desc' }],
+        data: { companyId: 'company-1', registryReportId: null },
       })
     )
   })


### PR DESCRIPTION
## Summary
- Forward `companyReportId` from checkDB through pipeline period save so each run keeps its own CompanyReport shell.
- Stop reusing the latest CompanyReport shell (and the shared null-registry shell) when save cannot infer report identity, so distinct PDFs no longer collapse into one editor shell after company-link merge.

## Test plan
- [ ] Run two different PDFs for related entities (e.g. Sampo Group + Sampo plc), merge under one company name in jobbstatus — editor should show two report shells.
- [ ] Re-run the same PDF — data should update on the existing shell, not create a duplicate.
- [ ] CI: Tests, Type Check, Lint, Format pass.

Made with [Cursor](https://cursor.com)