### PR TITLE
Trust caller-supplied wikidataId in guessWikidata, skip search

### DIFF
--- a/src/workers/guessWikidata.ts
+++ b/src/workers/guessWikidata.ts
@@ -472,6 +472,89 @@ const guessWikidata = new PipelineWorker<GuessWikidataJob>(
       return
     }
 
+    // Caller already knows the exact company (e.g. Validate's urlContexts.wikidataId,
+    // set on this job as job.data.wikidata) - trust it outright: no name search, no
+    // approval step. Distinct from overrideWikidataId above, which is a human
+    // explicitly correcting a guess and still needs to verify that correction.
+    if (pendingWikidata?.node) {
+      const trustedEntities = await getWikidataEntities([
+        pendingWikidata.node as `Q${number}`,
+      ])
+
+      if (trustedEntities.length) {
+        const [{ id, labels, descriptions }] = trustedEntities
+
+        const trustedWikidata = {
+          node: id,
+          url: `https://wikidata.org/wiki/${id}`,
+          label:
+            labels?.sv?.value ??
+            labels?.en?.value ??
+            Object.values(labels ?? {})[0]?.value ??
+            companyName,
+          description:
+            descriptions?.sv?.value ??
+            descriptions?.en?.value ??
+            Object.values(descriptions ?? {})[0]?.value ??
+            '',
+        } satisfies Wikidata
+
+        // Still guard against this wikidataId already belonging to a different
+        // pipeline company (e.g. a duplicate-company situation) - cheap id-based
+        // check, not a name search, so it doesn't reintroduce the guessing this
+        // fast path exists to skip.
+        const readyBeforeApproval = await requestCompanyLinkIfWikidataConflict(
+          job,
+          companyName,
+          trustedWikidata
+        )
+        if (!readyBeforeApproval) return
+
+        const metadata = {
+          source: 'pipeline-supplied-wikidata',
+          comment:
+            'Wikidata ID explicitly supplied by the caller (e.g. a Validate rerun) - trusted, no search performed',
+        }
+
+        await job.requestApproval(
+          'wikidata',
+          { type: 'wikidata', newValue: { wikidata: trustedWikidata } },
+          true, // auto-approved
+          metadata,
+          `Auto-approved wikidata for ${companyName} (caller-supplied)`
+        )
+
+        const ready = await ensureCompanyLinkBeforeWikidataPersist(
+          job,
+          companyName,
+          trustedWikidata
+        )
+        if (!ready) return
+
+        await persistApprovedWikidata(job, companyName, trustedWikidata, {
+          verified: false,
+          metadata,
+        })
+
+        await job.sendMessage({
+          content: `Wikidata already known for ${companyName} — skipped search.`,
+        })
+
+        return JSON.stringify(
+          {
+            status: 'approved',
+            wikidata: trustedWikidata,
+            message: `Auto-approved wikidata for ${companyName} (caller-supplied, no search)`,
+            metadata,
+          },
+          null,
+          2
+        )
+      }
+      // If the id doesn't resolve to a real entity, fall through to the normal
+      // search-based flow below as a safety net rather than failing outright.
+    }
+
     /* NOTE: Can be activated once the corresponding endpoint is ready in prod
 
     const queryProductionRes = await fetch(apiConfig.prod_base_url + '/companies/search?q=' + companyName , {method: 'GET', headers: {'Content-Type': 'application/json'}});    


### PR DESCRIPTION
## Summary
`guessWikidata` runs unconditionally on every `precheck` (not filtered by `runOnly`) and always re-derived the company's Wikidata identity from scratch via a name-based search - even when the caller already told the pipeline exactly which company this is (e.g. Validate's rerun feature passing `urlContexts.wikidataId`, which lands on `job.data.wikidata`). It would still search by the PDF-extracted company name, and only auto-approve if the result's label happened to textually match that name closely enough - otherwise it created a spurious "Wikidata mismatch" approval request, even when the correct entity was right there in the search results and `autoApprove` was on.

There's already a distinct fast path for a known id (`overrideWikidataId`), but it always forces manual approval regardless of `autoApprove` - that's intentional there, since it's for a human explicitly correcting a prior guess and needing to verify the correction.

- Add a new fast path for `job.data.wikidata` specifically: when the caller supplied it directly (not guessed), fetch that exact entity by id (no name search) and auto-approve unconditionally.
- Keeps the existing `requestCompanyLinkIfWikidataConflict` safety check (a cheap id-based lookup, not a search) so an id already linked to a *different* company still surfaces for staff confirmation instead of silently misattaching data.
- Verified `job.data.wikidata` is only ever set in one place ([pipeline-api's `pipelineCompanyJobData.ts`](https://github.com/Klimatbyran/pipeline-api/blob/main/src/lib/pipelineCompanyJobData.ts)), always from an explicit caller-supplied `urlContexts.wikidataId` - never an internal soft guess - so trusting it unconditionally here is safe.

Found while investigating a rerun from the Errors browser incorrectly surfacing a "Wikidata mismatch" for a company already confirmed via `urlContexts`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx prettier --check` clean
- [ ] Rerun a known company (e.g. Infortar) from the Errors browser once deployed, confirm no "Wikidata mismatch" approval is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how company Wikidata identity is resolved on every precheck run when a node is pre-set; wrong caller input could attach the wrong entity, though conflict detection and invalid-ID fallback limit blast radius.
> 
> **Overview**
> **`guessWikidata`** now short-circuits when **`job.data.wikidata`** already carries a Wikidata node (e.g. Validate reruns via `urlContexts.wikidataId`): it loads that entity by ID, auto-approves it, persists, and skips name search and label-mismatch approvals.
> 
> This path is separate from **`overrideWikidataId`**, which still requires manual verification. The existing **`requestCompanyLinkIfWikidataConflict`** check remains so an ID already tied to another pipeline company can still surface a company-link approval. If the ID does not resolve in Wikidata, processing falls through to the normal search/LLM flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 589019de42b2f0949215a3527318482eab81472a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->