### PR TITLE
Allow null biogenic emission units

### DIFF
--- a/prisma/migrations/20260827140000_make_biogenic_unit_nullable/migration.sql
+++ b/prisma/migrations/20260827140000_make_biogenic_unit_nullable/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "BiogenicEmissions" ALTER COLUMN "unit" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -253,7 +253,7 @@ model BiogenicEmissions {
   id          String  @id @default(cuid())
   /// Sometimes companies break it down into scope 1-3 - however these should always be stored as a total number according to the GHG protocol.
   total       Float?
-  unit        String
+  unit        String?
   emissionsId String? @unique
 
   emissions Emissions?      @relation(fields: [emissionsId], references: [id], onDelete: Cascade)

--- a/src/api/schemas/common.ts
+++ b/src/api/schemas/common.ts
@@ -78,11 +78,5 @@ const validEmissionsUnits = z.enum(['tCO2e', 'tCO2'])
 
 export const emissionUnitSchemaGarbo = validEmissionsUnits.nullable()
 
-/**
- * Zod `.default()` only applies to `undefined`, not `null`. LLM extraction
- * often returns `"unit": null`, so coerce nullish values to tCO2e.
- */
-export const emissionUnitSchemaWithDefault = z.preprocess(
-  (value) => (value == null ? 'tCO2e' : value),
-  validEmissionsUnits
-)
+export const emissionUnitSchemaWithDefault =
+  validEmissionsUnits.default('tCO2e')

--- a/src/api/schemas/request.ts
+++ b/src/api/schemas/request.ts
@@ -226,7 +226,7 @@ export const emissionsSchema = z
     biogenic: z
       .object({
         total: z.number().nullable().optional(),
-        unit: emissionUnitSchemaWithDefault,
+        unit: emissionUnitSchemaGarbo,
         verified: z.boolean().optional(),
       })
       .nullable()

--- a/src/api/schemas/response.ts
+++ b/src/api/schemas/response.ts
@@ -106,7 +106,7 @@ export const BiogenicSchema = z.object({
     .number()
     .nullable()
     .openapi({ description: 'Total biogenic emissions' }),
-  unit: z.string().openapi({ description: 'Unit of measurement' }),
+  unit: emissionUnitSchemaGarbo.openapi({ description: 'Unit of measurement' }),
   metadata: MetadataSchema,
 })
 

--- a/src/workers/followUp/biogenic.ts
+++ b/src/workers/followUp/biogenic.ts
@@ -1,7 +1,7 @@
 import { QUEUE_NAMES } from '../../queues'
 import { FollowUpJob, FollowUpWorker } from '../../lib/FollowUpWorker'
 import { z } from 'zod'
-import { emissionUnitSchemaWithDefault } from '../../api/schemas'
+import { emissionUnitSchemaGarbo } from '../../api/schemas'
 import { FollowUpType } from '../../types'
 
 const schema = z.object({
@@ -10,7 +10,7 @@ const schema = z.object({
       year: z.number(),
       biogenic: z.object({
         total: z.number(),
-        unit: emissionUnitSchemaWithDefault,
+        unit: emissionUnitSchemaGarbo,
       }),
     })
   ),


### PR DESCRIPTION
## Summary
- Reverts #1401’s coerce-`null`-to-`tCO2e` behavior on `emissionUnitSchemaWithDefault`.
- Allows biogenic `unit` to be null in request/response schemas and the biogenic follow-up extraction schema.
- Makes `BiogenicEmissions.unit` nullable in Prisma (same pattern as scope3 category units in #1019).

Safer short-term fix for pipeline saves that fail on `unit: null` without inventing a unit. Longer term we still want to tighten the biogenic prompt/extraction.

Pairs with UnearthData/api PR on `fix/nullable-biogenic-unit`.

## Test plan
- [ ] Apply migration (`npm run migrate`) on a local/stage DB
- [ ] POST reporting periods with `emissions.biogenic: { total: 12.3, unit: null }` — should accept and persist `unit: null`
- [ ] Confirm biogenic with explicit `tCO2e` / `tCO2` still works
- [ ] Re-run a job that previously failed on biogenic `unit` null after API deploy + migration


Made with [Cursor](https://cursor.com)