### PR TITLE
[Prod] Patch Version Bump v6.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo",
-  "version": "6.1.1-rc.1",
+  "version": "6.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo",
-      "version": "6.1.1-rc.1",
+      "version": "6.1.1",
       "hasInstallScript": true,
       "license": "MIT License",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garbo",
-  "version": "6.1.1-rc.1",
+  "version": "6.1.1",
   "description": "",
   "type": "module",
   "exports": {


### PR DESCRIPTION
# 🚀 Production Release PR

> **Title format:** `[Prod] Major/Minor/Patch Version Bump vX.X.X`

## 📦 Release Type

- [ ] Major version bump
- [ ] Minor version bump
- [x] Patch version bump

### Rollback Version

v6.1.0

## 🔁 Environment Promotion

This release promotes changes **from `staging` to `production`** (staging validated on `6.1.1-rc.x`).

## 📋 What's Being Released

Everything merged since **v6.1.0**:

### Wikidata approval fix ([#1389](https://github.com/Klimatbyran/garbo/pull/1389))

- Accept CUID for `verifiedByUserId` on company updates (was incorrectly validated as UUID)
- Fixes manual Wikidata approval in Validate: staff JWT user ids are Garbo `User.id` (cuid)
- **Required for prod:** workers persist Wikidata via Garbo internal API (`http://garbo/api`)

## 🗂 Deployment Notes

- No DB migration
- Deploy **Garbo API + worker** together (same image)
- Optional paired **API v1.7.1** for Unearth staff route parity
- After deploy: rerun or re-approve failed `guessWikidata` jobs

## ✅ Checklist

- [x] Version number is updated correctly (`6.1.1`)
- [ ] All relevant changes have been QA-tested in staging
- [x] Rollback version has been updated
- [x] Title follows the required format: `[Prod] Patch Version Bump v6.1.1`
