### PR TITLE
[Prod] Minor Version Bump v6.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo",
-  "version": "6.0.10-rc.6",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo",
-      "version": "6.0.10-rc.6",
+      "version": "6.1.0",
       "hasInstallScript": true,
       "license": "MIT License",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garbo",
-  "version": "6.0.10-rc.6",
+  "version": "6.1.0",
   "description": "",
   "type": "module",
   "exports": {


### PR DESCRIPTION
# 🚀 Production Release PR

> **Title format:** `[Prod] Major/Minor/Patch Version Bump vX.X.X`

## 📦 Release Type

- [ ] Major version bump
- [x] Minor version bump
- [ ] Patch version bump

### Rollback Version

v6.0.9

## 🔁 Environment Promotion

This release promotes changes **from `staging` to `production`** (staging validated on `6.0.10-rc.x`).

## 📋 What's Being Released

Everything merged since **v6.0.9**:

### Company link & dedup improvements
- Fix Nestlé-style company dedup, display names, and locale-aware LEI selection (#1381)
- Company link partial match and display name rename (#1384)
- Allow create-new company on partial name match approvals (#1385)

### LEI validation
- Validate LEI checksum and fail invalid extractions without blocking saves (#1386)

### Report shells
- Preserve separate CompanyReport shells when merging pipeline runs under one company (#1387)

### Error browser support (schema)
- Add `ErrorType` and `DatapointNote` tables for per-datapoint error notes
- Reconcile `Report.batchId` migration history with API repo

## 🗂 Deployment Notes

- Deploy **Garbo**, **pipeline-api v0.6.0**, **API v1.7.0**, and **Validate v1.17.0** together for the full company-link / LEI / error-notes flow
- DB migrations for datapoint notes ship with this release — migrate before or with API v1.7.0
- Flux will update production image tag after merge/build

## ✅ Checklist

- [x] Version number is updated correctly (`6.1.0`)
- [ ] All relevant changes have been QA-tested in staging
- [x] Rollback version has been updated
- [x] Title follows the required format: `[Prod] Minor Version Bump v6.1.0`
