### PR TITLE
Include threadId in the callbackUrl payload

### DIFF
--- a/src/workers/doclingParsePDF.ts
+++ b/src/workers/doclingParsePDF.ts
@@ -732,7 +732,7 @@ async function pollTaskAndGetResult(
       try {
         await fireCallback(
           job.data.callbackUrl,
-          { url: canonicalUrl, markdown },
+          { url: canonicalUrl, markdown, threadId: job.data.threadId },
           (msg) => job.log(msg)
         )
       } catch (err) {
@@ -799,7 +799,7 @@ async function pollTaskAndGetResult(
           try {
             await fireCallback(
               job.data.callbackUrl,
-              { url: canonicalUrl, markdown },
+              { url: canonicalUrl, markdown, threadId: job.data.threadId },
               (msg) => job.log(msg)
             )
           } catch (err) {


### PR DESCRIPTION
## Summary
- threadId already exists on every docling job (pipeline-api sets it once at parsePdf enqueue time, garbo threads it forward automatically) but was silently dropped when firing a callback.
- Sending it lets callbackUrl consumers (climate-plans-pipeline) correlate their own records back to garbo's original parsePdf/doclingParsePDF jobs — first step of a small cross-repo change so validate's Climate Pipeline tab can show PDF-parsing status too (currently invisible there).

## Test plan
- [x] tsc/prettier/eslint/full test suite all pass
- [ ] Follow-up PRs in climate-plans-pipeline, pipeline-api, validate consume this field

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional field on an existing webhook payload; no change to parsing, persistence, or callback failure handling.
> 
> **Overview**
> **Docling PDF parse callbacks** now include **`threadId`** alongside `url` and `markdown` when `callbackUrl` is set, in both the local docling-serve and Berget polling completion paths.
> 
> The job already carried `threadId` from enqueue; it was only omitted from the POST body. Downstream services (e.g. climate-plans-pipeline) can use it to tie webhook results back to the original Garbo `parsePdf` / `doclingParsePDF` thread for status UI and cross-repo correlation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89531d3036f674129d2b791947445c18608b6312. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->