### PR TITLE
Wire ALLOWED_CALLBACK_URLS into worker deployment's env

### DIFF
--- a/k8s/base/worker.yaml
+++ b/k8s/base/worker.yaml
@@ -205,6 +205,11 @@ spec:
                 secretKeyRef:
                   name: env
                   key: INTERNAL_SERVICE_TOKEN
+            - name: ALLOWED_CALLBACK_URLS
+              valueFrom:
+                secretKeyRef:
+                  name: env
+                  key: ALLOWED_CALLBACK_URLS
           imagePullPolicy: Always
 ---
 apiVersion: autoscaling/v2


### PR DESCRIPTION
## Summary
- \`worker.yaml\` (where the docling worker's \`fireCallback\` actually runs) never declared \`ALLOWED_CALLBACK_URLS\` in its env list.
- K8s doesn't expose a Secret's keys to a container automatically — each var needs an explicit `secretKeyRef` entry.
- So even with the key set correctly in the \`env\` Secret, the worker pod's \`process.env.ALLOWED_CALLBACK_URLS\` was always empty, and \`isAllowedCallbackUrl()\` rejected every callback with "Callback URL not in whitelist".

## Test plan
- [x] Verified `kubectl kustomize k8s/overlays/staging` includes the new env var correctly
- [ ] Confirm the `env` Secret in the stage cluster actually has `ALLOWED_CALLBACK_URLS` set, then redeploy the worker and re-test a climate-plan upload

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Kubernetes env entry with no application logic changes; fixes misconfiguration rather than altering callback security rules.
> 
> **Overview**
> The worker deployment now maps **`ALLOWED_CALLBACK_URLS`** from the shared `env` Secret into the container environment, matching how other worker settings are wired.
> 
> Previously the key could exist in the Secret but never reached the docling worker process, so `process.env.ALLOWED_CALLBACK_URLS` stayed empty, `isAllowedCallbackUrl()` treated every URL as disallowed, and **`fireCallback`** failed with “Callback URL not in whitelist”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f0063b45b778b5265845fe9bd4470ab74932b18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->