### PR TITLE
Collect alternative names after confirmed pipeline links

### DIFF
--- a/src/api/services/companyService.ts
+++ b/src/api/services/companyService.ts
@@ -471,6 +471,45 @@ class CompanyService {
     })
   }
 
+  /**
+   * After a confirmed company link, store the extracted report name as an
+   * alternative name when it is not just a formatting variant of `name`.
+   * Never changes canonical `name`. No-op when merge yields no change.
+   */
+  async collectAlternativeNameFromResolvedLink(
+    companyId: string,
+    extractedName: string
+  ): Promise<string[] | null> {
+    const trimmed = extractedName.trim()
+    if (!trimmed) return null
+
+    const company = await prisma.company.findUnique({
+      where: { id: companyId },
+      select: { name: true, alternativeNames: true },
+    })
+    if (!company) return null
+
+    const existing = company.alternativeNames ?? []
+    const merged = mergeAlternativeNames({
+      canonicalName: company.name,
+      existingAlternativeNames: existing,
+      incomingNames: [trimmed],
+    })
+
+    if (
+      merged.length === existing.length &&
+      merged.every((name, index) => name === existing[index])
+    ) {
+      return null
+    }
+
+    await prisma.company.update({
+      where: { id: companyId },
+      data: { alternativeNames: merged },
+    })
+    return merged
+  }
+
   async deleteCompany(companyId: string) {
     return prisma.company.delete({ where: { id: companyId } })
   }

--- a/src/lib/collectAlternativeNameAfterConfirmedLink.test.ts
+++ b/src/lib/collectAlternativeNameAfterConfirmedLink.test.ts
@@ -28,17 +28,27 @@ describe('collectAlternativeNameAfterConfirmedLink merge decision', () => {
       wouldCollectAlternativeName({
         canonicalName: 'Volvo AB',
         existingAlternativeNames: [],
+        extractedName: 'Volvo Group',
+      })
+    ).toBe(true)
+  })
+
+  it('does not collect legal-suffix / formatting variants of the canonical name', () => {
+    expect(
+      wouldCollectAlternativeName({
+        canonicalName: 'Volvo AB',
+        existingAlternativeNames: [],
         extractedName: 'AB Volvo',
       })
     ).toBe(false)
 
     expect(
       wouldCollectAlternativeName({
-        canonicalName: 'Volvo AB',
+        canonicalName: 'Nestlé Sverige',
         existingAlternativeNames: [],
-        extractedName: 'Volvo Group',
+        extractedName: 'Nestle Sverige',
       })
-    ).toBe(true)
+    ).toBe(false)
   })
 
   it('does not collect when the extracted name is already stored', () => {
@@ -47,16 +57,6 @@ describe('collectAlternativeNameAfterConfirmedLink merge decision', () => {
         canonicalName: 'Acme Corp',
         existingAlternativeNames: ['Acme Trading'],
         extractedName: 'Acme Trading',
-      })
-    ).toBe(false)
-  })
-
-  it('does not collect formatting variants of the canonical name', () => {
-    expect(
-      wouldCollectAlternativeName({
-        canonicalName: 'Nestlé Sverige',
-        existingAlternativeNames: [],
-        extractedName: 'Nestle Sverige',
       })
     ).toBe(false)
   })

--- a/src/lib/collectAlternativeNameAfterConfirmedLink.test.ts
+++ b/src/lib/collectAlternativeNameAfterConfirmedLink.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from '@jest/globals'
+import { mergeAlternativeNames } from './companyAlternativeNames'
+
+/**
+ * Mirrors the merge decision used by collectAlternativeNameFromResolvedLink
+ * without hitting the database.
+ */
+function wouldCollectAlternativeName(input: {
+  canonicalName: string
+  existingAlternativeNames: string[]
+  extractedName: string
+}): boolean {
+  const existing = input.existingAlternativeNames
+  const merged = mergeAlternativeNames({
+    canonicalName: input.canonicalName,
+    existingAlternativeNames: existing,
+    incomingNames: [input.extractedName],
+  })
+  return !(
+    merged.length === existing.length &&
+    merged.every((name, index) => name === existing[index])
+  )
+}
+
+describe('collectAlternativeNameAfterConfirmedLink merge decision', () => {
+  it('collects a distinct trading name onto a confirmed company', () => {
+    expect(
+      wouldCollectAlternativeName({
+        canonicalName: 'Volvo AB',
+        existingAlternativeNames: [],
+        extractedName: 'AB Volvo',
+      })
+    ).toBe(false)
+
+    expect(
+      wouldCollectAlternativeName({
+        canonicalName: 'Volvo AB',
+        existingAlternativeNames: [],
+        extractedName: 'Volvo Group',
+      })
+    ).toBe(true)
+  })
+
+  it('does not collect when the extracted name is already stored', () => {
+    expect(
+      wouldCollectAlternativeName({
+        canonicalName: 'Acme Corp',
+        existingAlternativeNames: ['Acme Trading'],
+        extractedName: 'Acme Trading',
+      })
+    ).toBe(false)
+  })
+
+  it('does not collect formatting variants of the canonical name', () => {
+    expect(
+      wouldCollectAlternativeName({
+        canonicalName: 'Nestlé Sverige',
+        existingAlternativeNames: [],
+        extractedName: 'Nestle Sverige',
+      })
+    ).toBe(false)
+  })
+})

--- a/src/lib/collectAlternativeNameAfterConfirmedLink.ts
+++ b/src/lib/collectAlternativeNameAfterConfirmedLink.ts
@@ -1,0 +1,34 @@
+import { companyService } from '../api/services/companyService'
+
+/**
+ * Best-effort: after a company is confirmed for a report run, remember the
+ * extracted report name as an alternative name for future search/proposals.
+ * Never auto-links; never changes canonical `name`. Failures are logged only.
+ */
+export async function collectAlternativeNameAfterConfirmedLink(input: {
+  companyId: string
+  extractedName: string
+  log?: (message: string) => void
+}): Promise<void> {
+  const companyId = input.companyId.trim()
+  const extractedName = input.extractedName.trim()
+  if (!companyId || !extractedName) return
+
+  try {
+    const merged = await companyService.collectAlternativeNameFromResolvedLink(
+      companyId,
+      extractedName
+    )
+    if (merged) {
+      input.log?.(
+        `Collected alternative name "${extractedName}" for company ${companyId}`
+      )
+    }
+  } catch (error) {
+    input.log?.(
+      `Failed to collect alternative name for company ${companyId}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    )
+  }
+}

--- a/src/workers/checkDB.ts
+++ b/src/workers/checkDB.ts
@@ -32,6 +32,7 @@ import {
   applyStaffCompanyLinkDisplayName,
   staffApprovedDisplayName,
 } from '../lib/applyStaffCompanyLink'
+import { collectAlternativeNameAfterConfirmedLink } from '../lib/collectAlternativeNameAfterConfirmedLink'
 import { resolvePipelineLei } from '../lib/normalizeLei'
 
 export class CheckDBJob extends PipelineJob {
@@ -109,6 +110,7 @@ const checkDB = new PipelineWorker(
       }
       if (typeof approved.companyId === 'string' && approved.companyId.trim()) {
         companyId = approved.companyId.trim()
+        const extractedNameForAlias = companyName
         const override = staffApprovedDisplayName(approved)
         if (override) {
           companyName = await applyStaffCompanyLinkDisplayName(
@@ -129,6 +131,11 @@ const checkDB = new PipelineWorker(
             wikidataId: wikidata?.node ?? null,
           })
         }
+        await collectAlternativeNameAfterConfirmedLink({
+          companyId,
+          extractedName: extractedNameForAlias,
+          log: (message) => job.log(message),
+        })
       }
     }
 
@@ -271,6 +278,11 @@ const checkDB = new PipelineWorker(
             wikidataId: wikidata?.node ?? null,
           })
         }
+        await collectAlternativeNameAfterConfirmedLink({
+          companyId,
+          extractedName: companyName,
+          log: (message) => job.log(message),
+        })
       }
     } else {
       job.log(

--- a/src/workers/precheck.ts
+++ b/src/workers/precheck.ts
@@ -11,6 +11,7 @@ import { apiFetch } from '../lib/api'
 import {
   resolvePipelineCompanyOutcome,
   findCompanyByWikidataId,
+  type CompanyResolutionMethod,
 } from '../lib/pipelineCompanyResolve'
 import { findOrCreatePipelineCompanyLocked } from '../lib/pipelineCompanyCreate'
 import { syncCanonicalReportRunCompanyId } from '../lib/pipelineRunCompanyId'
@@ -57,7 +58,7 @@ async function resolveOrCreateCompanyForPrecheck(
   | {
       status: 'resolved'
       companyId: string
-      method: import('../lib/pipelineCompanyResolve').CompanyResolutionMethod
+      method: CompanyResolutionMethod
     }
   | {
       status: 'ambiguous'
@@ -180,13 +181,11 @@ async function ensurePipelineCompany(
       )
     }
     await syncRunCompanyIdFromPrecheck(job, outcome.companyId, companyName)
-    if (outcome.method !== 'job_data') {
-      await collectAlternativeNameAfterConfirmedLink({
-        companyId: outcome.companyId,
-        extractedName: companyName,
-        log: (message) => job.log(message),
-      })
-    }
+    await collectAlternativeNameAfterConfirmedLink({
+      companyId: outcome.companyId,
+      extractedName: companyName,
+      log: (message) => job.log(message),
+    })
     return outcome.companyId
   }
 

--- a/src/workers/precheck.ts
+++ b/src/workers/precheck.ts
@@ -18,6 +18,7 @@ import {
   applyStaffCompanyLinkDisplayName,
   staffApprovedDisplayName,
 } from '../lib/applyStaffCompanyLink'
+import { collectAlternativeNameAfterConfirmedLink } from '../lib/collectAlternativeNameAfterConfirmedLink'
 import { EXTRACT_EMISSIONS_CHILD_QUEUES } from './precheckFlow'
 import { withPipelineJobOpts } from '../lib/pipelineJobOptions'
 
@@ -53,7 +54,11 @@ async function resolveOrCreateCompanyForPrecheck(
   job: PrecheckJob,
   companyName: string
 ): Promise<
-  | { status: 'resolved'; companyId: string }
+  | {
+      status: 'resolved'
+      companyId: string
+      method: import('../lib/pipelineCompanyResolve').CompanyResolutionMethod
+    }
   | {
       status: 'ambiguous'
       candidates: import('../lib/companyLinkResolve').CompanyLinkCandidate[]
@@ -87,7 +92,11 @@ async function resolveOrCreateCompanyForPrecheck(
     )
   }
 
-  return { status: 'resolved', companyId: outcome.companyId }
+  return {
+    status: 'resolved',
+    companyId: outcome.companyId,
+    method: outcome.method,
+  }
 }
 
 async function syncRunCompanyIdFromPrecheck(
@@ -138,6 +147,11 @@ async function ensurePipelineCompany(
       await job.updateData({ ...job.data, companyId, companyName: finalName })
       job.log(`Using staff-selected company id=${companyId}`)
       await syncRunCompanyIdFromPrecheck(job, companyId, finalName)
+      await collectAlternativeNameAfterConfirmedLink({
+        companyId,
+        extractedName: companyName,
+        log: (message) => job.log(message),
+      })
       return companyId
     }
   }
@@ -166,6 +180,13 @@ async function ensurePipelineCompany(
       )
     }
     await syncRunCompanyIdFromPrecheck(job, outcome.companyId, companyName)
+    if (outcome.method !== 'job_data') {
+      await collectAlternativeNameAfterConfirmedLink({
+        companyId: outcome.companyId,
+        extractedName: companyName,
+        log: (message) => job.log(message),
+      })
+    }
     return outcome.companyId
   }
 
@@ -255,6 +276,14 @@ async function ensurePipelineCompany(
   await job.updateData({ ...job.data, companyId, companyName })
   job.log(`Created or reused pipeline company id=${companyId}`)
   await syncRunCompanyIdFromPrecheck(job, companyId, companyName)
+  // Skip create: extracted name becomes canonical `name`. Collect on reuse.
+  if (locked.method !== 'created') {
+    await collectAlternativeNameAfterConfirmedLink({
+      companyId,
+      extractedName: companyName,
+      log: (message) => job.log(message),
+    })
+  }
   return companyId
 }
 


### PR DESCRIPTION
## Summary
- After a confirmed company link (staff select, exact-name/wikidata/lei resolve, or reuse under lock), store the extracted report name in `alternativeNames` when it is not a formatting variant of canonical `name`.
- Skips create-new / newly created companies (extracted name becomes canonical). Does not change pipeline auto-link rules: aliases remain suggest-only.
- Best-effort helper logs failures without blocking the pipeline.

## Test plan
- [ ] Staff-approve an alias/partial match to an existing company → company gains the extracted name as an alternative name
- [ ] Exact-name resolve with only formatting differences → no new alias written
- [ ] Create-new company link → no alias collected
- [ ] Confirm auto-link still only uses unique canonical `name` matches (alias hits still request approval)


Made with [Cursor](https://cursor.com)