### PR TITLE
fix: accept CUID for verifiedByUserId on company updates

### DIFF
--- a/src/api/schemas/request.ts
+++ b/src/api/schemas/request.ts
@@ -14,7 +14,7 @@ const createMetadataSchema = z.object({
     .optional(),
   verified: z.boolean().optional(),
   /** Staff user id when a human approved Wikidata in Validate (pipeline worker JWT). */
-  verifiedByUserId: z.string().uuid().optional(),
+  verifiedByUserId: z.string().cuid().optional(),
 })
 
 export const descriptionSchema = z.object({


### PR DESCRIPTION
## Summary

- Change \erifiedByUserId\ request validation from UUID to CUID
- Fixes Wikidata manual approval in Validate: staff JWT user ids are Garbo \User.id\ (cuid), not UUID

## Test plan

- [ ] Approve Wikidata in Validate Jobbstatus; \guessWikidata\ persist succeeds
- [ ] No migration required

Paired with UnearthData/api#89

Made with [Cursor](https://cursor.com)