### PR TITLE
Fix reportingQuality save creating duplicate CompanyReport on rerun

### DIFF
--- a/src/api/routes/internal/company.reportingQuality.ts
+++ b/src/api/routes/internal/company.reportingQuality.ts
@@ -39,6 +39,7 @@ export async function companyReportingQualityRoutes(app: FastifyInstance) {
       const { id } = request.params
       const {
         url,
+        companyReportId,
         usesGhgProtocolCategories,
         categoryLabelsExample,
         methodChanges,
@@ -56,6 +57,7 @@ export async function companyReportingQualityRoutes(app: FastifyInstance) {
         const company = await companyService.getCompanyByInternalId(id)
         await reportingQualityService.upsert(company.id, {
           url,
+          companyReportId,
           usesGhgProtocolCategories,
           categoryLabelsExample,
           methodChanges,

--- a/src/api/schemas/request.ts
+++ b/src/api/schemas/request.ts
@@ -323,6 +323,8 @@ const fragmentedValuesReportingSchema = z
 export const postReportingQualitySchema = z
   .object({
     url: z.string(),
+    /** Resolved once by checkDB; when present, skip re-deriving the report link from url. */
+    companyReportId: z.string().optional(),
     usesGhgProtocolCategories: z
       .enum(['FULL', 'GROUPED', 'CUSTOM_LABELS', 'SINGLE_TOTAL'])
       .nullable(),

--- a/src/api/services/reportingQualityService.ts
+++ b/src/api/services/reportingQualityService.ts
@@ -20,6 +20,8 @@ type Scope3CategoryFragmentation = {
 
 type ReportingQualityInput = {
   url: string
+  /** Resolved once by checkDB; when present, use directly instead of re-deriving via url. */
+  companyReportId?: string
   usesGhgProtocolCategories:
     | 'FULL'
     | 'GROUPED'
@@ -40,16 +42,27 @@ type ReportingQualityInput = {
 
 class ReportingQualityService {
   async upsert(companyId: string, input: ReportingQualityInput): Promise<void> {
-    const registryReport = await prisma.report.findFirst({
-      where: { url: input.url },
-      select: { id: true },
-    })
+    let companyReportId: string
 
-    const companyReportId =
-      await companyReportService.findOrCreateCompanyReport(
+    if (input.companyReportId?.trim()) {
+      companyReportId = input.companyReportId.trim()
+      await companyReportService.assertCompanyReportBelongsToCompany(
+        companyReportId,
+        companyId
+      )
+    } else {
+      // Fallback for callers that don't have a resolved companyReportId yet
+      // (e.g. a manual API call) - re-derive it from the registry by url.
+      const registryReport = await prisma.report.findFirst({
+        where: { url: input.url },
+        select: { id: true },
+      })
+
+      companyReportId = await companyReportService.findOrCreateCompanyReport(
         companyId,
         registryReport?.id ?? null
       )
+    }
 
     const fields = {
       usesGhgProtocolCategories: input.usesGhgProtocolCategories,

--- a/src/workers/diffReportingQuality.ts
+++ b/src/workers/diffReportingQuality.ts
@@ -16,6 +16,8 @@ type Scope3CategoryFragmentation = {
 export class DiffReportingQualityJob extends DiffJob {
   declare data: DiffJob['data'] & {
     companyName: string
+    /** Resolved once by checkDB; use directly instead of re-deriving via url at save time. */
+    companyReportId?: string
     reportingQuality: {
       usesGhgProtocolCategories:
         | 'FULL'
@@ -41,10 +43,11 @@ export class DiffReportingQualityJob extends DiffJob {
 const diffReportingQuality = new DiffWorker<DiffReportingQualityJob>(
   QUEUE_NAMES.DIFF_REPORTING_QUALITY,
   async (job) => {
-    const { companyName, url, reportingQuality } = job.data
+    const { companyName, url, companyReportId, reportingQuality } = job.data
 
     await job.enqueueSaveToAPI('reporting-quality', companyName, {
       url,
+      ...(companyReportId && { companyReportId }),
       usesGhgProtocolCategories: reportingQuality.usesGhgProtocolCategories,
       categoryLabelsExample: reportingQuality.categoryLabelsExample,
       methodChanges: reportingQuality.methodChanges,


### PR DESCRIPTION
## Summary
checkDB already resolves `companyReportId`/`registryReportId` once per run and carries it on `job.data` for exactly this purpose - the sibling `DIFF_REPORT_TYPE` job already uses it - but `diffReportingQuality` never read it, so the save endpoint fell back to an independent url-based `Report` lookup. That lookup silently breaks whenever the save-time url differs from the registry's stored url (e.g. a `forceReindex` rerun that re-caches the PDF to a fresh S3 location): the lookup misses, `registryReportId` resolves to null, and a brand new orphan `CompanyReport` gets created instead of reusing the existing linked one.

- Forward `companyReportId` through `diffReportingQuality`'s job data.
- Use it directly when present (with an `assertCompanyReportBelongsToCompany` safety check), falling back to the old url-based derivation only when it's absent (e.g. a manual API call with no pipeline context).

Found while investigating a Momentum Group rerun on stage that created a duplicate, registry-unlinked `CompanyReport` instead of saving against the existing one.

Companion fix in `api`: mirrors this same change on the save-endpoint side.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx prettier --check` clean for files in this PR
- [ ] Rerun Momentum Group's reportingQuality on stage once this + the api companion PR are deployed, confirm it saves against the existing CompanyReport (`cmpy5ie8h00f2w3urfia3cyr8`) instead of creating a new one

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `CompanyReport` is chosen for reporting-quality upserts; wrong or missing `companyReportId` could attach metadata to the wrong report, though the ownership assert mitigates cross-company misuse.
> 
> **Overview**
> **Fixes duplicate `CompanyReport` rows** when reporting quality is saved after a pipeline rerun where the PDF URL changed (e.g. fresh S3 cache on `forceReindex`).
> 
> The internal **reporting-quality** POST body and `reportingQualityService.upsert` now take optional **`companyReportId`** (already resolved in `checkDB`). When present, the service uses that id after **`assertCompanyReportBelongsToCompany`** and skips registry lookup by `url`. When absent (manual API calls), behavior is unchanged: resolve registry `Report` by `url`, then **`findOrCreateCompanyReport`**.
> 
> **`diffReportingQuality`** forwards `companyReportId` from job data into the save-to-API payload, aligning with sibling diff jobs that already carry the early-resolved report link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffe4f88b6a64e2ce66765db4403fab0d89a9df21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->