### PR TITLE
Track client API request service (garbo vs unearth)

### DIFF
--- a/doc/API_KEYS.md
+++ b/doc/API_KEYS.md
@@ -57,12 +57,12 @@ The gate only consults this registry; it does not infer permissions from route h
 
 Defined in `**prisma/schema.prisma**` (tables mapped with `@@map`):
 
-| Model                         | Purpose                                                                                                                                                                                 |
-| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `**ClientApiPermission**`     | One row per permission **code** (e.g. `api.companies.list`).                                                                                                                            |
-| `**ClientApiRole**`           | Named role (`**slug**`) e.g. `all_access`, `base`.                                                                                                                                      |
-| `**ClientApiRolePermission**` | Many-to-many: which permissions a role has.                                                                                                                                             |
-| `**ClientApiKey**`            | `**keyLookup**` (public id segment), `**secretHash**`, `**roleId**`, `**revokedAt**`, `**lastUsedAt**`. Full plaintext key is `**garb_<keyLookup>.<secret>**`; only the hash is stored. |
+| Model                         | Purpose                                                                                                                                                                                         |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `**ClientApiPermission**`     | One row per permission **code** (e.g. `api.companies.list`).                                                                                                                                    |
+| `**ClientApiRole**`           | Named role (`**slug**`) e.g. `all_access`, `base`.                                                                                                                                              |
+| `**ClientApiRolePermission**` | Many-to-many: which permissions a role has.                                                                                                                                                     |
+| `**ClientApiKey**`            | `**keyLookup**` (public id segment), `**secretHash**`, `**roleId**`, `**revokedAt**`, `**lastUsedAt**`. Full plaintext key is `**garb_<keyLookup>.<secret>**`; only the hash is stored.         |
 | `**ClientApiRequest**`        | One row per successful authenticated request. Fields: `**keyId**`, `**path**`, `**method**`, `**statusCode**`, `**service**` (`garbo` \| `unearth`), `**timestamp**`. Used for usage analytics. |
 
 Migrations: `prisma/migrations/20260413120000_client_api_keys/` (core tables), `20260512100000_client_api_key_last_used_at/` (`last_used_at` column), `20260513120000_client_api_request/` (usage tracking table).

--- a/doc/API_KEYS.md
+++ b/doc/API_KEYS.md
@@ -63,7 +63,7 @@ Defined in `**prisma/schema.prisma**` (tables mapped with `@@map`):
 | `**ClientApiRole**`           | Named role (`**slug**`) e.g. `all_access`, `base`.                                                                                                                                      |
 | `**ClientApiRolePermission**` | Many-to-many: which permissions a role has.                                                                                                                                             |
 | `**ClientApiKey**`            | `**keyLookup**` (public id segment), `**secretHash**`, `**roleId**`, `**revokedAt**`, `**lastUsedAt**`. Full plaintext key is `**garb_<keyLookup>.<secret>**`; only the hash is stored. |
-| `**ClientApiRequest**`        | One row per successful authenticated request (excluding `all_access` role). Fields: `**keyId**`, `**path**`, `**method**`, `**statusCode**`, `**timestamp**`. Used for usage analytics. |
+| `**ClientApiRequest**`        | One row per successful authenticated request. Fields: `**keyId**`, `**path**`, `**method**`, `**statusCode**`, `**service**` (`garbo` \| `unearth`), `**timestamp**`. Used for usage analytics. |
 
 Migrations: `prisma/migrations/20260413120000_client_api_keys/` (core tables), `20260512100000_client_api_key_last_used_at/` (`last_used_at` column), `20260513120000_client_api_request/` (usage tracking table).
 
@@ -71,7 +71,7 @@ Migrations: `prisma/migrations/20260413120000_client_api_keys/` (core tables), `
 
 ## Usage tracking (`ClientApiRequest`)
 
-Every successful request authenticated with a non-`all_access` key is logged to `**ClientApiRequest**`. The `all_access` role (used internally by Validate/Bolt) is excluded to avoid polluting the table with first-party traffic.
+Every successful request authenticated with a client API key is logged to `**ClientApiRequest**`, including `all_access` (Validate/Bolt). The `**service**` column records which API process handled the call (`garbo` or `unearth`) so Metabase/usage can split shared-DB traffic.
 
 Logging happens in the `**onResponse**` hook in `**clientApiKeyGate.ts**` — fire-and-forget, so it never blocks the response. Any write failure is logged with `**event: 'client_api_request_log_error'**`.
 

--- a/prisma/migrations/20260824120000_client_api_request_service/migration.sql
+++ b/prisma/migrations/20260824120000_client_api_request_service/migration.sql
@@ -1,0 +1,4 @@
+-- Which API process recorded the request (shared DB; values set by each service's gate).
+ALTER TABLE "client_api_request" ADD COLUMN "service" TEXT;
+
+CREATE INDEX "client_api_request_service_idx" ON "client_api_request"("service");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -739,12 +739,15 @@ model ClientApiRequest {
   path       String
   method     String
   statusCode Int      @map("status_code")
+  /// Which API wrote this row (`garbo` | `unearth`). Null for rows logged before this column existed.
+  service    String?  @map("service")
   timestamp  DateTime @default(now())
 
   key ClientApiKey @relation(fields: [keyId], references: [id], onDelete: Cascade)
 
   @@index([keyId])
   @@index([timestamp])
+  @@index([service])
   @@map("client_api_request")
 }
 

--- a/src/api/plugins/clientApiKeyGate.ts
+++ b/src/api/plugins/clientApiKeyGate.ts
@@ -196,6 +196,10 @@ async function clientApiKeyGatePlugin(app: FastifyInstance) {
 
   app.addHook('onResponse', (request, reply, done) => {
     const keyId = request.clientApiKeyId
+    // TODO: Once Garbo/Unearth client endpoint deduplication is complete, skip
+    // logging `all_access` again (Validate/Bolt first-party traffic) so
+    // `client_api_request` only retains partner/client usage. Mirror the same
+    // filter in Unearth's clientApiKeyGate and the usage summary if needed.
     if (keyId) {
       prisma.clientApiRequest
         .create({

--- a/src/api/plugins/clientApiKeyGate.ts
+++ b/src/api/plugins/clientApiKeyGate.ts
@@ -196,7 +196,7 @@ async function clientApiKeyGatePlugin(app: FastifyInstance) {
 
   app.addHook('onResponse', (request, reply, done) => {
     const keyId = request.clientApiKeyId
-    if (keyId && request.clientApiKeyRoleSlug !== 'all_access') {
+    if (keyId) {
       prisma.clientApiRequest
         .create({
           data: {
@@ -204,6 +204,7 @@ async function clientApiKeyGatePlugin(app: FastifyInstance) {
             path: pathnameOnly(request.url),
             method: request.method,
             statusCode: reply.statusCode,
+            service: 'garbo',
           },
         })
         .catch((err) =>

--- a/src/api/routes/internal/clientApiKeys.admin.ts
+++ b/src/api/routes/internal/clientApiKeys.admin.ts
@@ -39,6 +39,8 @@ const clientApiKeyListItemSchema = z.object({
 const usageEndpointSchema = z.object({
   method: z.string(),
   path: z.string(),
+  /** `garbo` | `unearth`; null for rows logged before service was recorded. */
+  service: z.string().nullable(),
   count: z.number(),
 })
 
@@ -342,7 +344,7 @@ export async function clientApiKeysAdminRoutes(app: FastifyInstance) {
       schema: {
         summary: 'Client API key usage summary',
         description:
-          'Staff only. Returns aggregated request counts per key and endpoint. Excludes all_access keys (internal traffic). Optional `since` query param (ISO date) to filter by time window.',
+          'Staff only. Returns aggregated request counts per key and endpoint for all roles (including all_access). Each endpoint row includes `service` (`garbo` | `unearth`, or null for legacy rows). Optional `since` query param (ISO date) to filter by time window.',
         tags: getTags('Internal'),
         querystring: z.object({
           since: z.string().datetime({ offset: true }).optional(),
@@ -359,7 +361,7 @@ export async function clientApiKeysAdminRoutes(app: FastifyInstance) {
       const where = since ? { timestamp: { gte: new Date(since) } } : {}
 
       const rows = await prisma.clientApiRequest.groupBy({
-        by: ['keyId', 'method', 'path'],
+        by: ['keyId', 'method', 'path', 'service'],
         where,
         _count: { id: true },
         _max: { timestamp: true },
@@ -384,7 +386,12 @@ export async function clientApiKeysAdminRoutes(app: FastifyInstance) {
           roleSlug: string
           totalRequests: number
           lastRequestAt: Date | null
-          endpoints: { method: string; path: string; count: number }[]
+          endpoints: {
+            method: string
+            path: string
+            service: string | null
+            count: number
+          }[]
         }
       >()
 
@@ -412,7 +419,12 @@ export async function clientApiKeysAdminRoutes(app: FastifyInstance) {
         if (ts && (!entry.lastRequestAt || ts > entry.lastRequestAt)) {
           entry.lastRequestAt = ts
         }
-        entry.endpoints.push({ method: row.method, path: row.path, count })
+        entry.endpoints.push({
+          method: row.method,
+          path: row.path,
+          service: row.service,
+          count,
+        })
       }
 
       return reply.send(


### PR DESCRIPTION
## Summary
- Add nullable `client_api_request.service` (migration owned here; Unearth mirrors schema only)
- Log **all** authenticated client keys (including `all_access`) with `service: 'garbo'`
- Include `service` in the usage summary aggregation so Metabase/Validate can tell Garbo vs Unearth traffic on the shared DB

## Deploy note
Apply this Garbo migration **before** deploying Unearth API builds that write `service`, or inserts will fail until the column exists.

## Test plan
- [ ] Run migration on stage
- [ ] Hit a gated client route with a non-`all_access` key and an `all_access` key; confirm rows in `client_api_request` with `service = 'garbo'`
- [ ] `GET /api/internal/client-api-keys/usage` returns endpoint rows with `service`
- [ ] Metabase: `SELECT service, COUNT(*) FROM client_api_request GROUP BY 1`

Made with [Cursor](https://cursor.com)