### PR TITLE
[Prod] Patch Version Bump v6.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo",
-  "version": "6.1.4-rc.8",
+  "version": "6.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo",
-      "version": "6.1.4-rc.8",
+      "version": "6.1.4",
       "hasInstallScript": true,
       "license": "MIT License",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garbo",
-  "version": "6.1.4-rc.8",
+  "version": "6.1.4",
   "description": "",
   "type": "module",
   "exports": {


### PR DESCRIPTION
# 🚀 Production Release PR

> **Title format:** `[Prod] Major/Minor/Patch Version Bump vX.X.X`

## 📦 Release Type

_Select the appropriate release type by marking with an `x`._

- [ ] Major version bump
- [ ] Minor version bump
- [x] Patch version bump

### Rollback Version

_Note the relevant rollback version to enable quick rollback if necessary._

v6.1.3

## 🔁 Environment Promotion

This release promotes changes **from `staging` to `production`** (staging validated on `6.1.4-rc.x`).

## 📋 What's Being Released

Everything merged since **v6.1.3**:

### Callback URL / climate-plan handoff
- Add callbackUrl support for generic pipeline handoff ([#1396](https://github.com/Klimatbyran/garbo/pull/1396))
- Wire `ALLOWED_CALLBACK_URLS` into the worker deployment env ([#1399](https://github.com/Klimatbyran/garbo/pull/1399))
- Fail fast on a non-whitelisted callbackUrl before Docling parsing ([#1400](https://github.com/Klimatbyran/garbo/pull/1400))
- Include `threadId` in the callbackUrl payload ([#1403](https://github.com/Klimatbyran/garbo/pull/1403))

### Emission units
- Coerce null emission units to tCO2e on save ([#1401](https://github.com/Klimatbyran/garbo/pull/1401))
- Allow null biogenic emission units instead of defaulting to tCO2e ([#1402](https://github.com/Klimatbyran/garbo/pull/1402))

### Wikidata / company linking
- Require human approval when a Wikidata ID already belongs to another company ([#1398](https://github.com/Klimatbyran/garbo/pull/1398))

### Cleanup
- Remove unused client export and aux routes duplicated by unearth-api ([#1377](https://github.com/Klimatbyran/garbo/pull/1377))
- Remove unused rare client routes and internal read mirrors ([#1378](https://github.com/Klimatbyran/garbo/pull/1378))

## 🗂 Deployment Notes (optional)

_Anything to watch out for: DB migrations, feature flags, long-running jobs, cache warmup, etc._

- **DB migrations (apply on deploy via init `npm run migrate`):**
  - `20260821140000_report_markdown`
  - `20260827140000_make_biogenic_unit_nullable` — apply before or with Unearth API **v1.9.1**
- Deploy **Garbo API + worker** together (same image); worker needs `ALLOWED_CALLBACK_URLS` for climate-plan callback handoff
- Coordinate with Validate **v1.19.1** for Climate Pipeline PDF-parsing pills (`threadId` in callback)

## ✅ Checklist

- [x] Version number is updated correctly (code/package and/or k8s image tag)
- [ ] All relevant changes have been QA-tested in staging
- [x] Rollback version has been updated
- [x] Title follows the required format: `[Prod] Patch Version Bump v6.1.4`

---

_This template is for versioned production releases only. For other PR types, please select a different template._