### PR TITLE
Add company alternativeNames foundation

### DIFF
--- a/prisma/migrations/20260824140000_company_alternative_names/migration.sql
+++ b/prisma/migrations/20260824140000_company_alternative_names/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Company" ADD COLUMN "alternativeNames" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,6 +41,9 @@ model Company {
   /// Tags to help categorize and filter companies. Each string must match TagOption.slug.
   tags String[]
 
+  /// Other known names for internal search and company linking. Do not duplicate `name`.
+  alternativeNames String[] @default([])
+
   logoUrl String?
 
   identifiers CompanyIdentifier[]

--- a/src/lib/companyAlternativeNames.test.ts
+++ b/src/lib/companyAlternativeNames.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from '@jest/globals'
+import {
+  isFormattingVariantOfCompanyName,
+  mergeAlternativeNames,
+} from './companyAlternativeNames'
+import { companyNameMatchKey } from './companyLinkResolve'
+
+describe('companyNameMatchKey', () => {
+  it('folds case, spaces, periods, and legal suffixes', () => {
+    expect(companyNameMatchKey('Volvo AB')).toBe('volvo')
+    expect(companyNameMatchKey('VOLVO  A.B.')).toBe('volvo')
+    expect(companyNameMatchKey('AB Volvo')).toBe('volvo')
+    expect(companyNameMatchKey('  Volvo,   AB ')).toBe('volvo')
+  })
+
+  it('keeps significant tokens so brand-family entities stay distinct', () => {
+    expect(companyNameMatchKey('Volvo AB')).toBe('volvo')
+    expect(companyNameMatchKey('Volvo Cars')).toBe('volvo cars')
+    expect(companyNameMatchKey('Volvo AB')).not.toBe(
+      companyNameMatchKey('Volvo Cars')
+    )
+  })
+
+  it('folds diacritics and ampersands', () => {
+    expect(companyNameMatchKey('Nestlé Sverige')).toBe('nestle sverige')
+    expect(companyNameMatchKey('H&M')).toBe('h m')
+    expect(companyNameMatchKey('H & M')).toBe('h m')
+  })
+})
+
+describe('mergeAlternativeNames', () => {
+  it('dedupes formatting variants and drops the canonical name', () => {
+    expect(
+      mergeAlternativeNames({
+        canonicalName: 'Volvo AB',
+        existingAlternativeNames: ['VOLVO  A.B.', 'Ab Volvo'],
+        incomingNames: ['volvo ab', 'Volvo Group'],
+      })
+    ).toEqual(['Volvo Group'])
+  })
+
+  it('keeps distinct significant-token names (Volvo Cars ≠ Volvo AB)', () => {
+    expect(
+      mergeAlternativeNames({
+        canonicalName: 'Volvo AB',
+        incomingNames: ['Volvo Cars', 'AB Volvo'],
+      })
+    ).toEqual(['Volvo Cars'])
+  })
+
+  it('prefers the richer diacritic display form for the same key', () => {
+    expect(
+      mergeAlternativeNames({
+        canonicalName: 'Other Co',
+        existingAlternativeNames: ['Nestle Sverige'],
+        incomingNames: ['Nestlé Sverige'],
+      })
+    ).toEqual(['Nestlé Sverige'])
+  })
+
+  it('trims empties and ignores blank incoming values', () => {
+    expect(
+      mergeAlternativeNames({
+        canonicalName: 'Acme',
+        existingAlternativeNames: ['', '  '],
+        incomingNames: [' Acme Trading ', ''],
+      })
+    ).toEqual(['Acme Trading'])
+  })
+})
+
+describe('isFormattingVariantOfCompanyName', () => {
+  it('treats punctuation and suffix-only differences as formatting variants', () => {
+    expect(isFormattingVariantOfCompanyName('Volvo AB', 'AB Volvo')).toBe(true)
+    expect(isFormattingVariantOfCompanyName('Volvo AB', 'VOLVO A.B.')).toBe(true)
+  })
+
+  it('does not treat Volvo Cars as a formatting variant of Volvo AB', () => {
+    expect(isFormattingVariantOfCompanyName('Volvo AB', 'Volvo Cars')).toBe(
+      false
+    )
+  })
+})

--- a/src/lib/companyAlternativeNames.test.ts
+++ b/src/lib/companyAlternativeNames.test.ts
@@ -26,6 +26,17 @@ describe('companyNameMatchKey', () => {
     expect(companyNameMatchKey('H&M')).toBe('h m')
     expect(companyNameMatchKey('H & M')).toBe('h m')
   })
+
+  it('strips Nordic slash-form legal suffixes (A/S, AS/A)', () => {
+    expect(companyNameMatchKey('Company A/S')).toBe('company')
+    expect(companyNameMatchKey('Equinor A/S')).toBe('equinor')
+    expect(companyNameMatchKey('Foo AS/A')).toBe('foo')
+  })
+
+  it('normalizes hyphens so spacing variants share a key', () => {
+    expect(companyNameMatchKey('Coca-Cola')).toBe('coca cola')
+    expect(companyNameMatchKey('Coca - Cola')).toBe('coca cola')
+  })
 })
 
 describe('mergeAlternativeNames', () => {

--- a/src/lib/companyAlternativeNames.test.ts
+++ b/src/lib/companyAlternativeNames.test.ts
@@ -83,7 +83,9 @@ describe('mergeAlternativeNames', () => {
 describe('isFormattingVariantOfCompanyName', () => {
   it('treats punctuation and suffix-only differences as formatting variants', () => {
     expect(isFormattingVariantOfCompanyName('Volvo AB', 'AB Volvo')).toBe(true)
-    expect(isFormattingVariantOfCompanyName('Volvo AB', 'VOLVO A.B.')).toBe(true)
+    expect(isFormattingVariantOfCompanyName('Volvo AB', 'VOLVO A.B.')).toBe(
+      true
+    )
   })
 
   it('does not treat Volvo Cars as a formatting variant of Volvo AB', () => {

--- a/src/lib/companyAlternativeNames.ts
+++ b/src/lib/companyAlternativeNames.ts
@@ -14,7 +14,7 @@ function preferDisplayForm(existing: string, incoming: string): string {
   if (companyNameHasDiacritics(existing) !== companyNameHasDiacritics(incoming)) {
     return preferRicherDiacriticCompanyName(existing, incoming)
   }
-  // Prefer the form that looks more like a proper name (more letters / casing).
+  // Prefer the form with more letters when keys collide (e.g. "AB" vs "Aktiebolag" noise already stripped by key).
   const existingLetterCount = (existing.match(/\p{L}/gu) ?? []).length
   const incomingLetterCount = (incoming.match(/\p{L}/gu) ?? []).length
   if (incomingLetterCount > existingLetterCount) return incoming.trim()
@@ -40,7 +40,7 @@ export function mergeAlternativeNames({
   const byKey = new Map<string, string>()
 
   for (const raw of [...existingAlternativeNames, ...incomingNames]) {
-    const trimmed = raw?.trim()
+    const trimmed = raw.trim()
     if (!trimmed) continue
 
     const key = companyNameMatchKey(trimmed)

--- a/src/lib/companyAlternativeNames.ts
+++ b/src/lib/companyAlternativeNames.ts
@@ -11,7 +11,9 @@ export type MergeAlternativeNamesOptions = {
 }
 
 function preferDisplayForm(existing: string, incoming: string): string {
-  if (companyNameHasDiacritics(existing) !== companyNameHasDiacritics(incoming)) {
+  if (
+    companyNameHasDiacritics(existing) !== companyNameHasDiacritics(incoming)
+  ) {
     return preferRicherDiacriticCompanyName(existing, incoming)
   }
   // Prefer the form with more letters when keys collide (e.g. "AB" vs "Aktiebolag" noise already stripped by key).

--- a/src/lib/companyAlternativeNames.ts
+++ b/src/lib/companyAlternativeNames.ts
@@ -1,0 +1,73 @@
+import {
+  companyNameHasDiacritics,
+  companyNameMatchKey,
+  preferRicherDiacriticCompanyName,
+} from './companyLinkResolve'
+
+export type MergeAlternativeNamesOptions = {
+  canonicalName: string
+  existingAlternativeNames?: readonly string[]
+  incomingNames?: readonly string[]
+}
+
+function preferDisplayForm(existing: string, incoming: string): string {
+  if (companyNameHasDiacritics(existing) !== companyNameHasDiacritics(incoming)) {
+    return preferRicherDiacriticCompanyName(existing, incoming)
+  }
+  // Prefer the form that looks more like a proper name (more letters / casing).
+  const existingLetterCount = (existing.match(/\p{L}/gu) ?? []).length
+  const incomingLetterCount = (incoming.match(/\p{L}/gu) ?? []).length
+  if (incomingLetterCount > existingLetterCount) return incoming.trim()
+  if (existingLetterCount > incomingLetterCount) return existing.trim()
+  return existing.trim()
+}
+
+/**
+ * Merge alternative names for storage: trim, drop empties and canonical
+ * duplicates (by match key), and keep one display form per match key.
+ *
+ * Does not decide whether a name *should* be collected — callers gate that
+ * (manual edit vs confirmed link). Distinct entities that share a brand core
+ * (e.g. Volvo AB vs Volvo Cars) keep different keys and stay separate entries
+ * if both are passed in for different companies.
+ */
+export function mergeAlternativeNames({
+  canonicalName,
+  existingAlternativeNames = [],
+  incomingNames = [],
+}: MergeAlternativeNamesOptions): string[] {
+  const canonicalKey = companyNameMatchKey(canonicalName)
+  const byKey = new Map<string, string>()
+
+  for (const raw of [...existingAlternativeNames, ...incomingNames]) {
+    const trimmed = raw?.trim()
+    if (!trimmed) continue
+
+    const key = companyNameMatchKey(trimmed)
+    if (!key) continue
+    if (canonicalKey && key === canonicalKey) continue
+
+    const existing = byKey.get(key)
+    byKey.set(key, existing ? preferDisplayForm(existing, trimmed) : trimmed)
+  }
+
+  return [...byKey.values()]
+}
+
+/**
+ * True when `candidateName` is only a formatting / legal-suffix variant of
+ * `canonicalName` (same match key). Useful for deciding auto-collect is a
+ * no-op; distinct names like "Volvo Cars" vs "Volvo AB" return false.
+ */
+export function isFormattingVariantOfCompanyName(
+  canonicalName: string,
+  candidateName: string
+): boolean {
+  const canonicalKey = companyNameMatchKey(canonicalName)
+  const candidateKey = companyNameMatchKey(candidateName)
+  return (
+    canonicalKey.length > 0 &&
+    candidateKey.length > 0 &&
+    canonicalKey === candidateKey
+  )
+}

--- a/src/lib/companyLinkResolve.test.ts
+++ b/src/lib/companyLinkResolve.test.ts
@@ -43,6 +43,7 @@ describe('companyLinkResolve', () => {
     expect(normalizeCompanyNameForMatch('Siemens AG')).toBe('siemens')
     expect(normalizeCompanyNameForMatch('Acme Corp.')).toBe('acme')
     expect(normalizeCompanyNameForMatch('Example LLC')).toBe('example')
+    expect(normalizeCompanyNameForMatch('VOLVO A.B.')).toBe('volvo')
     expect(stripLegalEntitySuffixes('Nokia Oyj')).toBe('Nokia')
   })
 

--- a/src/lib/companyLinkResolve.test.ts
+++ b/src/lib/companyLinkResolve.test.ts
@@ -44,6 +44,7 @@ describe('companyLinkResolve', () => {
     expect(normalizeCompanyNameForMatch('Acme Corp.')).toBe('acme')
     expect(normalizeCompanyNameForMatch('Example LLC')).toBe('example')
     expect(normalizeCompanyNameForMatch('VOLVO A.B.')).toBe('volvo')
+    expect(normalizeCompanyNameForMatch('Company A/S')).toBe('company')
     expect(stripLegalEntitySuffixes('Nokia Oyj')).toBe('Nokia')
   })
 

--- a/src/lib/companyLinkResolve.ts
+++ b/src/lib/companyLinkResolve.ts
@@ -165,14 +165,29 @@ export function preferRicherDiacriticCompanyName(
   return existing
 }
 
-export function normalizeCompanyNameForMatch(name: string): string {
+/**
+ * Stable match key for company names: fold diacritics, lowercase, strip
+ * punctuation/noise, collapse whitespace, drop legal-entity tokens.
+ * Use for equality checks and alternative-name dedupe — not for display.
+ */
+export function companyNameMatchKey(name: string): string {
   return foldDiacriticsForCompanyMatch(name)
     .trim()
     .toLocaleLowerCase('sv-SE')
-    .split(/\s+/)
-    .filter((word) => !isLegalEntitySuffix(word))
+    // "A.B." → "ab" so legal-suffix stripping still sees a single token
+    .replace(/\./g, '')
+    .replace(/[&/,()'"’´`+]/g, ' ')
+    .replace(/[^\p{L}\p{N}\s-]/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .split(' ')
+    .filter((word) => word.length > 0 && !isLegalEntitySuffix(word))
     .join(' ')
     .trim()
+}
+
+/** Historical name; delegates to {@link companyNameMatchKey}. */
+export function normalizeCompanyNameForMatch(name: string): string {
+  return companyNameMatchKey(name)
 }
 
 export function dedupeCompanyLinkCandidates(

--- a/src/lib/companyLinkResolve.ts
+++ b/src/lib/companyLinkResolve.ts
@@ -171,20 +171,22 @@ export function preferRicherDiacriticCompanyName(
  * Use for equality checks and alternative-name dedupe — not for display.
  */
 export function companyNameMatchKey(name: string): string {
-  return foldDiacriticsForCompanyMatch(name)
-    .trim()
-    .toLocaleLowerCase('sv-SE')
-    // Preserve Nordic slash-form suffixes before `/` becomes a separator.
-    .replace(/\ba\s*\/\s*s\b/g, 'as')
-    .replace(/\bas\s*\/\s*a\b/g, 'asa')
-    // "A.B." → "ab" so legal-suffix stripping still sees a single token
-    .replace(/\./g, '')
-    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
-    .replace(/\s+/g, ' ')
-    .split(' ')
-    .filter((word) => word.length > 0 && !isLegalEntitySuffix(word))
-    .join(' ')
-    .trim()
+  return (
+    foldDiacriticsForCompanyMatch(name)
+      .trim()
+      .toLocaleLowerCase('sv-SE')
+      // Preserve Nordic slash-form suffixes before `/` becomes a separator.
+      .replace(/\ba\s*\/\s*s\b/g, 'as')
+      .replace(/\bas\s*\/\s*a\b/g, 'asa')
+      // "A.B." → "ab" so legal-suffix stripping still sees a single token
+      .replace(/\./g, '')
+      .replace(/[^\p{L}\p{N}\s]/gu, ' ')
+      .replace(/\s+/g, ' ')
+      .split(' ')
+      .filter((word) => word.length > 0 && !isLegalEntitySuffix(word))
+      .join(' ')
+      .trim()
+  )
 }
 
 /** Historical name; delegates to {@link companyNameMatchKey}. */

--- a/src/lib/companyLinkResolve.ts
+++ b/src/lib/companyLinkResolve.ts
@@ -174,10 +174,12 @@ export function companyNameMatchKey(name: string): string {
   return foldDiacriticsForCompanyMatch(name)
     .trim()
     .toLocaleLowerCase('sv-SE')
+    // Preserve Nordic slash-form suffixes before `/` becomes a separator.
+    .replace(/\ba\s*\/\s*s\b/g, 'as')
+    .replace(/\bas\s*\/\s*a\b/g, 'asa')
     // "A.B." → "ab" so legal-suffix stripping still sees a single token
     .replace(/\./g, '')
-    .replace(/[&/,()'"’´`+]/g, ' ')
-    .replace(/[^\p{L}\p{N}\s-]/gu, ' ')
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
     .replace(/\s+/g, ' ')
     .split(' ')
     .filter((word) => word.length > 0 && !isLegalEntitySuffix(word))


### PR DESCRIPTION
## Summary
- Adds `Company.alternativeNames` (`String[]`, default empty) with a Prisma migration
- Strengthens name matching via `companyNameMatchKey` (case, spaces, periods, punctuation, legal suffixes, diacritics); `normalizeCompanyNameForMatch` delegates to it
- Adds `mergeAlternativeNames` / `isFormattingVariantOfCompanyName` for safe storage dedupe without collapsing distinct entities (e.g. Volvo AB vs Volvo Cars)

This is **PR1** of the alternative-names series. No API/search/UI behavior change yet beyond the schema field.

## Test plan
- [ ] Review migration SQL (`alternativeNames TEXT[] DEFAULT ARRAY[]::TEXT[]`)
- [ ] `npx jest src/lib/companyAlternativeNames.test.ts src/lib/companyLinkResolve.test.ts`
- [ ] Confirm match keys: `Volvo AB` / `VOLVO A.B.` / `AB Volvo` → `volvo`; `Volvo Cars` → `volvo cars`
- [ ] Confirm merge drops canonical duplicates and keeps distinct significant-token names

## Follow-ups
- API repo: mirror schema + company search/update
- Garbo: expose in API + resolve/search
- Garbo: auto-collect on confirmed link
- Validate: admin edit UI
- API: coverage/crawler search


Made with [Cursor](https://cursor.com)