### PR TITLE
Fail fast on non-whitelisted callbackUrl before parsing

### DIFF
--- a/src/workers/doclingParsePDF.ts
+++ b/src/workers/doclingParsePDF.ts
@@ -3,7 +3,7 @@ import { UnrecoverableError } from 'bullmq'
 import { QUEUE_NAMES } from '../queues'
 import docling from '../config/docling'
 import redis from '../config/redis'
-import { fireCallback } from '../lib/webhook'
+import { fireCallback, isAllowedCallbackUrl } from '../lib/webhook'
 import { prisma } from '../lib/prisma'
 import { buildReportMatchConditions } from '@/api/services/registryReportIdentity'
 import { buildPipelineReportIdentity } from '../lib/reportSaveIdentity'
@@ -397,6 +397,19 @@ const doclingParsePDF = new PipelineWorker(
 
     // Log configuration once (first job only) - appears in BullMQ logs
     logConfigurationOnce(job)
+
+    // Fail fast, before burning an expensive Docling call, when the
+    // caller's callbackUrl was never going to be deliverable — this is a
+    // permanent misconfiguration (a retry can't fix it), unlike a
+    // transient failure in the actual fireCallback call later (see below),
+    // which intentionally doesn't fail the job — markdown is already
+    // persisted by then, so nothing is lost, and it can be recovered via
+    // GET /api/reports/registry/markdown?url=... without re-parsing.
+    if (job.data.callbackUrl && !isAllowedCallbackUrl(job.data.callbackUrl)) {
+      throw new UnrecoverableError(
+        `Callback URL not in whitelist: ${job.data.callbackUrl}`
+      )
+    }
 
     try {
       if (taskId) {

--- a/src/workers/doclingParsePDF.ts
+++ b/src/workers/doclingParsePDF.ts
@@ -399,7 +399,7 @@ const doclingParsePDF = new PipelineWorker(
     logConfigurationOnce(job)
 
     // Fail fast, before burning an expensive Docling call, when the
-    // caller's callbackUrl was never going to be deliverable — this is a
+    // caller's callbackUrl is not in ALLOWED_CALLBACK_URLS — this is a
     // permanent misconfiguration (a retry can't fix it), unlike a
     // transient failure in the actual fireCallback call later (see below),
     // which intentionally doesn't fail the job — markdown is already


### PR DESCRIPTION
## Summary
- A non-whitelisted `callbackUrl` is a permanent misconfiguration — no retry or amount of waiting fixes it, so failing before the (expensive) Docling call runs avoids wasted work.
- Left the existing behavior alone for the *actual* callback delivery failing after a successful parse (network blip, consumer down) — that's transient, and the parsed markdown is already persisted by then via `persistMarkdown`, so it's recoverable via `GET /api/reports/registry/markdown?url=...` without re-parsing. Not something a retry-storm should be triggered for either.

## Test plan
- [x] `tsc --noEmit`, prettier, eslint, full test suite (300 tests) all pass
- [ ] Manually verify: submit a climate-plan URL with a bad/non-whitelisted callbackUrl and confirm the job fails immediately (no Docling call in logs) instead of after a full parse

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard in the PDF worker with no change to parsing, persistence, or successful callback delivery behavior.
> 
> **Overview**
> The **docling PDF worker** now validates `callbackUrl` against `ALLOWED_CALLBACK_URLS` **before** any Docling API work runs. If a callback URL is present but not whitelisted, the job throws **`UnrecoverableError`** so BullMQ does not retry a permanent misconfiguration and no expensive parse is wasted.
> 
> This reuses **`isAllowedCallbackUrl`** from `webhook` (same rule as `fireCallback`). **Post-parse callback delivery** stays unchanged: transient network or consumer failures are still logged and do not fail the job, since markdown is already persisted and recoverable via the registry markdown API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1a0a54af34d45fa7a5393ba8bec10dafe795785. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->