### PR TITLE
Persist coverage company matches and report links

### DIFF
--- a/prisma/migrations/20260828120000_coverage_persisted_links/migration.sql
+++ b/prisma/migrations/20260828120000_coverage_persisted_links/migration.sql
@@ -1,0 +1,70 @@
+-- Persist coverage company match outcomes and entry↔report discovery links.
+
+CREATE TYPE "CoverageMatchStatus" AS ENUM ('matched', 'ambiguous', 'missing');
+CREATE TYPE "CoverageMatchMethod" AS ENUM ('auto', 'manual');
+CREATE TYPE "CoverageReportLinkStatus" AS ENUM ('matched', 'ambiguous', 'rejected');
+CREATE TYPE "CoverageReportMatchSource" AS ENUM ('wikidata', 'name', 'manual');
+
+ALTER TABLE "coverage_list_entries"
+ADD COLUMN "match_status" "CoverageMatchStatus",
+ADD COLUMN "match_method" "CoverageMatchMethod",
+ADD COLUMN "suggested_company_id" TEXT,
+ADD COLUMN "matched_at" TIMESTAMP(3);
+
+CREATE INDEX "coverage_list_entries_suggested_company_id_idx"
+ON "coverage_list_entries"("suggested_company_id");
+
+CREATE INDEX "coverage_list_entries_year_id_match_status_idx"
+ON "coverage_list_entries"("year_id", "match_status");
+
+ALTER TABLE "coverage_list_entries"
+ADD CONSTRAINT "coverage_list_entries_suggested_company_id_fkey"
+FOREIGN KEY ("suggested_company_id") REFERENCES "Company"("id")
+ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Preserve existing staff overrides as manual persisted matches.
+UPDATE "coverage_list_entries"
+SET
+  "match_status" = 'missing',
+  "match_method" = 'manual',
+  "matched_at" = CURRENT_TIMESTAMP
+WHERE "match_confirmed_missing" = true;
+
+UPDATE "coverage_list_entries"
+SET
+  "match_status" = 'matched',
+  "match_method" = 'manual',
+  "matched_at" = CURRENT_TIMESTAMP
+WHERE "matched_company_id" IS NOT NULL
+  AND "match_confirmed_missing" = false;
+
+CREATE TABLE "coverage_entry_reports" (
+    "id" TEXT NOT NULL,
+    "entry_id" TEXT NOT NULL,
+    "report_id" TEXT NOT NULL,
+    "link_status" "CoverageReportLinkStatus" NOT NULL DEFAULT 'matched',
+    "match_source" "CoverageReportMatchSource" NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "coverage_entry_reports_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "coverage_entry_reports_entry_id_report_id_key"
+ON "coverage_entry_reports"("entry_id", "report_id");
+
+CREATE INDEX "coverage_entry_reports_entry_id_idx"
+ON "coverage_entry_reports"("entry_id");
+
+CREATE INDEX "coverage_entry_reports_report_id_idx"
+ON "coverage_entry_reports"("report_id");
+
+ALTER TABLE "coverage_entry_reports"
+ADD CONSTRAINT "coverage_entry_reports_entry_id_fkey"
+FOREIGN KEY ("entry_id") REFERENCES "coverage_list_entries"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "coverage_entry_reports"
+ADD CONSTRAINT "coverage_entry_reports_report_id_fkey"
+FOREIGN KEY ("report_id") REFERENCES "Report"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,7 +45,8 @@ model Company {
 
   identifiers CompanyIdentifier[]
 
-  coverageListEntries CoverageListEntry[]
+  coverageListEntries            CoverageListEntry[] @relation("CoverageEntryMatchedCompany")
+  coverageListEntrySuggestions   CoverageListEntry[] @relation("CoverageEntrySuggestedCompany")
 }
 
 enum CompanyIdentifierType {
@@ -604,7 +605,8 @@ model Report {
   batchId      String?     @map("batch_id")
   batch        Batch?      @relation(fields: [batchId], references: [id], onDelete: SetNull, onUpdate: Cascade)
 
-  companyReports CompanyReport[]
+  companyReports       CompanyReport[]
+  coverageEntryReports CoverageEntryReport[]
 
   @@index([reportTypeId])
   @@index([batchId])
@@ -789,27 +791,78 @@ model CoverageListYear {
   @@map("coverage_list_years")
 }
 
+enum CoverageMatchStatus {
+  matched
+  ambiguous
+  missing
+}
+
+enum CoverageMatchMethod {
+  auto
+  manual
+}
+
+enum CoverageReportLinkStatus {
+  matched
+  ambiguous
+  rejected
+}
+
+enum CoverageReportMatchSource {
+  wikidata
+  name
+  manual
+}
+
 /// Pasted company name line belonging to a list year edition.
 model CoverageListEntry {
-  id                    String           @id @default(cuid())
-  yearId                String           @map("year_id")
-  year                  CoverageListYear @relation(fields: [yearId], references: [id], onDelete: Cascade)
+  id                    String               @id @default(cuid())
+  yearId                String               @map("year_id")
+  year                  CoverageListYear     @relation(fields: [yearId], references: [id], onDelete: Cascade)
   name                  String
-  sortOrder             Int              @default(0) @map("sort_order")
-  /// Staff-confirmed DB company match; overrides auto-matching when set.
-  matchedCompanyId      String?          @map("matched_company_id")
-  matchedCompany        Company?         @relation(fields: [matchedCompanyId], references: [id], onDelete: SetNull)
+  sortOrder             Int                  @default(0) @map("sort_order")
+  /// Persisted company match outcome; null until rematch or staff override.
+  matchStatus           CoverageMatchStatus? @map("match_status")
+  matchMethod           CoverageMatchMethod? @map("match_method")
+  /// DB company match (auto or staff-confirmed).
+  matchedCompanyId      String?              @map("matched_company_id")
+  matchedCompany        Company?             @relation("CoverageEntryMatchedCompany", fields: [matchedCompanyId], references: [id], onDelete: SetNull)
+  /// Primary suggestion when status is ambiguous.
+  suggestedCompanyId    String?              @map("suggested_company_id")
+  suggestedCompany      Company?             @relation("CoverageEntrySuggestedCompany", fields: [suggestedCompanyId], references: [id], onDelete: SetNull)
   /// Staff confirmed this list name is not in the DB (overrides ambiguous suggestions).
-  matchConfirmedMissing Boolean          @default(false) @map("match_confirmed_missing")
+  matchConfirmedMissing Boolean              @default(false) @map("match_confirmed_missing")
+  matchedAt             DateTime?            @map("matched_at")
   /// Cached registry report count for fast coverage filters.
-  registryReportCount   Int              @default(0) @map("registry_report_count")
+  registryReportCount   Int                  @default(0) @map("registry_report_count")
   /// Cached flag: at least one linked registry report is prod-ready.
-  hasProdReadyReport    Boolean          @default(false) @map("has_prod_ready_report")
-  registryRefreshedAt   DateTime?        @map("registry_refreshed_at")
+  hasProdReadyReport    Boolean              @default(false) @map("has_prod_ready_report")
+  registryRefreshedAt   DateTime?            @map("registry_refreshed_at")
+  reportLinks           CoverageEntryReport[]
 
   @@index([yearId])
   @@index([matchedCompanyId])
+  @@index([suggestedCompanyId])
+  @@index([yearId, matchStatus])
   @@index([yearId, registryReportCount])
   @@index([yearId, hasProdReadyReport])
   @@map("coverage_list_entries")
+}
+
+/// Persisted Coverage entry ↔ registry Report discovery links.
+model CoverageEntryReport {
+  id          String                     @id @default(cuid())
+  entryId     String                     @map("entry_id")
+  entry       CoverageListEntry          @relation(fields: [entryId], references: [id], onDelete: Cascade)
+  reportId    String                     @map("report_id")
+  report      Report                     @relation(fields: [reportId], references: [id], onDelete: Cascade)
+  linkStatus  CoverageReportLinkStatus   @default(matched) @map("link_status")
+  matchSource CoverageReportMatchSource  @map("match_source")
+  createdAt   DateTime                   @default(now()) @map("created_at")
+  updatedAt   DateTime                   @updatedAt @map("updated_at")
+
+  @@unique([entryId, reportId])
+  @@index([entryId])
+  @@index([reportId])
+  @@map("coverage_entry_reports")
 }


### PR DESCRIPTION
## Summary
- Add `matchStatus` / `matchMethod` / `suggestedCompanyId` / `matchedAt` on `CoverageListEntry`
- Add `coverage_entry_reports` join table for persisted Coverage ↔ Report discovery links
- Backfill existing staff overrides as manual matches

## Test plan
- [ ] Apply migration against stage DB (`prisma migrate deploy`)
- [ ] Confirm existing `matched_company_id` rows become `match_status=matched`, `match_method=manual`
- [ ] Confirm `match_confirmed_missing` rows become `match_status=missing`, `match_method=manual`
- [ ] Deploy with API rematch PR and Validate rematch UI PR


Made with [Cursor](https://cursor.com)