### PR TITLE
Coerce null emission units to tCO2e on save

### DIFF
--- a/src/api/schemas/common.ts
+++ b/src/api/schemas/common.ts
@@ -78,5 +78,11 @@ const validEmissionsUnits = z.enum(['tCO2e', 'tCO2'])
 
 export const emissionUnitSchemaGarbo = validEmissionsUnits.nullable()
 
-export const emissionUnitSchemaWithDefault =
-  validEmissionsUnits.default('tCO2e')
+/**
+ * Zod `.default()` only applies to `undefined`, not `null`. LLM extraction
+ * often returns `"unit": null`, so coerce nullish values to tCO2e.
+ */
+export const emissionUnitSchemaWithDefault = z.preprocess(
+  (value) => (value == null ? 'tCO2e' : value),
+  validEmissionsUnits
+)

--- a/src/workers/followUp/biogenic.ts
+++ b/src/workers/followUp/biogenic.ts
@@ -1,7 +1,7 @@
 import { QUEUE_NAMES } from '../../queues'
 import { FollowUpJob, FollowUpWorker } from '../../lib/FollowUpWorker'
 import { z } from 'zod'
-import { emissionUnitSchemaGarbo } from '../../api/schemas'
+import { emissionUnitSchemaWithDefault } from '../../api/schemas'
 import { FollowUpType } from '../../types'
 
 const schema = z.object({
@@ -10,7 +10,7 @@ const schema = z.object({
       year: z.number(),
       biogenic: z.object({
         total: z.number(),
-        unit: emissionUnitSchemaGarbo,
+        unit: emissionUnitSchemaWithDefault,
       }),
     })
   ),


### PR DESCRIPTION
## Summary
- LLM extraction often returns `"unit": null` for biogenic (and other) emissions; Zod `.default('tCO2e')` only applies to `undefined`, so the API rejected the payload and pipeline jobs retried forever.
- `emissionUnitSchemaWithDefault` now coerces nullish values to `tCO2e`.
- Biogenic follow-up schema uses that default so extraction matches the prompt (“assume tCO2e if unclear”).

Related gap left by #1025 / #1019 (nullable units for scope2 / scope3 categories, but not biogenic via the default schema).

Pairs with UnearthData/api PR (same branch name).

## Test plan
- [ ] Re-run a failed job that hit `biogenic/unit Expected 'tCO2e' | 'tCO2', received null` after API deploy — should save
- [ ] Confirm explicit `tCO2` / `tCO2e` still pass through unchanged
- [ ] Spot-check biogenic follow-up extraction still validates when unit is omitted or null


Made with [Cursor](https://cursor.com)