### PR TITLE
[Prod] Patch Version Bump v6.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo",
-  "version": "6.1.2-rc.3",
+  "version": "6.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo",
-      "version": "6.1.2-rc.3",
+      "version": "6.1.2",
       "hasInstallScript": true,
       "license": "MIT License",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garbo",
-  "version": "6.1.2-rc.3",
+  "version": "6.1.2",
   "description": "",
   "type": "module",
   "exports": {


### PR DESCRIPTION
# 🚀 Production Release PR

> **Title format:** `[Prod] Major/Minor/Patch Version Bump vX.X.X`

## 📦 Release Type

- [ ] Major version bump
- [ ] Minor version bump
- [x] Patch version bump

### Rollback Version

v6.1.1

## 🔁 Environment Promotion

This release promotes changes **from `staging` to `production`** (staging validated on `6.1.2-rc.x`).

## 📋 What's Being Released

Everything merged since **v6.1.1**:

### Reporting quality worker ([#1291](https://github.com/Klimatbyran/garbo/pull/1291))

- New pipeline follow-up that extracts reporting quality flags from each processed PDF
- Creates `ReportingQuality` table (linked to `CompanyReport`) plus follow-up migrations for detail / fragmented values
- **Required for prod:** Unearth API already queries this table on pipeline company list; without this deploy, prod returns `P2021` (`ReportingQuality` does not exist)

### Reporting quality save fix ([#1391](https://github.com/Klimatbyran/garbo/pull/1391))

- Forward `companyReportId` into reportingQuality save instead of re-deriving via URL
- Prevents duplicate / orphan `CompanyReport` rows on force-reindex reruns

### Remove unused territorial client reads ([#1376](https://github.com/Klimatbyran/garbo/pull/1376))

- Drop Garbo client routes for municipalities / regions / nation (served by Unearth)

## 🗂 Deployment Notes

- **DB migrations (apply on deploy via init `npm run migrate`):**
  - `20260806120000_add_reporting_quality`
  - `20260810120000_reporting_quality_detail`
  - `20260810130000_reporting_quality_fragmented_values`
- Deploy **Garbo API + worker** together (same image)
- After deploy: confirm `/api/pipeline/companies` and Unearth `/api/internal-pipeline/companies` return 200 (fixes missing `ReportingQuality` table on prod)

## ✅ Checklist

- [x] Version number is updated correctly (`6.1.2`)
- [ ] All relevant changes have been QA-tested in staging
- [x] Rollback version has been updated
- [x] Title follows the required format: `[Prod] Patch Version Bump v6.1.2`