### PR TITLE
[Prod] Patch Version Bump v6.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garbo",
-  "version": "6.1.5-rc.5",
+  "version": "6.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garbo",
-      "version": "6.1.5-rc.5",
+      "version": "6.1.5",
       "hasInstallScript": true,
       "license": "MIT License",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garbo",
-  "version": "6.1.5-rc.5",
+  "version": "6.1.5",
   "description": "",
   "type": "module",
   "exports": {


### PR DESCRIPTION
# 🚀 Production Release PR

> **Title format:** `[Prod] Major/Minor/Patch Version Bump vX.X.X`

## 📦 Release Type

_Select the appropriate release type by marking with an `x`._

- [ ] Major version bump
- [ ] Minor version bump
- [x] Patch version bump

### Rollback Version

_Note the relevant rollback version to enable quick rollback if necessary._

v6.1.4

## 🔁 Environment Promotion

This release promotes changes **from `staging` to `production`** (staging validated on `6.1.5-rc.x`).

## 📋 What's Being Released

Everything merged since **v6.1.4**:

### Company alternative names
- Add `Company.alternativeNames` foundation + match-key helpers ([#1395](https://github.com/Klimatbyran/garbo/pull/1395))
- Expose alternativeNames in API, search, and pipeline resolve (alias hits suggest-only, never silent auto-link) ([#1408](https://github.com/Klimatbyran/garbo/pull/1408))
- Auto-collect extracted report names onto confirmed company links ([#1409](https://github.com/Klimatbyran/garbo/pull/1409))

### Coverage persistence
- Persist coverage company matches and entry–report links ([#1407](https://github.com/Klimatbyran/garbo/pull/1407))

### Cleanup
- Remove leftover territorial municipality/region/nation data (routes already on unearth-api) ([#1406](https://github.com/Klimatbyran/garbo/pull/1406))

## 🗂 Deployment Notes (optional)

_Anything to watch out for: DB migrations, feature flags, long-running jobs, cache warmup, etc._

- **DB migrations (apply on deploy via init `npm run migrate`):**
  - `20260824140000_company_alternative_names`
  - `20260828120000_coverage_persisted_links`
- Deploy **Garbo before** Unearth API **v1.9.2** and Validate **v1.19.2** (column + coverage schema owners)
- Deploy **Garbo API + worker** together (same image); workers need the collect-on-link behavior
- Coordinate with Validate **v1.19.2** (alt-names editor) and Unearth API **v1.9.2** (coverage search/match + persisted links)

## ✅ Checklist

- [x] Version number is updated correctly (code/package and/or k8s image tag)
- [ ] All relevant changes have been QA-tested in staging
- [x] Rollback version has been updated
- [x] Title follows the required format: `[Prod] Patch Version Bump v6.1.5`

---

_This template is for versioned production releases only. For other PR types, please select a different template._

Made with [Cursor](https://cursor.com)