### PR TITLE
Expose company alternativeNames in API and pipeline resolve

### DIFF
--- a/src/api/args.ts
+++ b/src/api/args.ts
@@ -104,6 +104,7 @@ export const detailedCompanyArgs = {
     },
     lei: true,
     tags: true,
+    alternativeNames: true,
     reportingPeriods: {
       select: {
         id: true,
@@ -295,6 +296,7 @@ export const companyListArgs = {
       select: { id: true, year: true, metadata: metadataArgs },
     },
     tags: true,
+    alternativeNames: true,
     reportingPeriods: {
       select: {
         startDate: true,
@@ -418,6 +420,7 @@ export const companyExportArgs = (year?) => {
         select: { id: true, year: true },
       },
       tags: true,
+      alternativeNames: true,
       reportingPeriods: {
         select: {
           startDate: true,

--- a/src/api/routes/internal/company.pipelineRead.ts
+++ b/src/api/routes/internal/company.pipelineRead.ts
@@ -119,6 +119,7 @@ export async function pipelineCompanyReadRoutes(app: FastifyInstance) {
           name: company.name,
           wikidataId: company.wikidataId ?? null,
           lei: company.lei ?? null,
+          alternativeNames: company.alternativeNames ?? [],
         }))
       )
     }

--- a/src/api/routes/internal/company.update.ts
+++ b/src/api/routes/internal/company.update.ts
@@ -75,8 +75,16 @@ export async function companyUpdateRoutes(app: FastifyInstance) {
       request: AuthenticatedFastifyRequest<{ Body: PostCompanyBody }>,
       reply
     ) => {
-      const { wikidataId, tags, name, internalComment, url, logoUrl, lei } =
-        request.body
+      const {
+        wikidataId,
+        tags,
+        name,
+        internalComment,
+        url,
+        logoUrl,
+        lei,
+        alternativeNames,
+      } = request.body
       if (!(await validateTags(tags, reply))) return
 
       try {
@@ -85,6 +93,7 @@ export async function companyUpdateRoutes(app: FastifyInstance) {
           wikidataId,
           internalComment,
           tags,
+          alternativeNames,
           url,
           logoUrl: logoUrl ?? undefined,
           lei,
@@ -144,6 +153,7 @@ export async function companyUpdateRoutes(app: FastifyInstance) {
         url,
         logoUrl,
         lei,
+        alternativeNames,
         metadata,
         verified,
         verifiedByUserId,
@@ -178,6 +188,7 @@ export async function companyUpdateRoutes(app: FastifyInstance) {
             name,
             internalComment,
             tags,
+            alternativeNames,
             url,
             logoUrl: logoUrl ?? undefined,
             lei,

--- a/src/api/schemas/common.ts
+++ b/src/api/schemas/common.ts
@@ -39,6 +39,7 @@ export const pipelineCompanySearchHitSchema = z.object({
   name: z.string(),
   wikidataId: wikidataIdSchema.nullable().optional(),
   lei: z.string().nullable().optional(),
+  alternativeNames: z.array(z.string()).optional(),
 })
 
 export const pipelineCompanySearchListSchema = z.array(

--- a/src/api/schemas/request.ts
+++ b/src/api/schemas/request.ts
@@ -80,6 +80,8 @@ export const postCompanyBodySchema = z
     logoUrl: z.string().url().optional().nullable(),
     internalComment: z.string().optional(),
     tags: z.array(z.string()).optional(),
+    /// Other known names for internal matching; cleaned/deduped on write.
+    alternativeNames: z.array(z.string()).optional(),
     lei: z.string().optional(),
   })
   .merge(createMetadataSchema)

--- a/src/api/schemas/response.ts
+++ b/src/api/schemas/response.ts
@@ -476,6 +476,7 @@ export const MinimalCompanyBase = CompanyBaseSchema.extend({
   baseYear: BaseYearSchema.nullable().optional(),
   logoUrl: z.string().url().optional().nullable(),
   tags: z.array(z.string()),
+  alternativeNames: z.array(z.string()).optional(),
 })
 
 const CompanyBase = CompanyBaseSchema.extend({
@@ -533,6 +534,7 @@ export const CompanyDetails = CompanyBase.extend({
  */
 export const InternalCompanyDetails = CompanyDetails.extend({
   tags: z.array(z.string()),
+  alternativeNames: z.array(z.string()).default([]),
   identifiers: z.array(CompanyIdentifierSchema).optional(),
 })
 

--- a/src/api/services/companyService.ts
+++ b/src/api/services/companyService.ts
@@ -23,6 +23,7 @@ import {
 } from '@/lib/company-emissions/companyEmissionsCalculator'
 import { calculateFutureEmissionTrend } from '@/lib/company-emissions/companyEmissionsFutureTrendCalculator'
 import { foldDiacriticsForCompanyMatch } from '../../lib/companyLinkResolve'
+import { mergeAlternativeNames } from '../../lib/companyAlternativeNames'
 import Firecrawl, { SearchResultWeb } from '@mendable/firecrawl-js'
 import { CompanyReports, SaveReportsBody, SaveReportsResult } from '../types'
 import { pdf } from 'pdf-to-img'
@@ -111,13 +112,32 @@ class CompanyService {
       SELECT "id"
       FROM "Company"
       WHERE lower(name) LIKE ${likePattern}
+         OR EXISTS (
+              SELECT 1
+              FROM unnest(COALESCE("alternativeNames", ARRAY[]::text[])) AS alt
+              WHERE lower(alt) LIKE ${likePattern}
+            )
          OR (
               char_length(${normalizedSearchTerm}) >= 3
-              AND to_tsvector('simple', name) @@ websearch_to_tsquery('simple', ${normalizedSearchTerm})
+              AND (
+                to_tsvector('simple', name) @@ websearch_to_tsquery('simple', ${normalizedSearchTerm})
+                OR EXISTS (
+                  SELECT 1
+                  FROM unnest(COALESCE("alternativeNames", ARRAY[]::text[])) AS alt
+                  WHERE to_tsvector('simple', alt) @@ websearch_to_tsquery('simple', ${normalizedSearchTerm})
+                )
+              )
             )
          OR (
               char_length(${foldedSearchTerm}) >= 3
-              AND translate(lower(name), ${SQL_ACCENT_FROM}, ${SQL_ACCENT_TO}) LIKE ${foldedLikePattern}
+              AND (
+                translate(lower(name), ${SQL_ACCENT_FROM}, ${SQL_ACCENT_TO}) LIKE ${foldedLikePattern}
+                OR EXISTS (
+                  SELECT 1
+                  FROM unnest(COALESCE("alternativeNames", ARRAY[]::text[])) AS alt
+                  WHERE translate(lower(alt), ${SQL_ACCENT_FROM}, ${SQL_ACCENT_TO}) LIKE ${foldedLikePattern}
+                )
+              )
             )
       ORDER BY
         CASE WHEN lower(name) LIKE ${likePattern} THEN 0 ELSE 1 END,
@@ -358,6 +378,7 @@ class CompanyService {
   async createCompany({
     wikidataId,
     user,
+    alternativeNames,
     ...data
   }: {
     wikidataId?: string | null
@@ -366,6 +387,7 @@ class CompanyService {
     logoUrl?: string
     internalComment?: string
     tags?: string[]
+    alternativeNames?: string[]
     lei?: string
     user?: User
   }) {
@@ -386,6 +408,14 @@ class CompanyService {
       data: {
         ...data,
         wikidataId: wikidataId ?? null,
+        ...(alternativeNames !== undefined
+          ? {
+              alternativeNames: mergeAlternativeNames({
+                canonicalName: data.name,
+                incomingNames: alternativeNames,
+              }),
+            }
+          : {}),
       },
     })
 
@@ -405,13 +435,25 @@ class CompanyService {
       logoUrl?: string
       internalComment?: string
       tags?: string[]
+      alternativeNames?: string[]
       lei?: string
     },
     user?: User
   ) {
+    const { alternativeNames, ...rest } = data
     const company = await prisma.company.update({
       where: { id: companyId },
-      data,
+      data: {
+        ...rest,
+        ...(alternativeNames !== undefined
+          ? {
+              alternativeNames: mergeAlternativeNames({
+                canonicalName: data.name,
+                incomingNames: alternativeNames,
+              }),
+            }
+          : {}),
+      },
     })
 
     await companyIdentifierService.syncFromLegacyColumns(company, {

--- a/src/lib/companyLinkResolve.test.ts
+++ b/src/lib/companyLinkResolve.test.ts
@@ -56,6 +56,37 @@ describe('companyLinkResolve', () => {
     expect(result).toEqual({ action: 'resolve', companyId: 'alfa-1' })
   })
 
+  it('resolves when exactly one candidate matches via an alternative name', () => {
+    const result = assessCompanyLinkResolution('AB Volvo', [
+      {
+        id: 'volvo-1',
+        name: 'Volvo Group',
+        alternativeNames: ['Volvo AB', 'AB Volvo'],
+      },
+      { id: 'other', name: 'Other Co' },
+    ])
+    expect(result).toEqual({ action: 'resolve', companyId: 'volvo-1' })
+  })
+
+  it('does not auto-resolve Volvo Cars against Volvo AB aliases', () => {
+    const candidates = [
+      {
+        id: 'volvo-ab',
+        name: 'Volvo AB',
+        alternativeNames: ['AB Volvo'],
+      },
+      {
+        id: 'volvo-cars',
+        name: 'Volvo Cars',
+      },
+    ]
+    const result = assessCompanyLinkResolution('Volvo Cars', candidates)
+    expect(result).toEqual({
+      action: 'resolve',
+      companyId: 'volvo-cars',
+    })
+  })
+
   it('flags ambiguity when multiple candidates share the normalized name', () => {
     const candidates = [
       { id: 'alfa-1', name: 'Alfa Laval', wikidataId: 'Q686030' },

--- a/src/lib/companyLinkResolve.test.ts
+++ b/src/lib/companyLinkResolve.test.ts
@@ -56,19 +56,24 @@ describe('companyLinkResolve', () => {
     expect(result).toEqual({ action: 'resolve', companyId: 'alfa-1' })
   })
 
-  it('resolves when exactly one candidate matches via an alternative name', () => {
-    const result = assessCompanyLinkResolution('AB Volvo', [
+  it('sends alias-only exact hits to staff review (never auto-links)', () => {
+    const candidates = [
       {
         id: 'volvo-1',
         name: 'Volvo Group',
         alternativeNames: ['Volvo AB', 'AB Volvo'],
       },
       { id: 'other', name: 'Other Co' },
-    ])
-    expect(result).toEqual({ action: 'resolve', companyId: 'volvo-1' })
+    ]
+    const result = assessCompanyLinkResolution('AB Volvo', candidates)
+    expect(result).toEqual({
+      action: 'ambiguous',
+      candidates: [candidates[0]],
+      matchedViaAlternativeName: true,
+    })
   })
 
-  it('does not auto-resolve Volvo Cars against Volvo AB aliases', () => {
+  it('still auto-resolves Volvo Cars via canonical name, not Volvo AB aliases', () => {
     const candidates = [
       {
         id: 'volvo-ab',

--- a/src/lib/companyLinkResolve.ts
+++ b/src/lib/companyLinkResolve.ts
@@ -18,6 +18,11 @@ export type CompanyLinkResolution =
       candidates: CompanyLinkCandidate[]
       /** True when candidates matched on shared core token (e.g. Sampo Group vs Sampo plc). */
       partialNameMatch?: boolean
+      /**
+       * True when the extracted name matched an alternative name (not the canonical
+       * `name`). These never auto-link — staff must confirm.
+       */
+      matchedViaAlternativeName?: boolean
     }
   | { action: 'create' }
 
@@ -213,29 +218,34 @@ export function dedupeCompanyLinkCandidates(
   })
 }
 
-function companyLinkCandidateMatchKeys(
-  candidate: CompanyLinkCandidate
-): string[] {
-  const keys = new Set<string>()
-  if (candidate.name) {
-    const nameKey = normalizeCompanyNameForMatch(candidate.name)
-    if (nameKey) keys.add(nameKey)
-  }
-  for (const alternativeName of candidate.alternativeNames ?? []) {
-    const key = normalizeCompanyNameForMatch(alternativeName)
-    if (key) keys.add(key)
-  }
-  return [...keys]
-}
-
+/** Exact match against canonical `name` only — used for auto-link. */
 export function pickExactNameMatches(
   extractedName: string,
   candidates: CompanyLinkCandidate[]
 ): CompanyLinkCandidate[] {
   const target = normalizeCompanyNameForMatch(extractedName)
   if (!target) return []
+  return candidates.filter(
+    (candidate) =>
+      candidate.name && normalizeCompanyNameForMatch(candidate.name) === target
+  )
+}
+
+/**
+ * Exact match against `alternativeNames` only. Used to propose review
+ * candidates — never for auto-link.
+ */
+export function pickExactAlternativeNameMatches(
+  extractedName: string,
+  candidates: CompanyLinkCandidate[]
+): CompanyLinkCandidate[] {
+  const target = normalizeCompanyNameForMatch(extractedName)
+  if (!target) return []
   return candidates.filter((candidate) =>
-    companyLinkCandidateMatchKeys(candidate).includes(target)
+    (candidate.alternativeNames ?? []).some(
+      (alternativeName) =>
+        normalizeCompanyNameForMatch(alternativeName) === target
+    )
   )
 }
 
@@ -258,9 +268,10 @@ export function wikidataSelectionMatchesCompanyName(
 
 /**
  * Decide whether to auto-link, ask a human, or create a new company.
- * Auto-link only when exactly one candidate matches the normalized name.
+ * Auto-link only when exactly one candidate matches the canonical name.
+ * Exact alternative-name hits always go to staff (strong proposals, no auto-link).
  * Partial core-token matches (e.g. Sampo Group vs Sampo plc) go to staff with a focused candidate list.
- * Any other fuzzy hit without a single exact match also goes to staff.
+ * Any other fuzzy hit without a single exact canonical match also goes to staff.
  */
 export function assessCompanyLinkResolution(
   extractedName: string,
@@ -272,16 +283,31 @@ export function assessCompanyLinkResolution(
     return { action: 'create' }
   }
 
-  const exactMatches = pickExactNameMatches(extractedName, uniqueCandidates)
+  const exactCanonicalMatches = pickExactNameMatches(
+    extractedName,
+    uniqueCandidates
+  )
 
-  if (exactMatches.length === 1) {
-    return { action: 'resolve', companyId: exactMatches[0].id }
+  if (exactCanonicalMatches.length === 1) {
+    return { action: 'resolve', companyId: exactCanonicalMatches[0].id }
   }
 
-  if (exactMatches.length > 1) {
+  if (exactCanonicalMatches.length > 1) {
     return {
       action: 'ambiguous',
-      candidates: dedupeCompanyLinkCandidates(exactMatches),
+      candidates: dedupeCompanyLinkCandidates(exactCanonicalMatches),
+    }
+  }
+
+  const exactAlternativeMatches = pickExactAlternativeNameMatches(
+    extractedName,
+    uniqueCandidates
+  )
+  if (exactAlternativeMatches.length >= 1) {
+    return {
+      action: 'ambiguous',
+      candidates: dedupeCompanyLinkCandidates(exactAlternativeMatches),
+      matchedViaAlternativeName: true,
     }
   }
 

--- a/src/lib/companyLinkResolve.ts
+++ b/src/lib/companyLinkResolve.ts
@@ -8,6 +8,7 @@ export type CompanyLinkCandidate = {
   name: string
   wikidataId?: string | null
   lei?: string | null
+  alternativeNames?: string[] | null
 }
 
 export type CompanyLinkResolution =
@@ -80,10 +81,17 @@ export function pickPartialNameMatches(
   extractedName: string,
   candidates: CompanyLinkCandidate[]
 ): CompanyLinkCandidate[] {
-  return candidates.filter(
-    (candidate) =>
-      candidate.name && isPartialCompanyNameMatch(extractedName, candidate.name)
-  )
+  return candidates.filter((candidate) => {
+    if (
+      candidate.name &&
+      isPartialCompanyNameMatch(extractedName, candidate.name)
+    ) {
+      return true
+    }
+    return (candidate.alternativeNames ?? []).some((alternativeName) =>
+      isPartialCompanyNameMatch(extractedName, alternativeName)
+    )
+  })
 }
 
 export { stripLegalEntitySuffixes }
@@ -205,14 +213,29 @@ export function dedupeCompanyLinkCandidates(
   })
 }
 
+function companyLinkCandidateMatchKeys(
+  candidate: CompanyLinkCandidate
+): string[] {
+  const keys = new Set<string>()
+  if (candidate.name) {
+    const nameKey = normalizeCompanyNameForMatch(candidate.name)
+    if (nameKey) keys.add(nameKey)
+  }
+  for (const alternativeName of candidate.alternativeNames ?? []) {
+    const key = normalizeCompanyNameForMatch(alternativeName)
+    if (key) keys.add(key)
+  }
+  return [...keys]
+}
+
 export function pickExactNameMatches(
   extractedName: string,
   candidates: CompanyLinkCandidate[]
 ): CompanyLinkCandidate[] {
   const target = normalizeCompanyNameForMatch(extractedName)
-  return candidates.filter(
-    (candidate) =>
-      candidate.name && normalizeCompanyNameForMatch(candidate.name) === target
+  if (!target) return []
+  return candidates.filter((candidate) =>
+    companyLinkCandidateMatchKeys(candidate).includes(target)
   )
 }
 

--- a/src/lib/pipelineCompanyResolve.test.ts
+++ b/src/lib/pipelineCompanyResolve.test.ts
@@ -163,6 +163,7 @@ describe('resolveOrCreatePipelineCompanyId', () => {
       name: 'Alfa Laval',
       wikidataId: 'Q686030',
       lei: null,
+      alternativeNames: [],
     })
   })
 
@@ -184,6 +185,7 @@ describe('resolveOrCreatePipelineCompanyId', () => {
       name: 'Acme',
       wikidataId: null,
       lei: '5493001KJTIIGC8Y1R12',
+      alternativeNames: [],
     })
   })
 

--- a/src/lib/pipelineCompanyResolve.ts
+++ b/src/lib/pipelineCompanyResolve.ts
@@ -39,6 +39,7 @@ export type PipelineCompanyResolveOutcome =
       extractedName: string
       candidates: CompanyLinkCandidate[]
       partialNameMatch?: boolean
+      matchedViaAlternativeName?: boolean
     }
   | { status: 'create'; extractedName: string }
 
@@ -223,6 +224,7 @@ export async function resolvePipelineCompanyOutcome(
       extractedName: companyName,
       candidates: assessment.candidates,
       partialNameMatch: assessment.partialNameMatch,
+      matchedViaAlternativeName: assessment.matchedViaAlternativeName,
     }
   }
 
@@ -249,6 +251,7 @@ export async function resolvePipelineCompanyAfterIdentifiers(
       extractedName: string
       candidates: CompanyLinkCandidate[]
       partialNameMatch?: boolean
+      matchedViaAlternativeName?: boolean
     }
 > {
   const wikidataId = identifiers.wikidata?.node?.trim()
@@ -292,6 +295,7 @@ export async function resolvePipelineCompanyAfterIdentifiers(
       extractedName: companyName,
       candidates: assessment.candidates,
       partialNameMatch: assessment.partialNameMatch,
+      matchedViaAlternativeName: assessment.matchedViaAlternativeName,
     }
   }
 

--- a/src/lib/pipelineCompanyResolve.ts
+++ b/src/lib/pipelineCompanyResolve.ts
@@ -47,6 +47,7 @@ type PipelineCompanyRecord = {
   name?: string
   wikidataId?: string | null
   lei?: string | null
+  alternativeNames?: string[] | null
 }
 
 /** Resolve wikidata Q-id / LEI / UUID prefix to the internal Company.id used for mutations. */
@@ -84,6 +85,7 @@ function toCompanyLinkCandidate(
     name: record.name ?? '',
     wikidataId: record.wikidataId ?? null,
     lei: record.lei ?? null,
+    alternativeNames: record.alternativeNames ?? [],
   }
 }
 
@@ -118,7 +120,14 @@ async function collectNameSearchCandidates(
   const coreToken = companyNameCoreToken(companyName)
   if (coreToken) {
     for (const hit of await searchCompaniesByName(coreToken)) {
-      if (hit.name && isPartialCompanyNameMatch(companyName, hit.name)) {
+      const namesToCompare = [hit.name, ...(hit.alternativeNames ?? [])].filter(
+        Boolean
+      )
+      if (
+        namesToCompare.some((candidateName) =>
+          isPartialCompanyNameMatch(companyName, candidateName)
+        )
+      ) {
         byId.set(hit.id, hit)
       }
     }

--- a/src/workers/checkDB.ts
+++ b/src/workers/checkDB.ts
@@ -233,14 +233,19 @@ const checkDB = new PipelineWorker(
                 partialNameMatch: true,
                 displayName: saveResolution.extractedName,
               }),
+              ...(saveResolution.matchedViaAlternativeName && {
+                matchedViaAlternativeName: true,
+              }),
             },
           },
           false,
           {
             source: 'checkdb-company-resolve',
-            comment: saveResolution.partialNameMatch
-              ? 'Partial name match — select the correct company and optionally set display name'
-              : 'Multiple matching companies found before save — please select the correct company',
+            comment: saveResolution.matchedViaAlternativeName
+              ? 'Matched via alternative name — confirm the correct company before continuing'
+              : saveResolution.partialNameMatch
+                ? 'Partial name match — select the correct company and optionally set display name'
+                : 'Multiple matching companies found before save — please select the correct company',
           },
           `Company link before save for ${companyName}`
         )

--- a/src/workers/precheck.ts
+++ b/src/workers/precheck.ts
@@ -58,6 +58,7 @@ async function resolveOrCreateCompanyForPrecheck(
       status: 'ambiguous'
       candidates: import('../lib/companyLinkResolve').CompanyLinkCandidate[]
       partialNameMatch?: boolean
+      matchedViaAlternativeName?: boolean
     }
   | null
 > {
@@ -76,6 +77,7 @@ async function resolveOrCreateCompanyForPrecheck(
       status: 'ambiguous',
       candidates: outcome.candidates,
       partialNameMatch: outcome.partialNameMatch,
+      matchedViaAlternativeName: outcome.matchedViaAlternativeName,
     }
   }
 
@@ -177,9 +179,11 @@ async function ensurePipelineCompany(
 
     const metadata = {
       source: 'company-name-search',
-      comment: outcome.partialNameMatch
-        ? 'Partial name match — select the correct company and optionally set display name'
-        : 'Multiple matching companies found — please select the correct company',
+      comment: outcome.matchedViaAlternativeName
+        ? 'Matched via alternative name — confirm the correct company before continuing'
+        : outcome.partialNameMatch
+          ? 'Partial name match — select the correct company and optionally set display name'
+          : 'Multiple matching companies found — please select the correct company',
     }
 
     await job.requestApproval(
@@ -192,6 +196,9 @@ async function ensurePipelineCompany(
           ...(outcome.partialNameMatch && {
             partialNameMatch: true,
             displayName: outcome.extractedName,
+          }),
+          ...(outcome.matchedViaAlternativeName && {
+            matchedViaAlternativeName: true,
           }),
         },
       },
@@ -224,14 +231,19 @@ async function ensurePipelineCompany(
             partialNameMatch: true,
             displayName: companyName,
           }),
+          ...(locked.matchedViaAlternativeName && {
+            matchedViaAlternativeName: true,
+          }),
         },
       },
       false,
       {
         source: 'company-name-search',
-        comment: locked.partialNameMatch
-          ? 'Partial name match — select the correct company and optionally set display name'
-          : 'Multiple matching companies found — please select the correct company',
+        comment: locked.matchedViaAlternativeName
+          ? 'Matched via alternative name — confirm the correct company before continuing'
+          : locked.partialNameMatch
+            ? 'Partial name match — select the correct company and optionally set display name'
+            : 'Multiple matching companies found — please select the correct company',
       },
       `Company link for ${companyName}`
     )


### PR DESCRIPTION
## Summary
- Read/write `alternativeNames` on company create/update (deduped via `mergeAlternativeNames`)
- Company search (incl. pipeline lightweight search) matches `name` **or** aliases
- Pipeline link resolution treats aliases as exact-match surfaces; still ambiguous unless one exact hit
- Response schemas expose aliases on internal/list payloads; partner schemas unchanged

Depends on #1395 (merged). Stack with API PR 2a for Unearth parity.

## Test plan
- [ ] Create/update company with `alternativeNames`; confirm formatting variants of `name` are dropped
- [ ] Search by an alias returns the company; canonical name still ranks first when both match
- [ ] Pipeline resolve: unique alias exact match auto-links; Volvo Cars vs Volvo AB stays distinct
- [ ] `npx jest src/lib/companyLinkResolve.test.ts`


Made with [Cursor](https://cursor.com)