### PR TITLE
[1405] Update the Swedish translation of the GICS categories

### DIFF
--- a/output/en/industry-gics.json
+++ b/output/en/industry-gics.json
@@ -94,7 +94,7 @@
     "sectorName": "Materials",
     "groupName": "Materials",
     "industryName": "Containers & Packaging",
-    "subIndustryName": "Metal, Glass & Plastic Containers ",
+    "subIndustryName": "Metal, Glass & Plastic Containers",
     "subIndustryDescription": "Manufacturers of metal, glass or plastic containers. Includes corks and caps."
   },
   "15103020": {
@@ -290,7 +290,7 @@
     "sectorName": "Industrials",
     "groupName": "Commercial  & Professional Services",
     "industryName": "Professional Services",
-    "subIndustryName": "Data Processing & Outsourced Services ",
+    "subIndustryName": "Data Processing & Outsourced Services",
     "subIndustryDescription": "Providers of commercial data processing and/or business process outsourcing services. This Sub-Industry includes companies providing services for customer experience management, back-office automation, call center management, and investor communications."
   },
   "20301010": {
@@ -325,7 +325,7 @@
     "sectorName": "Industrials",
     "groupName": "Transportation",
     "industryName": "Ground Transportation",
-    "subIndustryName": "Cargo Ground Transportation ",
+    "subIndustryName": "Cargo Ground Transportation",
     "subIndustryDescription": "Companies providing ground transportation services for goods and freight."
   },
   "20304040": {
@@ -360,7 +360,7 @@
     "sectorName": "Consumer Discretionary",
     "groupName": "Automobiles & Components",
     "industryName": "Automobile Components",
-    "subIndustryName": "Automotive Parts & Equipment ",
+    "subIndustryName": "Automotive Parts & Equipment",
     "subIndustryDescription": "Manufacturers of parts and accessories for  automobiles and motorcycles. Excludes companies classified in the Tires & Rubber Sub-Industry."
   },
   "25101020": {
@@ -570,7 +570,7 @@
     "sectorName": "Consumer Staples",
     "groupName": "Consumer Staples Distribution & Retail",
     "industryName": "Consumer Staples Distribution & Retail",
-    "subIndustryName": "Consumer Staples Merchandise Retail ",
+    "subIndustryName": "Consumer Staples Merchandise Retail",
     "subIndustryDescription": "Retailers offering a wide range of consumer staples merchandise such as food, household, and personal care products. This Sub-Industry includes hypermarkets, super centers and other consumer staples retailers such as discount retail spaces and on-line marketplaces selling mostly consumer staples goods."
   },
   "30201010": {
@@ -626,7 +626,7 @@
     "sectorName": "Consumer Staples",
     "groupName": "Personal Care Products",
     "industryName": "Personal Care Products",
-    "subIndustryName": "Personal Care Products ",
+    "subIndustryName": "Personal Care Products",
     "subIndustryDescription": "Manufacturers of personal and beauty care products, including cosmetics and perfumes."
   },
   "35101010": {
@@ -738,14 +738,14 @@
     "sectorName": "Financials",
     "groupName": "Financial Services",
     "industryName": "Financial Services",
-    "subIndustryName": "Commercial & Residential Mortgage Finance ",
+    "subIndustryName": "Commercial & Residential Mortgage Finance",
     "subIndustryDescription": "Financial companies providing commercial and residential mortgage financing and related mortgage services. This Sub-Industry includes non-deposit funded mortgage lending institutions, building societies, companies providing real estate financing products, loan servicing, mortgage broker services, and mortgage insurance. "
   },
   "40201060": {
     "sectorName": "Financials",
     "groupName": "Financial Services",
     "industryName": "Financial Services",
-    "subIndustryName": "Transaction & Payment Processing Services ",
+    "subIndustryName": "Transaction & Payment Processing Services",
     "subIndustryDescription": "Providers of transaction & payment processing services and related payment services including digital/mobile payment processors, payment service providers & gateways, and digital wallet providers."
   },
   "40202010": {
@@ -871,7 +871,7 @@
     "sectorName": "Information Technology",
     "groupName": "Technology Hardware & Equipment",
     "industryName": "Electronic Equipment, Instruments & Components",
-    "subIndustryName": "Electronic Equipment & Instruments ",
+    "subIndustryName": "Electronic Equipment & Instruments",
     "subIndustryDescription": "Manufacturers of electronic equipment and instruments including analytical, electronic test and measurement instruments, scanner/barcode products, lasers, display screens, point-of-sales machines, and security system equipment."
   },
   "45203015": {
@@ -1018,7 +1018,7 @@
     "sectorName": "Utilities",
     "groupName": "Utilities",
     "industryName": "Independent Power and Renewable Electricity Producers",
-    "subIndustryName": "Renewable Electricity ",
+    "subIndustryName": "Renewable Electricity",
     "subIndustryDescription": "Companies that engage in the generation and distribution of electricity using renewable sources, including, but not limited to, companies that produce electricity using biomass, geothermal energy, solar energy, hydropower, and wind power. Excludes companies manufacturing capital equipment used to generate electricity using renewable sources, such as manufacturers of solar power systems, installers of photovoltaic cells,  and companies involved in the provision of technology, components, and services mainly to this market. "
   },
   "60101010": {
@@ -1067,7 +1067,7 @@
     "sectorName": "Real Estate",
     "groupName": "Equity Real Estate Investment Trusts (REITs)",
     "industryName": "Residential REITs",
-    "subIndustryName": "Single-Family Residential REITs ",
+    "subIndustryName": "Single-Family Residential REITs",
     "subIndustryDescription": "Companies or Trusts engaged in the acquisition, development, ownership, leasing, management and operation of single-family residential housing including manufactured homes."
   },
   "60107010": {

--- a/output/sv/industry-gics.json
+++ b/output/sv/industry-gics.json
@@ -32,7 +32,7 @@
     "groupName": "Energi",
     "industryName": "Olja, gas och förbrukningsbränslen",
     "subIndustryName": "Raffinering och marknadsföring av olja och gas",
-    "subIndustryDescription": "Företag som sysslar med raffinering och marknadsföring av olja, gas och/eller raffinerade produkter som inte klassificeras i underbranscherna Integrated Oil och Gas eller Independent Power Producers och Energy Traders."
+    "subIndustryDescription": "Företag som sysslar med raffinering och marknadsföring av olja, gas och/eller raffinerade produkter som inte klassificeras i underbranscherna Integrerad olje- och gasverksamhet eller Oberoende elproducenter och energihandlare."
   },
   "10102040": {
     "sectorName": "Energi",
@@ -46,21 +46,21 @@
     "groupName": "Energi",
     "industryName": "Olja, gas och förbrukningsbränslen",
     "subIndustryName": "Kol och förbrukningsbränslen",
-    "subIndustryDescription": "Företag som främst är involverade i produktion och brytning av kol, relaterade produkter och andra förbrukningsbränslen relaterade till energiproduktion.  Exkluderar företag som främst producerar gaser klassificerade i underbranschen Industrial Gases och företag som främst utvinner metallurgiskt kol (kokskol) som används för stålproduktion."
+    "subIndustryDescription": "Företag som främst är involverade i produktion och brytning av kol, relaterade produkter och andra förbrukningsbränslen relaterade till energiproduktion. Exkluderar företag som främst producerar gaser klassificerade i underbranschen Industrigaser och företag som främst utvinner metallurgiskt kol (kokskol) som används för stålproduktion."
   },
   "15101010": {
     "sectorName": "Material",
     "groupName": "Material",
     "industryName": "Kemikalier",
     "subIndustryName": "Råvarukemikalier",
-    "subIndustryDescription": "Företag som främst producerar industrikemikalier och baskemikalier. Inklusive men inte begränsat till plast, syntetiska fibrer, filmer, råvarubaserade färger och pigment, sprängämnen och petrokemikalier. Utesluter kemiföretag som klassificeras i underbranscherna diversifierade kemikalier, gödselmedel och jordbrukskemikalier, industrigaser eller specialkemikalier."
+    "subIndustryDescription": "Företag som främst producerar industrikemikalier och baskemikalier. Inklusive men inte begränsat till plast, syntetiska fibrer, filmer, råvarubaserade färger och pigment, sprängämnen och petrokemikalier. Utesluter kemiföretag som klassificeras i underbranscherna Diversifierade kemikalier, Gödselmedel och jordbrukskemikalier, Industrigaser eller Specialkemikalier."
   },
   "15101020": {
     "sectorName": "Material",
     "groupName": "Material",
     "industryName": "Kemikalier",
     "subIndustryName": "Diversifierade kemikalier",
-    "subIndustryDescription": "Tillverkare av ett diversifierat utbud av kemiska produkter som inte klassificeras i underbranscherna industrigaser, råvarukemikalier, specialkemikalier eller gödselmedel och jordbrukskemikalier."
+    "subIndustryDescription": "Tillverkare av ett diversifierat utbud av kemiska produkter som inte klassificeras i underbranscherna Industrigaser, Råvarukemikalier, Specialkemikalier eller Gödselmedel och jordbrukskemikalier."
   },
   "15101030": {
     "sectorName": "Material",
@@ -87,8 +87,8 @@
     "sectorName": "Material",
     "groupName": "Material",
     "industryName": "Konstruktionsmaterial",
-    "subIndustryName": "Konstruktionsmaterial",
-    "subIndustryDescription": "Tillverkare av byggmaterial, inklusive sand, lera, gips, kalk, ballast, cement, betong och tegelstenar. Andra färdiga eller halvfärdiga byggnadsmaterial klassificeras i underbranschen för byggnadsprodukter."
+    "subIndustryName": "Byggmaterial",
+    "subIndustryDescription": "Tillverkare av byggmaterial, inklusive sand, lera, gips, kalk, ballast, cement, betong och tegelstenar. Andra färdiga eller halvfärdiga byggnadsmaterial klassificeras i underbranschen Byggprodukter."
   },
   "15103010": {
     "sectorName": "Material",
@@ -109,14 +109,14 @@
     "groupName": "Material",
     "industryName": "Metaller och gruvor",
     "subIndustryName": "Aluminium",
-    "subIndustryDescription": "Producenter av aluminium och relaterade produkter, inklusive företag som bryter eller bearbetar bauxit och företag som återvinner aluminium för att producera färdiga eller halvfärdiga produkter. Exkluderar företag som främst tillverkar byggnadsmaterial i aluminium som klassificeras i underbranschen byggprodukter."
+    "subIndustryDescription": "Producenter av aluminium och relaterade produkter, inklusive företag som bryter eller bearbetar bauxit och företag som återvinner aluminium för att producera färdiga eller halvfärdiga produkter. Exkluderar företag som främst tillverkar byggnadsmaterial i aluminium som klassificeras i underbranschen Byggprodukter."
   },
   "15104020": {
     "sectorName": "Material",
     "groupName": "Material",
     "industryName": "Metaller och gruvor",
     "subIndustryName": "Diversifierad metall- och gruvindustri",
-    "subIndustryDescription": "Företag som ägnar sig åt diversifierad produktion eller utvinning av metaller och mineraler som inte klassificeras någon annanstans. Inklusive, men inte begränsat till, brytning av icke-järnmetaller (utom bauxit), salt- och boratbrytning, brytning av fosfatsten och diversifierad gruvverksamhet. Omfattar inte järnmalmsbrytning, som klassificeras i underbranschen stål, bauxitbrytning, som klassificeras i underbranschen aluminium, och kolbrytning, som klassificeras i underbranschen stål eller kol och förbrukningsbränslen."
+    "subIndustryDescription": "Företag som ägnar sig åt diversifierad produktion eller utvinning av metaller och mineraler som inte klassificeras någon annanstans. Inklusive, men inte begränsat till, brytning av icke-järnmetaller (utom bauxit), salt- och boratbrytning, brytning av fosfatsten och diversifierad gruvverksamhet. Omfattar inte järnmalmsbrytning, som klassificeras i underbranschen Stål, bauxitbrytning, som klassificeras i underbranschen Aluminium, och kolbrytning, som klassificeras i underbranscherna Stål och Kol och förbrukningsbränslen."
   },
   "15104025": {
     "sectorName": "Material",
@@ -137,7 +137,7 @@
     "groupName": "Material",
     "industryName": "Metaller och gruvor",
     "subIndustryName": "Ädelmetaller och mineraler",
-    "subIndustryDescription": "Företag som utvinner ädelmetaller och mineraler som inte klassificeras i underbranschen guld. Omfattar företag som främst utvinner platina."
+    "subIndustryDescription": "Företag som utvinner ädelmetaller och mineraler som inte klassificeras i underbranschen Guld. Omfattar företag som främst utvinner platina."
   },
   "15104045": {
     "sectorName": "Material",
@@ -179,28 +179,28 @@
     "groupName": "Kapitalvaror",
     "industryName": "Byggprodukter",
     "subIndustryName": "Byggprodukter",
-    "subIndustryDescription": "Tillverkare av byggkomponenter och produkter och utrustning för renovering. Omfattar inte timmer och plywood som klassificeras under skogsprodukter samt cement och andra material som klassificeras under underbranschen för byggmaterial."
+    "subIndustryDescription": "Tillverkare av byggkomponenter och produkter och utrustning för renovering. Omfattar inte timmer och plywood som klassificeras under skogsprodukter samt cement och andra material som klassificeras under underbranschen Byggmaterial."
   },
   "20103010": {
     "sectorName": "Industriprodukter",
     "groupName": "Kapitalvaror",
     "industryName": "Bygg- och anläggningsverksamhet",
     "subIndustryName": "Bygg- och anläggningsverksamhet",
-    "subIndustryDescription": "Företag som huvudsakligen är verksamma inom byggande av kommersiella lokaler. Inkluderar anläggningsföretag och storskaliga entreprenörer. Exkluderar företag som klassificeras i underbranschen för husbyggnad."
+    "subIndustryDescription": "Företag som huvudsakligen är verksamma inom byggande av kommersiella lokaler. Inkluderar anläggningsföretag och storskaliga entreprenörer. Exkluderar företag som klassificeras i underbranschen Husbyggnad."
   },
   "20104010": {
     "sectorName": "Industriprodukter",
     "groupName": "Kapitalvaror",
     "industryName": "Elektrisk utrustning",
     "subIndustryName": "Elektriska komponenter och utrustning",
-    "subIndustryDescription": "Företag som producerar elektriska kablar och ledningar, elektriska komponenter eller utrustning som inte klassificeras i underbranschen för tung elektrisk utrustning."
+    "subIndustryDescription": "Företag som producerar elektriska kablar och ledningar, elektriska komponenter eller utrustning som inte klassificeras i underbranschen Tung elektrisk utrustning."
   },
   "20104020": {
     "sectorName": "Industriprodukter",
     "groupName": "Kapitalvaror",
     "industryName": "Elektrisk utrustning",
     "subIndustryName": "Tung elektrisk utrustning",
-    "subIndustryDescription": "Tillverkare av kraftgenererande utrustning och annan tung elektrisk utrustning, inklusive kraftturbiner, tunga elektriska maskiner avsedda för fast användning och stora elektriska system. Omfattar inte kablar och ledningar, som klassificeras i underbranschen för elektriska komponenter och utrustning."
+    "subIndustryDescription": "Tillverkare av kraftgenererande utrustning och annan tung elektrisk utrustning, inklusive kraftturbiner, tunga elektriska maskiner avsedda för fast användning och stora elektriska system. Omfattar inte kablar och ledningar, som klassificeras i underbranschen Elektriska komponenter och utrustning."
   },
   "20105010": {
     "sectorName": "Industriprodukter",
@@ -220,8 +220,8 @@
     "sectorName": "Industriprodukter",
     "groupName": "Kapitalvaror",
     "industryName": "Maskiner",
-    "subIndustryName": "Lantbruks- och jordbruksmaskiner",
-    "subIndustryDescription": "Företag som tillverkar jordbruksmaskiner, lantbruksmaskiner och tillhörande delar. Omfattar maskiner som används för produktion av grödor och boskap, jordbrukstraktorer, planterings- och gödslingsmaskiner, utrustning för spridning av gödningsmedel och kemikalier samt spannmålstorkar och blåsmaskiner."
+    "subIndustryName": "Jordbruks- och lantbruksmaskiner",
+    "subIndustryDescription": "Företag som tillverkar jordbruksmaskiner och tillhörande delar. Omfattar maskiner som används för produktion av grödor och boskap, jordbrukstraktorer, planterings- och gödslingsmaskiner, utrustning för spridning av gödningsmedel och kemikalier samt spannmålstorkar och blåsmaskiner."
   },
   "20106020": {
     "sectorName": "Industriprodukter",
@@ -249,7 +249,7 @@
     "groupName": "Kommersiella och professionella tjänster",
     "industryName": "Kommersiella tjänster och förnödenheter",
     "subIndustryName": "Miljö- och fastighetstjänster",
-    "subIndustryDescription": "Företag som tillhandahåller tjänster inom miljö- och anläggningsunderhåll. Omfattar tjänster för avfallshantering, fastighetsförvaltning och föroreningskontroll.  Exklusive storskaliga vattenreningssystem som klassificeras i underbranschen vattenförsörjning."
+    "subIndustryDescription": "Företag som tillhandahåller tjänster inom miljö- och anläggningsunderhåll. Omfattar tjänster för avfallshantering, fastighetsförvaltning och föroreningskontroll. Exklusive storskaliga vattenreningssystem som klassificeras i underbranschen Vattenförsörjning."
   },
   "20201060": {
     "sectorName": "Industriprodukter",
@@ -263,20 +263,20 @@
     "groupName": "Kommersiella och professionella tjänster",
     "industryName": "Kommersiella tjänster och förnödenheter",
     "subIndustryName": "Diversifierade stödtjänster",
-    "subIndustryDescription": "Företag som främst tillhandahåller arbetsorienterade stödtjänster till företag och myndigheter.  Omfattar kommersiell städning, restaurang- och cateringtjänster, reparation av utrustning, industriellt underhåll, industriauktioner, lagring och magasinering, transaktionstjänster, uthyrning av uniformer och andra stödtjänster till företag."
+    "subIndustryDescription": "Företag som främst tillhandahåller arbetsorienterade stödtjänster till företag och myndigheter. Omfattar kommersiell städning, restaurang- och cateringtjänster, reparation av utrustning, industriellt underhåll, industriauktioner, lagring och magasinering, transaktionstjänster, uthyrning av uniformer och andra stödtjänster till företag."
   },
   "20201080": {
     "sectorName": "Industriprodukter",
     "groupName": "Kommersiella och professionella tjänster",
     "industryName": "Kommersiella tjänster och förnödenheter",
     "subIndustryName": "Säkerhets- och larmtjänster",
-    "subIndustryDescription": "Företag som tillhandahåller säkerhets- och skyddstjänster till företag och myndigheter. Omfattar företag som tillhandahåller tjänster såsom kriminalvårdsanstalter, säkerhets- och larmtjänster, värdetransporter och bevakning.  Exkluderar företag som tillhandahåller säkerhetsprogramvara som klassificeras under underbranschen Programvara för system och hemsäkerhetstjänster som klassificeras under underbranschen Specialiserade konsumenttjänster. Omfattar inte heller företag som tillverkar utrustning för säkerhetssystem klassificerade under underbranschen Electronic Equipment och Instruments."
+    "subIndustryDescription": "Företag som tillhandahåller säkerhets- och skyddstjänster till företag och myndigheter. Omfattar företag som tillhandahåller tjänster såsom kriminalvårdsanstalter, säkerhets- och larmtjänster, värdetransporter och bevakning. Exkluderar företag som tillhandahåller säkerhetsprogramvara som klassificeras under underbranschen Programvara för system och hemsäkerhetstjänster som klassificeras under underbranschen Specialiserade konsumenttjänster. Omfattar inte heller företag som tillverkar utrustning för säkerhetssystem klassificerade under underbranschen Elektronisk utrustning och instrument."
   },
   "20202010": {
     "sectorName": "Industriprodukter",
     "groupName": "Kommersiella och professionella tjänster",
     "industryName": "Professionella tjänster",
-    "subIndustryName": "Human Resource och Arbetsförmedling",
+    "subIndustryName": "Personal- och arbetsförmedlingstjänster",
     "subIndustryDescription": "Företag som tillhandahåller affärsstödjande tjänster relaterade till hantering av humankapital. Denna underbransch omfattar arbetsförmedlingar, utbildning av anställda, lönebearbetning, stödtjänster för förmåner och pensioner, rekryteringstjänster för företag och arbetssökande samt jobbportaler på nätet som genererar intäkter från avgifter eller provisioner för att erbjuda rekryteringstjänster till företag eller arbetssökande."
   },
   "20202020": {
@@ -284,7 +284,7 @@
     "groupName": "Kommersiella och professionella tjänster",
     "industryName": "Professionella tjänster",
     "subIndustryName": "Forskning och konsulttjänster",
-    "subIndustryDescription": "Företag som huvudsakligen tillhandahåller forsknings- och konsulttjänster till företag och myndigheter som inte klassificeras någon annanstans.  Omfattar företag som arbetar med managementkonsulttjänster, arkitektonisk design, affärsinformation eller vetenskaplig forskning, marknadsföring samt test- och certifieringstjänster. Exkluderar företag som tillhandahåller konsulttjänster inom informationsteknologi som klassificeras i underbranschen IT-konsulttjänster och andra tjänster."
+    "subIndustryDescription": "Företag som huvudsakligen tillhandahåller forsknings- och konsulttjänster till företag och myndigheter som inte klassificeras någon annanstans. Omfattar företag som arbetar med managementkonsulttjänster, arkitektonisk design, affärsinformation eller vetenskaplig forskning, marknadsföring samt test- och certifieringstjänster. Exkluderar företag som tillhandahåller konsulttjänster inom informationsteknologi som klassificeras i underbranschen IT-konsulttjänster och andra tjänster."
   },
   "20202030": {
     "sectorName": "Industriprodukter",
@@ -298,7 +298,7 @@
     "groupName": "Transport",
     "industryName": "Flygfrakt och logistik",
     "subIndustryName": "Flygfrakt och logistik",
-    "subIndustryDescription": "Företag som tillhandahåller flygfrakt, kurir- och logistiktjänster, inklusive paket- och postleveranser samt tullombud. Utesluter de företag som klassificeras i underbranscherna Airlines, Marine eller Trucking."
+    "subIndustryDescription": "Företag som tillhandahåller flygfrakt, kurir- och logistiktjänster, inklusive paket- och postleveranser samt tullombud. Utesluter de företag som klassificeras i underbranscherna Flygbolag, Sjöfart eller Lastbilstransporter."
   },
   "20302010": {
     "sectorName": "Industriprodukter",
@@ -382,7 +382,7 @@
     "groupName": "Bilar och komponenter",
     "industryName": "Bilar",
     "subIndustryName": "Tillverkare av motorcyklar",
-    "subIndustryDescription": "Företag som tillverkar motorcyklar, skotrar eller trehjulingar. Exkluderar cyklar som klassificeras i underbranschen för fritidsprodukter."
+    "subIndustryDescription": "Företag som tillverkar motorcyklar, skotrar eller trehjulingar. Exkluderar cyklar som klassificeras i underbranschen Fritidsprodukter."
   },
   "25201010": {
     "sectorName": "Sällanköpsvaror",
@@ -410,7 +410,7 @@
     "groupName": "Konsumentvaror och kläder",
     "industryName": "Sällanköpsvaror för hushåll",
     "subIndustryName": "Hushållsapparater",
-    "subIndustryDescription": "Tillverkare av elektriska hushållsapparater och relaterade produkter.  Inkluderar tillverkare av el- och handverktyg, inklusive verktyg för trädgårdsskötsel.  Exkluderar TV-apparater och andra ljud- och videoprodukter som klassificeras i underbranschen Konsumentelektronik och persondatorer som klassificeras i underbranschen Teknik Hårdvara, lagring och kringutrustning."
+    "subIndustryDescription": "Tillverkare av elektriska hushållsapparater och relaterade produkter. Inkluderar tillverkare av el- och handverktyg, inklusive verktyg för trädgårdsskötsel. Exkluderar TV-apparater och andra ljud- och videoprodukter som klassificeras i underbranschen Konsumentelektronik och persondatorer som klassificeras i underbranschen Teknik Hårdvara, lagring och kringutrustning."
   },
   "25201050": {
     "sectorName": "Sällanköpsvaror",
@@ -431,7 +431,7 @@
     "groupName": "Konsumentvaror och kläder",
     "industryName": "Textilier, kläder och lyxvaror",
     "subIndustryName": "Kläder, accessoarer och lyxvaror",
-    "subIndustryDescription": "Tillverkare av kläder, accessoarer och lyxvaror. Inkluderar företag som främst tillverkar designerhandväskor, plånböcker, bagage, smycken och klockor. Exkluderar skor som klassificeras i underbranschen för skor."
+    "subIndustryDescription": "Tillverkare av kläder, accessoarer och lyxvaror. Inkluderar företag som främst tillverkar designerhandväskor, plånböcker, bagage, smycken och klockor. Exkluderar skor som klassificeras i underbranschen Skor."
   },
   "25203020": {
     "sectorName": "Sällanköpsvaror",
@@ -445,7 +445,7 @@
     "groupName": "Konsumentvaror och kläder",
     "industryName": "Textilier, kläder och lyxvaror",
     "subIndustryName": "Textilier",
-    "subIndustryDescription": "Tillverkare av textil och relaterade produkter som inte klassificeras i underbranscherna kläder, accessoarer och lyxvaror, skor eller heminredning."
+    "subIndustryDescription": "Tillverkare av textil och relaterade produkter som inte klassificeras i underbranscherna Kläder, accessoarer och lyxvaror, Skor eller Heminredning."
   },
   "25301010": {
     "sectorName": "Sällanköpsvaror",
@@ -487,7 +487,7 @@
     "groupName": "Konsumenttjänster",
     "industryName": "Diversifierade konsumenttjänster",
     "subIndustryName": "Specialiserade konsumenttjänster",
-    "subIndustryDescription": "Företag som tillhandahåller konsumenttjänster som inte klassificeras någon annanstans.  Omfattar bostadstjänster, hemsäkerhet, juridiska tjänster, personliga tjänster, renoverings- och inredningstjänster, konsumentauktioner samt bröllops- och begravningstjänster."
+    "subIndustryDescription": "Företag som tillhandahåller konsumenttjänster som inte klassificeras någon annanstans. Omfattar bostadstjänster, hemsäkerhet, juridiska tjänster, personliga tjänster, renoverings- och inredningstjänster, konsumentauktioner samt bröllops- och begravningstjänster."
   },
   "25501010": {
     "sectorName": "Sällanköpsvaror",
@@ -499,8 +499,8 @@
   "25503030": {
     "sectorName": "Sällanköpsvaror",
     "groupName": "Distribution och detaljhandel för sällanköpsvaror",
-    "industryName": "Broadline Detaljhandel",
-    "subIndustryName": "Broadline Detaljhandel",
+    "industryName": "Bred detaljhandel",
+    "subIndustryName": "Bred detaljhandel",
     "subIndustryDescription": "Återförsäljare som erbjuder ett brett sortiment av sällanköpsvaror. Denna delbransch omfattar detaljister som säljer allmänna varor och lågprisvaror, varuhus och online-återförsäljare och marknadsplatser som främst säljer sällanköpsvaror."
   },
   "25504010": {
@@ -536,21 +536,21 @@
     "groupName": "Distribution och detaljhandel för sällanköpsvaror",
     "industryName": "Specialiserad butikshandel",
     "subIndustryName": "Detaljhandel med fordon",
-    "subIndustryDescription": "Ägare och operatörer av butiker som specialiserar sig på detaljhandel med fordon.  Omfattar bilhandlare, bensinstationer och återförsäljare av biltillbehör, motorcyklar och reservdelar, bilglas samt bilutrustning och reservdelar."
+    "subIndustryDescription": "Ägare och operatörer av butiker som specialiserar sig på detaljhandel med fordon. Omfattar bilhandlare, bensinstationer och återförsäljare av biltillbehör, motorcyklar och reservdelar, bilglas samt bilutrustning och reservdelar."
   },
   "25504060": {
     "sectorName": "Sällanköpsvaror",
     "groupName": "Distribution och detaljhandel för sällanköpsvaror",
     "industryName": "Specialiserad butikshandel",
     "subIndustryName": "Detaljhandel med heminredning",
-    "subIndustryDescription": "Ägare och operatörer av möbel- och heminredningsbutiker.  Omfattar möbler för bostäder, heminredning, hushållsartiklar och inredningsdesign.  Exklusive butiker för hem- och trädgårdsförbättringar, klassificerade i underbranschen för detaljhandel med hemförbättringar."
+    "subIndustryDescription": "Ägare och operatörer av möbel- och heminredningsbutiker. Omfattar möbler för bostäder, heminredning, hushållsartiklar och inredningsdesign. Exklusive butiker för hem- och trädgårdsförbättringar, klassificerade i underbranschen Detaljhandel för hemförbättringar."
   },
   "30101010": {
     "sectorName": "Dagligvaror",
     "groupName": "Distribution och detaljhandel för dagligvaror",
     "industryName": "Distribution och detaljhandel för dagligvaror",
     "subIndustryName": "Detaljhandel med läkemedel",
-    "subIndustryDescription": "Ägare och operatörer av främst drug retail-butiker och apotek."
+    "subIndustryDescription": "Ägare och operatörer av främst detaljhandelsbutiker för läkemedel och apotek."
   },
   "30101020": {
     "sectorName": "Dagligvaror",
@@ -570,8 +570,8 @@
     "sectorName": "Dagligvaror",
     "groupName": "Distribution och detaljhandel för dagligvaror",
     "industryName": "Distribution och detaljhandel för dagligvaror",
-    "subIndustryName": "Konsumentvaror Dagligvaror Detaljhandel",
-    "subIndustryDescription": "Återförsäljare som erbjuder ett brett sortiment av dagligvaror såsom livsmedel, hushållsprodukter och produkter för personlig vård. Denna delbransch omfattar hypermarkets, supercenters och andra detaljister som säljer dagligvaror, t.ex. lågprisbutiker och marknadsplatser på nätet som främst säljer dagligvaror."
+    "subIndustryName": "Detaljhandel med dagligvaror",
+    "subIndustryDescription": "Återförsäljare som erbjuder ett brett sortiment av dagligvaror såsom livsmedel, hushållsprodukter och produkter för personlig vård. Denna delbransch omfattar stormarknader, varuhus med stort sortiment och andra detaljister som säljer dagligvaror, t.ex. lågprisbutiker och marknadsplatser på nätet som främst säljer dagligvaror."
   },
   "30201010": {
     "sectorName": "Dagligvaror",
@@ -585,7 +585,7 @@
     "groupName": "Livsmedel, drycker och tobak",
     "industryName": "Drycker",
     "subIndustryName": "Destillerier och vinodlare",
-    "subIndustryDescription": "Destillatörer, vinodlare och producenter av alkoholhaltiga drycker som inte klassificeras i underbranschen bryggerier."
+    "subIndustryDescription": "Destillatörer, vinodlare och producenter av alkoholhaltiga drycker som inte klassificeras i underbranschen Bryggerier."
   },
   "30201030": {
     "sectorName": "Dagligvaror",
@@ -599,7 +599,7 @@
     "groupName": "Livsmedel, drycker och tobak",
     "industryName": "Livsmedelsprodukter",
     "subIndustryName": "Jordbruksprodukter och tjänster",
-    "subIndustryDescription": "Producenter av jordbruksprodukter. Omfattar växtodlare, ägare av plantager och företag som producerar och bearbetar livsmedel men inte förpackar och marknadsför dem. Utesluter företag som klassificeras i underbranschen för skogsprodukter och de som förpackar och marknadsför livsmedelsprodukter som klassificeras i underbranschen för förpackade livsmedel."
+    "subIndustryDescription": "Producenter av jordbruksprodukter. Omfattar växtodlare, ägare av plantager och företag som producerar och bearbetar livsmedel men inte förpackar och marknadsför dem. Utesluter företag som klassificeras i underbranschen Skogsprodukter och de som förpackar och marknadsför livsmedelsprodukter som klassificeras i underbranschen för förpackade livsmedel."
   },
   "30202030": {
     "sectorName": "Dagligvaror",
@@ -620,7 +620,7 @@
     "groupName": "Personvårdsprodukter",
     "industryName": "Hushållsprodukter",
     "subIndustryName": "Hushållsprodukter",
-    "subIndustryDescription": "Tillverkare av icke varaktiga hushållsprodukter, inklusive tvättmedel, tvål, blöjor och andra mjukpapper och hushållspapper som inte klassificeras i underbranschen för pappersprodukter."
+    "subIndustryDescription": "Tillverkare av icke varaktiga hushållsprodukter, inklusive tvättmedel, tvål, blöjor och andra mjukpapper och hushållspapper som inte klassificeras i underbranschen Pappersprodukter."
   },
   "30302010": {
     "sectorName": "Dagligvaror",
@@ -668,22 +668,22 @@
     "sectorName": "Hälsovård",
     "groupName": "Medicinteknisk utrustning och vårdtjänster",
     "industryName": "Vårdgivare och tjänster inom hälso- och sjukvård",
-    "subIndustryName": "Managed Health Care",
-    "subIndustryDescription": "Ägare och operatörer av Health Maintenance Organizations (HMOs) och andra managed plans."
+    "subIndustryName": "Organiserad hälso- och sjukvård",
+    "subIndustryDescription": "Ägare och operatörer av organisationer för organiserad hälso- och sjukvård (HMO) och andra vårdplaner."
   },
   "35103010": {
     "sectorName": "Hälsovård",
     "groupName": "Medicinteknisk utrustning och vårdtjänster",
     "industryName": "Hälsovårdsteknik",
     "subIndustryName": "Hälsovårdsteknik",
-    "subIndustryDescription": "Företag som tillhandahåller informationsteknologitjänster främst till vårdgivare.  Inkluderar företag som tillhandahåller programvaror för applikationer, system och/eller databehandling, internetbaserade verktyg och IT-konsulttjänster till läkare, sjukhus eller företag som huvudsakligen är verksamma inom hälso- och sjukvårdssektorn"
+    "subIndustryDescription": "Företag som tillhandahåller informationsteknologitjänster främst till vårdgivare. Inkluderar företag som tillhandahåller programvaror för applikationer, system och/eller databehandling, internetbaserade verktyg och IT-konsulttjänster till läkare, sjukhus eller företag som huvudsakligen är verksamma inom hälso- och sjukvårdssektorn"
   },
   "35201010": {
     "sectorName": "Hälsovård",
     "groupName": "Läkemedel, bioteknik och life sciences",
     "industryName": "Bioteknik",
     "subIndustryName": "Bioteknik",
-    "subIndustryDescription": "Företag som främst ägnar sig åt forskning, utveckling, tillverkning och/eller marknadsföring av produkter baserade på genetisk analys och genteknik.  Inkluderar företag som specialiserar sig på proteinbaserade läkemedel för behandling av sjukdomar hos människor. Utesluter företag som tillverkar produkter med hjälp av bioteknik men utan tillämpning inom hälso- och sjukvården."
+    "subIndustryDescription": "Företag som främst ägnar sig åt forskning, utveckling, tillverkning och/eller marknadsföring av produkter baserade på genetisk analys och genteknik. Inkluderar företag som specialiserar sig på proteinbaserade läkemedel för behandling av sjukdomar hos människor. Utesluter företag som tillverkar produkter med hjälp av bioteknik men utan tillämpning inom hälso- och sjukvården."
   },
   "35202010": {
     "sectorName": "Hälsovård",
@@ -697,21 +697,21 @@
     "groupName": "Läkemedel, bioteknik och life sciences",
     "industryName": "Verktyg och tjänster för biovetenskap",
     "subIndustryName": "Verktyg och tjänster för biovetenskap",
-    "subIndustryDescription": "Företag som möjliggör läkemedelsupptäckt, utveckling och produktion genom att tillhandahålla analytiska verktyg, instrument, förbrukningsvaror och tillbehör, tjänster för kliniska prövningar och kontraktsforskningstjänster.  Inkluderar företag som främst betjänar läkemedels- och bioteknikindustrin."
+    "subIndustryDescription": "Företag som möjliggör läkemedelsupptäckt, utveckling och produktion genom att tillhandahålla analytiska verktyg, instrument, förbrukningsvaror och tillbehör, tjänster för kliniska prövningar och kontraktsforskningstjänster. Inkluderar företag som främst betjänar läkemedels- och bioteknikindustrin."
   },
   "40101010": {
     "sectorName": "Finans",
     "groupName": "Banker",
     "industryName": "Banker",
     "subIndustryName": "Diversifierade banker",
-    "subIndustryDescription": "Stora, geografiskt diversifierade banker med nationell täckning vars intäkter främst härrör från konventionell bankverksamhet, som har betydande affärsverksamhet inom retail banking och utlåning till små och medelstora företag och som tillhandahåller ett brett utbud av finansiella tjänster.  Exkluderar banker klassificerade i underbranscherna Regionala banker och Finansiering av kommersiella och privata bostadslån. Exkluderar även investmentbanker klassificerade i underbranschen Investmentbanking och mäkleri."
+    "subIndustryDescription": "Stora, geografiskt diversifierade banker med nationell täckning vars intäkter främst härrör från konventionell bankverksamhet, som har betydande affärsverksamhet inom retail banking och utlåning till små och medelstora företag och som tillhandahåller ett brett utbud av finansiella tjänster. Exkluderar banker klassificerade i underbranscherna Regionala banker och Finansiering av kommersiella och privata bostadslån. Exkluderar även investmentbanker klassificerade i underbranschen Investmentbankverksamhet och mäkleri."
   },
   "40101015": {
     "sectorName": "Finans",
     "groupName": "Banker",
     "industryName": "Banker",
     "subIndustryName": "Regionala banker",
-    "subIndustryDescription": "Affärsbanker, sparbanker och thrifts vars verksamhet huvudsakligen består av konventionell bankverksamhet såsom bankverksamhet för privatpersoner och mindre företag, utlåning till företag och olika typer av hypotekslån till bostäder och kommersiella fastigheter som huvudsakligen finansieras genom inlåning. Regionbanker tenderar att bedriva verksamhet i begränsade geografiska regioner. Exkluderar företag som klassificeras i underbranscherna Diversifierade banker och Finansiering av kommersiella och privata bostadslån. Utesluter även investmentbanker som klassificeras i underbranschen Investmentbanking och mäkleri."
+    "subIndustryDescription": "Affärsbanker, sparbanker och thrifts vars verksamhet huvudsakligen består av konventionell bankverksamhet såsom bankverksamhet för privatpersoner och mindre företag, utlåning till företag och olika typer av hypotekslån till bostäder och kommersiella fastigheter som huvudsakligen finansieras genom inlåning. Regionbanker tenderar att bedriva verksamhet i begränsade geografiska regioner. Exkluderar företag som klassificeras i underbranscherna Diversifierade banker och Finansiering av kommersiella och privata bostadslån. Utesluter även investmentbanker som klassificeras i underbranschen Investmentbankverksamhet och mäkleri."
   },
   "40201020": {
     "sectorName": "Finans",
@@ -725,7 +725,7 @@
     "groupName": "Finansiella tjänster",
     "industryName": "Finansiella tjänster",
     "subIndustryName": "Multisektoriella innehav",
-    "subIndustryDescription": "Ett företag med betydande diversifierade innehav i tre eller flera sektorer, där ingen av dessa bidrar med en majoritet av vinsten och/eller försäljningen. Innehavet är till övervägande del av icke-kontrollerande karaktär.  Inkluderar diversifierade finansbolag där ägarandelarna är av kontrollerande karaktär. Utesluter andra diversifierade företag som klassificeras i underbranschen Industriella konglomerat."
+    "subIndustryDescription": "Ett företag med betydande diversifierade innehav i tre eller flera sektorer där ingen av dessa bidrar med en majoritet av vinsten och/eller försäljningen. Innehavet är till övervägande del av icke-kontrollerande karaktär. Inkluderar diversifierade finansbolag där ägarandelarna är av kontrollerande karaktär. Utesluter andra diversifierade företag som klassificeras i underbranschen Industriella konglomerat."
   },
   "40201040": {
     "sectorName": "Finans",
@@ -753,20 +753,20 @@
     "groupName": "Finansiella tjänster",
     "industryName": "Konsumentfinansiering",
     "subIndustryName": "Konsumentfinansiering",
-    "subIndustryDescription": "Leverantörer av konsumentfinansieringstjänster, inklusive personliga krediter, kreditkort, leasingfinansiering, reserelaterade penningtjänster och pantbanker.  Omfattar inte hypotekslångivare som klassificeras i underbranschen Finansiering av kommersiella och privata bostadslån."
+    "subIndustryDescription": "Leverantörer av konsumentfinansieringstjänster, inklusive personliga krediter, kreditkort, leasingfinansiering, reserelaterade penningtjänster och pantbanker. Omfattar inte hypotekslångivare som klassificeras i underbranschen Finansiering av kommersiella och privata bostadslån."
   },
   "40203010": {
     "sectorName": "Finans",
     "groupName": "Finansiella tjänster",
     "industryName": "Kapitalmarknader",
     "subIndustryName": "Kapitalförvaltning och depåbanker",
-    "subIndustryDescription": "Finansiella institutioner som främst ägnar sig åt investeringsförvaltning och/eller relaterade depåförvarings- och värdepapperstjänster. Inkluderar företag som driver värdepappersfonder, slutna fonder och investeringsfonder.  Exkluderar banker och andra finansiella institutioner som främst ägnar sig åt kommersiell utlåning, investment banking, mäkleri och annan specialiserad finansiell verksamhet."
+    "subIndustryDescription": "Finansiella institutioner som främst ägnar sig åt investeringsförvaltning och/eller relaterade depåförvarings- och värdepapperstjänster. Inkluderar företag som driver värdepappersfonder, slutna fonder och investeringsfonder. Exkluderar banker och andra finansiella institutioner som främst ägnar sig åt kommersiell utlåning, investment banking, mäkleri och annan specialiserad finansiell verksamhet."
   },
   "40203020": {
     "sectorName": "Finans",
     "groupName": "Finansiella tjänster",
     "industryName": "Kapitalmarknader",
-    "subIndustryName": "Investmentbanking och mäkleri",
+    "subIndustryName": "Investmentbankverksamhet och mäkleri",
     "subIndustryDescription": "Finansiella institutioner som främst ägnar sig åt investment banking och mäklartjänster, inklusive aktie- och skuldgarantier, fusioner och förvärv, värdepapperslån och rådgivning. Exkluderar banker och andra finansinstitut som främst ägnar sig åt kommersiell utlåning, kapitalförvaltning och specialiserad finansiell verksamhet."
   },
   "40203030": {
@@ -774,7 +774,7 @@
     "groupName": "Finansiella tjänster",
     "industryName": "Kapitalmarknader",
     "subIndustryName": "Diversifierade kapitalmarknader",
-    "subIndustryDescription": "Finansiella institutioner som främst ägnar sig åt diversifierad kapitalmarknadsverksamhet, inklusive en betydande närvaro inom minst två av följande områden: utlåning till stora företag, investment banking, mäkleri och kapitalförvaltning. Utesluter mindre diversifierade företag som klassificeras i underbranscherna Asset Management och Custody Banks eller Investmentbanking och mäkleri.  Utesluter även företag som klassificeras i branschgrupperna Banker eller Försäkringar eller underbranschen Konsumentfinansiering."
+    "subIndustryDescription": "Finansiella institutioner som främst ägnar sig åt diversifierad kapitalmarknadsverksamhet, inklusive en betydande närvaro inom minst två av följande områden: utlåning till stora företag, investmentbankverksamhet, mäkleri och kapitalförvaltning. Utesluter mindre diversifierade företag som klassificeras i underbranscherna Kapitalförvaltning och depåbanker eller Investmentbankverksamhet och mäkleri. Utesluter även företag som klassificeras i branschgrupperna Banker och Försäkringar eller underbranschen Konsumentfinansiering."
   },
   "40203040": {
     "sectorName": "Finans",
@@ -786,9 +786,9 @@
   "40204010": {
     "sectorName": "Finans",
     "groupName": "Finansiella tjänster",
-    "industryName": "Hypotekslån Fastighetsinvesteringar\nTrusts (REITs)",
-    "subIndustryName": "REITs för hypotekslån",
-    "subIndustryDescription": "Företag eller stiftelser som tillhandahåller, genererar, köper och/eller värdepapperiserar bostadslån och/eller kommersiella hypotekslån.  Inkluderar truster som investerar i värdepapper med säkerhet i hypotekslån och andra tillgångar relaterade till hypotekslån."
+    "industryName": "Hypoteks-REITs",
+    "subIndustryName": "Hypoteks-REITs",
+    "subIndustryDescription": "Företag eller stiftelser som tillhandahåller, genererar, köper och/eller värdepapperiserar bostadslån och/eller kommersiella hypotekslån. Inkluderar truster som investerar i värdepapper med säkerhet i hypotekslån och andra tillgångar relaterade till hypotekslån."
   },
   "40301010": {
     "sectorName": "Finans",
@@ -802,13 +802,13 @@
     "groupName": "Försäkringar",
     "industryName": "Försäkringar",
     "subIndustryName": "Liv- och sjukförsäkring",
-    "subIndustryDescription": "Företag som främst tillhandahåller liv-, invaliditets-, skade- eller kompletterande sjukförsäkring. Exkluderar managed care-bolag som klassificeras i underbranschen Managed Health Care."
+    "subIndustryDescription": "Företag som främst tillhandahåller liv-, invaliditets-, skade- eller kompletterande sjukförsäkring. Exkluderar företag inom organiserad hälso- och sjukvård som klassificeras i underbranschen Organiserad hälso- och sjukvård."
   },
   "40301030": {
     "sectorName": "Finans",
     "groupName": "Försäkringar",
     "industryName": "Försäkringar",
-    "subIndustryName": "Multi-line försäkring",
+    "subIndustryName": "Diversifierade försäkringar",
     "subIndustryDescription": "Försäkringsbolag med diversifierade intressen inom liv-, sjuk-, sak- och olycksfallsförsäkring."
   },
   "40301040": {
@@ -830,14 +830,14 @@
     "groupName": "Programvara och tjänster",
     "industryName": "IT-tjänster",
     "subIndustryName": "IT-konsulttjänster och andra tjänster",
-    "subIndustryDescription": "Leverantörer av tjänster inom informationsteknik och systemintegration som inte klassificeras i underbranschen Databehandling och outsourcade tjänster.  Omfattar konsulttjänster inom informationsteknik och informationshantering."
+    "subIndustryDescription": "Leverantörer av tjänster inom informationsteknik och systemintegration som inte klassificeras i underbranschen Databehandling och outsourcade tjänster. Omfattar konsulttjänster inom informationsteknik och informationshantering."
   },
   "45102030": {
     "sectorName": "IT",
     "groupName": "Programvara och tjänster",
     "industryName": "IT-tjänster",
     "subIndustryName": "Internettjänster och infrastruktur",
-    "subIndustryDescription": "Företag som tillhandahåller tjänster och infrastruktur för internetindustrin, inklusive datacenter och molnbaserade nätverks- och lagringsinfrastrukturer. Inkluderar även företag som tillhandahåller webbhotellstjänster. Exkluderar företag som klassificeras i Software Industry."
+    "subIndustryDescription": "Företag som tillhandahåller tjänster och infrastruktur för internetindustrin, inklusive datacenter och molnbaserade nätverks- och lagringsinfrastrukturer. Inkluderar även företag som tillhandahåller webbhotellstjänster. Exkluderar företag som klassificeras branschen Programvara."
   },
   "45103010": {
     "sectorName": "IT",
@@ -858,13 +858,13 @@
     "groupName": "Teknisk hårdvara och utrustning",
     "industryName": "Kommunikationsutrustning",
     "subIndustryName": "Kommunikationsutrustning",
-    "subIndustryDescription": "Tillverkare av kommunikationsutrustning och -produkter, inklusive LAN, WAN, routrar, telefoner, växlar och centraler. Omfattar inte tillverkare av mobiltelefoner som klassificeras i underbranschen för teknisk hårdvara, lagring och kringutrustning."
+    "subIndustryDescription": "Tillverkare av kommunikationsutrustning och -produkter, inklusive LAN, WAN, routrar, telefoner, växlar och centraler. Omfattar inte tillverkare av mobiltelefoner som klassificeras i underbranschen Teknisk hårdvara, lagring och kringutrustning."
   },
   "45202030": {
     "sectorName": "IT",
     "groupName": "Teknisk hårdvara och utrustning",
-    "industryName": "Teknik Hårdvara, lagring och kringutrustning",
-    "subIndustryName": "Teknik Hårdvara, lagring och kringutrustning",
+    "industryName": "Teknisk hårdvara, lagring och kringutrustning",
+    "subIndustryName": "Teknisk hårdvara, lagring och kringutrustning",
     "subIndustryDescription": "Tillverkare av mobiltelefoner, persondatorer, servrar, elektroniska datorkomponenter och kringutrustning. Inkluderar datalagringskomponenter, moderkort, ljud- och bildkort, bildskärmar, tangentbord, skrivare och annan kringutrustning. Omfattar inte halvledare som klassificeras i underbranschen Halvledare."
   },
   "45203010": {
@@ -886,7 +886,7 @@
     "groupName": "Teknisk hårdvara och utrustning",
     "industryName": "Elektronisk utrustning, instrument och komponenter",
     "subIndustryName": "Tjänster för elektronisk tillverkning",
-    "subIndustryDescription": "Tillverkare av elektronisk utrustning, främst för OEM-marknaden (Original Equipment Manufacturers)."
+    "subIndustryDescription": "Tillverkare av elektronisk utrustning, främst för OEM-marknaden (tillverkare av originalutrustning)."
   },
   "45203030": {
     "sectorName": "IT",
@@ -913,7 +913,7 @@
     "sectorName": "Kommunikation",
     "groupName": "Telekommunikationstjänster",
     "industryName": "Diversifierade telekommunikationstjänster",
-    "subIndustryName": "Alternativa transportörer",
+    "subIndustryName": "Alternativa teleoperatörer",
     "subIndustryDescription": "Leverantör av kommunikations- och dataöverföringstjänster med hög densitet, främst genom ett fiberoptiskt kabelnätverk med hög bandbredd."
   },
   "50101020": {
@@ -991,13 +991,13 @@
     "groupName": "Kraftförsörjning",
     "industryName": "Gasförsörjning",
     "subIndustryName": "Gasförsörjning",
-    "subIndustryDescription": "Företag vars huvuduppgift är att distribuera och överföra naturgas och tillverkad gas. Exkluderar företag som huvudsakligen är involverade i prospektering eller produktion av gas, klassificerade i underbranschen Oil och Gas Exploration och Production. Omfattar inte heller företag som sysslar med lagring och/eller transport av olja, gas och/eller raffinerade produkter, klassificerade i underbranschen Oil och Gas Storage och Transportation Sub-Industry."
+    "subIndustryDescription": "Företag vars huvuduppgift är att distribuera och överföra naturgas och tillverkad gas. Exkluderar företag som huvudsakligen är involverade i prospektering eller produktion av gas, klassificerade i underbranschen Prospektering och produktion av olja och gas. Omfattar inte heller företag som sysslar med lagring och/eller transport av olja, gas och/eller raffinerade produkter, klassificerade i underbranschen Lagring och transport av olja och gas."
   },
   "55103010": {
     "sectorName": "Kraftförsörjning",
     "groupName": "Kraftförsörjning",
-    "industryName": "Flera användningsområden",
-    "subIndustryName": "Flera användningsområden",
+    "industryName": "Diversifierade allmännyttiga tjänster",
+    "subIndustryName": "Diversifierade allmännyttiga tjänster",
     "subIndustryDescription": "Allmännyttiga företag med betydande diversifierad verksamhet utöver kärnverksamheten inom el, gas och/eller vatten."
   },
   "55104010": {
@@ -1088,7 +1088,7 @@
     "sectorName": "Fastigheter",
     "groupName": "Equity Real Estate Investment Trusts (REITs)",
     "industryName": "Specialiserade REITs",
-    "subIndustryName": "REITs för självförvarare",
+    "subIndustryName": "REITs för förrådsfastigheter",
     "subIndustryDescription": "Företag eller stiftelser som ägnar sig åt förvärv, utveckling, ägande, uthyrning, förvaltning och drift av lagerfastigheter."
   },
   "60108030": {
@@ -1102,7 +1102,7 @@
     "sectorName": "Fastigheter",
     "groupName": "Equity Real Estate Investment Trusts (REITs)",
     "industryName": "Specialiserade REITs",
-    "subIndustryName": "REITs för skog",
+    "subIndustryName": "REITs för skogsfastigheter",
     "subIndustryDescription": "Företag eller stiftelser som ägnar sig åt förvärv, utveckling, ägande, uthyrning, förvaltning och drift av skogsmark och skogsrelaterade fastigheter."
   },
   "60108050": {

--- a/output/sv/industry-gics.json
+++ b/output/sv/industry-gics.json
@@ -17,7 +17,7 @@
     "sectorName": "Energi",
     "groupName": "Energi",
     "industryName": "Olja, gas och förbrukningsbränslen",
-    "subIndustryName": "Integrerad olja & gas",
+    "subIndustryName": "Integrerad olja och gas",
     "subIndustryDescription": "Integrerade oljebolag som bedriver prospektering och produktion av olja och gas samt minst en annan betydande verksamhet inom antingen raffinering, marknadsföring och transport eller kemikalier."
   },
   "10102020": {
@@ -31,8 +31,8 @@
     "sectorName": "Energi",
     "groupName": "Energi",
     "industryName": "Olja, gas och förbrukningsbränslen",
-    "subIndustryName": "Raffinering & marknadsföring av olja & gas",
-    "subIndustryDescription": "Företag som sysslar med raffinering och marknadsföring av olja, gas och/eller raffinerade produkter som inte klassificeras i underbranscherna Integrated Oil & Gas eller Independent Power Producers & Energy Traders."
+    "subIndustryName": "Raffinering och marknadsföring av olja och gas",
+    "subIndustryDescription": "Företag som sysslar med raffinering och marknadsföring av olja, gas och/eller raffinerade produkter som inte klassificeras i underbranscherna Integrated Oil och Gas eller Independent Power Producers och Energy Traders."
   },
   "10102040": {
     "sectorName": "Energi",
@@ -45,15 +45,15 @@
     "sectorName": "Energi",
     "groupName": "Energi",
     "industryName": "Olja, gas och förbrukningsbränslen",
-    "subIndustryName": "Kol & förbrukningsbränslen",
-    "subIndustryDescription": "Företag som främst är involverade i produktion och brytning av kol, relaterade produkter och andra förbrukningsbränslen relaterade till energiproduktion.  Exkluderar företag som främst producerar gaser klassificerade i underindustrin Industrial Gases och företag som främst utvinner metallurgiskt kol (kokskol) som används för stålproduktion."
+    "subIndustryName": "Kol och förbrukningsbränslen",
+    "subIndustryDescription": "Företag som främst är involverade i produktion och brytning av kol, relaterade produkter och andra förbrukningsbränslen relaterade till energiproduktion.  Exkluderar företag som främst producerar gaser klassificerade i underbranschen Industrial Gases och företag som främst utvinner metallurgiskt kol (kokskol) som används för stålproduktion."
   },
   "15101010": {
     "sectorName": "Material",
     "groupName": "Material",
     "industryName": "Kemikalier",
     "subIndustryName": "Råvarukemikalier",
-    "subIndustryDescription": "Företag som främst producerar industrikemikalier och baskemikalier. Inklusive men inte begränsat till plast, syntetiska fibrer, filmer, råvarubaserade färger och pigment, sprängämnen och petrokemikalier. Utesluter kemiföretag som klassificeras i underindustrierna Diversified Chemicals, Fertilizers & Agricultural Chemicals, Industrial Gases eller Specialty Chemicals."
+    "subIndustryDescription": "Företag som främst producerar industrikemikalier och baskemikalier. Inklusive men inte begränsat till plast, syntetiska fibrer, filmer, råvarubaserade färger och pigment, sprängämnen och petrokemikalier. Utesluter kemiföretag som klassificeras i underbranscherna diversifierade kemikalier, gödselmedel och jordbrukskemikalier, industrigaser eller specialkemikalier."
   },
   "15101020": {
     "sectorName": "Material",
@@ -66,14 +66,14 @@
     "sectorName": "Material",
     "groupName": "Material",
     "industryName": "Kemikalier",
-    "subIndustryName": "Gödselmedel & jordbrukskemikalier",
+    "subIndustryName": "Gödselmedel och jordbrukskemikalier",
     "subIndustryDescription": "Tillverkare av gödningsmedel, bekämpningsmedel, kaliumklorid eller andra jordbruksrelaterade kemikalier som inte klassificeras någon annanstans."
   },
   "15101040": {
     "sectorName": "Material",
     "groupName": "Material",
     "industryName": "Kemikalier",
-    "subIndustryName": "Industriella gaser",
+    "subIndustryName": "Industrigaser",
     "subIndustryDescription": "Tillverkare av industrigaser."
   },
   "15101050": {
@@ -88,84 +88,84 @@
     "groupName": "Material",
     "industryName": "Konstruktionsmaterial",
     "subIndustryName": "Konstruktionsmaterial",
-    "subIndustryDescription": "Tillverkare av byggmaterial, inklusive sand, lera, gips, kalk, ballast, cement, betong och tegelstenar. Andra färdiga eller halvfärdiga byggnadsmaterial klassificeras i underindustrin för byggnadsprodukter."
+    "subIndustryDescription": "Tillverkare av byggmaterial, inklusive sand, lera, gips, kalk, ballast, cement, betong och tegelstenar. Andra färdiga eller halvfärdiga byggnadsmaterial klassificeras i underbranschen för byggnadsprodukter."
   },
   "15103010": {
     "sectorName": "Material",
     "groupName": "Material",
-    "industryName": "Behållare & förpackningar",
+    "industryName": "Behållare och förpackningar",
     "subIndustryName": "Metall-, glas- och plastbehållare",
     "subIndustryDescription": "Tillverkare av behållare av metall, glas eller plast. Inkluderar korkar och kapsyler."
   },
   "15103020": {
     "sectorName": "Material",
     "groupName": "Material",
-    "industryName": "Behållare & förpackningar",
+    "industryName": "Behållare och förpackningar",
     "subIndustryName": "Produkter och material för pappers- och plastförpackningar",
     "subIndustryDescription": "Tillverkare av behållare och förpackningar av papper och kartong."
   },
   "15104010": {
     "sectorName": "Material",
     "groupName": "Material",
-    "industryName": "Metaller & gruvor",
+    "industryName": "Metaller och gruvor",
     "subIndustryName": "Aluminium",
-    "subIndustryDescription": "Producenter av aluminium och relaterade produkter, inklusive företag som bryter eller bearbetar bauxit och företag som återvinner aluminium för att producera färdiga eller halvfärdiga produkter. Exkluderar företag som främst tillverkar byggnadsmaterial i aluminium som klassificeras i underindustrin Building Products Sub-Industry."
+    "subIndustryDescription": "Producenter av aluminium och relaterade produkter, inklusive företag som bryter eller bearbetar bauxit och företag som återvinner aluminium för att producera färdiga eller halvfärdiga produkter. Exkluderar företag som främst tillverkar byggnadsmaterial i aluminium som klassificeras i underbranschen byggprodukter."
   },
   "15104020": {
     "sectorName": "Material",
     "groupName": "Material",
-    "industryName": "Metaller & gruvor",
+    "industryName": "Metaller och gruvor",
     "subIndustryName": "Diversifierad metall- och gruvindustri",
-    "subIndustryDescription": "Företag som ägnar sig åt diversifierad produktion eller utvinning av metaller och mineraler som inte klassificeras någon annanstans. Inklusive, men inte begränsat till, brytning av icke-järnmetaller (utom bauxit), salt- och boratbrytning, brytning av fosfatsten och diversifierad gruvverksamhet. Omfattar inte järnmalmsbrytning, som klassificeras i underindustrin stål, bauxitbrytning, som klassificeras i underindustrin aluminium, och kolbrytning, som klassificeras i underindustrierna stål eller kol och förbrukningsbränslen."
+    "subIndustryDescription": "Företag som ägnar sig åt diversifierad produktion eller utvinning av metaller och mineraler som inte klassificeras någon annanstans. Inklusive, men inte begränsat till, brytning av icke-järnmetaller (utom bauxit), salt- och boratbrytning, brytning av fosfatsten och diversifierad gruvverksamhet. Omfattar inte järnmalmsbrytning, som klassificeras i underbranschen stål, bauxitbrytning, som klassificeras i underbranschen aluminium, och kolbrytning, som klassificeras i underbranschen stål eller kol och förbrukningsbränslen."
   },
   "15104025": {
     "sectorName": "Material",
     "groupName": "Material",
-    "industryName": "Metaller & gruvor",
+    "industryName": "Metaller och gruvor",
     "subIndustryName": "Koppar",
     "subIndustryDescription": "Företag som främst är involverade i brytning av kopparmalm."
   },
   "15104030": {
     "sectorName": "Material",
     "groupName": "Material",
-    "industryName": "Metaller & gruvor",
+    "industryName": "Metaller och gruvor",
     "subIndustryName": "Guld",
     "subIndustryDescription": "Producenter av guld och relaterade produkter, inklusive företag som utvinner eller bearbetar guld och de sydafrikanska finanshus som främst investerar i, men inte driver, guldgruvor."
   },
   "15104040": {
     "sectorName": "Material",
     "groupName": "Material",
-    "industryName": "Metaller & gruvor",
-    "subIndustryName": "Ädelmetaller & mineraler",
-    "subIndustryDescription": "Företag som utvinner ädelmetaller och mineraler som inte klassificeras i Gold Sub-Industry. Omfattar företag som främst utvinner platina."
+    "industryName": "Metaller och gruvor",
+    "subIndustryName": "Ädelmetaller och mineraler",
+    "subIndustryDescription": "Företag som utvinner ädelmetaller och mineraler som inte klassificeras i underbranschen guld. Omfattar företag som främst utvinner platina."
   },
   "15104045": {
     "sectorName": "Material",
     "groupName": "Material",
-    "industryName": "Metaller & gruvor",
+    "industryName": "Metaller och gruvor",
     "subIndustryName": "Silver",
     "subIndustryDescription": "Företag som främst utvinner silver. Utesluter företag som klassificeras i underbranscherna Guld eller Ädelmetaller och mineraler."
   },
   "15104050": {
     "sectorName": "Material",
     "groupName": "Material",
-    "industryName": "Metaller & gruvor",
+    "industryName": "Metaller och gruvor",
     "subIndustryName": "Stål",
     "subIndustryDescription": "Producenter av järn och stål och relaterade produkter, inklusive metallurgisk kolbrytning (kokskol) som används för stålproduktion."
   },
   "15105010": {
     "sectorName": "Material",
     "groupName": "Material",
-    "industryName": "Papper & skogsindustriprodukter",
+    "industryName": "Papper och skogsindustriprodukter",
     "subIndustryName": "Skogsprodukter",
     "subIndustryDescription": "Tillverkare av timmer och relaterade träprodukter. Inkluderar timmer för byggnadsindustrin."
   },
   "15105020": {
     "sectorName": "Material",
     "groupName": "Material",
-    "industryName": "Papper & skogsindustriprodukter",
+    "industryName": "Papper och skogsindustriprodukter",
     "subIndustryName": "Pappersprodukter",
-    "subIndustryDescription": "Tillverkare av alla papperskvaliteter. Utesluter företag som specialiserar sig på pappersförpackningar som klassificeras i underindustrin för pappersförpackningar."
+    "subIndustryDescription": "Tillverkare av alla papperskvaliteter. Utesluter företag som specialiserar sig på pappersförpackningar som klassificeras i underbranschen för pappersförpackningar."
   },
   "20101010": {
     "sectorName": "Industriprodukter",
@@ -179,28 +179,28 @@
     "groupName": "Kapitalvaror",
     "industryName": "Byggprodukter",
     "subIndustryName": "Byggprodukter",
-    "subIndustryDescription": "Tillverkare av byggkomponenter och produkter och utrustning för hemförbättring. Omfattar inte timmer och plywood som klassificeras under skogsprodukter samt cement och andra material som klassificeras under underindustrin för byggmaterial."
+    "subIndustryDescription": "Tillverkare av byggkomponenter och produkter och utrustning för renovering. Omfattar inte timmer och plywood som klassificeras under skogsprodukter samt cement och andra material som klassificeras under underbranschen för byggmaterial."
   },
   "20103010": {
     "sectorName": "Industriprodukter",
     "groupName": "Kapitalvaror",
     "industryName": "Bygg- och anläggningsverksamhet",
     "subIndustryName": "Bygg- och anläggningsverksamhet",
-    "subIndustryDescription": "Företag som huvudsakligen är verksamma inom byggande av kommersiella lokaler. Inkluderar anläggningsföretag och storskaliga entreprenörer. Exkluderar företag som klassificeras i underindustrin för husbyggnad."
+    "subIndustryDescription": "Företag som huvudsakligen är verksamma inom byggande av kommersiella lokaler. Inkluderar anläggningsföretag och storskaliga entreprenörer. Exkluderar företag som klassificeras i underbranschen för husbyggnad."
   },
   "20104010": {
     "sectorName": "Industriprodukter",
     "groupName": "Kapitalvaror",
     "industryName": "Elektrisk utrustning",
     "subIndustryName": "Elektriska komponenter och utrustning",
-    "subIndustryDescription": "Företag som producerar elektriska kablar och ledningar, elektriska komponenter eller utrustning som inte klassificeras i underindustrin för tung elektrisk utrustning."
+    "subIndustryDescription": "Företag som producerar elektriska kablar och ledningar, elektriska komponenter eller utrustning som inte klassificeras i underbranschen för tung elektrisk utrustning."
   },
   "20104020": {
     "sectorName": "Industriprodukter",
     "groupName": "Kapitalvaror",
     "industryName": "Elektrisk utrustning",
     "subIndustryName": "Tung elektrisk utrustning",
-    "subIndustryDescription": "Tillverkare av kraftgenererande utrustning och annan tung elektrisk utrustning, inklusive kraftturbiner, tunga elektriska maskiner avsedda för fast användning och stora elektriska system. Omfattar inte kablar och ledningar, som klassificeras i underindustrin för elektriska komponenter och utrustning."
+    "subIndustryDescription": "Tillverkare av kraftgenererande utrustning och annan tung elektrisk utrustning, inklusive kraftturbiner, tunga elektriska maskiner avsedda för fast användning och stora elektriska system. Omfattar inte kablar och ledningar, som klassificeras i underbranschen för elektriska komponenter och utrustning."
   },
   "20105010": {
     "sectorName": "Industriprodukter",
@@ -227,14 +227,14 @@
     "sectorName": "Industriprodukter",
     "groupName": "Kapitalvaror",
     "industryName": "Maskiner",
-    "subIndustryName": "Industriella maskiner & förnödenheter & komponenter",
+    "subIndustryName": "Industrimaskiner samt tillbehör och komponenter",
     "subIndustryDescription": "Tillverkare av industrimaskiner och industrikomponenter. Omfattar företag som tillverkar pressar, verktygsmaskiner, kompressorer, utrustning för föroreningskontroll, hissar, rulltrappor, isolatorer, pumpar, rullager och andra metallprodukter."
   },
   "20107010": {
     "sectorName": "Industriprodukter",
     "groupName": "Kapitalvaror",
-    "industryName": "Handelsföretag & distributörer",
-    "subIndustryName": "Handelsföretag & distributörer",
+    "industryName": "Handelsföretag och distributörer",
+    "subIndustryName": "Handelsföretag och distributörer",
     "subIndustryDescription": "Handelsföretag och andra distributörer av industriell utrustning och produkter."
   },
   "20201010": {
@@ -249,13 +249,13 @@
     "groupName": "Kommersiella och professionella tjänster",
     "industryName": "Kommersiella tjänster och förnödenheter",
     "subIndustryName": "Miljö- och fastighetstjänster",
-    "subIndustryDescription": "Företag som tillhandahåller tjänster inom miljö- och anläggningsunderhåll. Omfattar tjänster för avfallshantering, fastighetsförvaltning och föroreningskontroll.  Exklusive storskaliga vattenreningssystem som klassificeras i undergruppen Water Utilities Sub-Industry."
+    "subIndustryDescription": "Företag som tillhandahåller tjänster inom miljö- och anläggningsunderhåll. Omfattar tjänster för avfallshantering, fastighetsförvaltning och föroreningskontroll.  Exklusive storskaliga vattenreningssystem som klassificeras i underbranschen vattenförsörjning."
   },
   "20201060": {
     "sectorName": "Industriprodukter",
     "groupName": "Kommersiella och professionella tjänster",
     "industryName": "Kommersiella tjänster och förnödenheter",
-    "subIndustryName": "Kontorstjänster & kontorsmaterial",
+    "subIndustryName": "Kontorstjänster och kontorsmaterial",
     "subIndustryDescription": "Leverantörer av kontorstjänster och tillverkare av kontorsmaterial och kontorsutrustning som inte klassificeras annorstädes."
   },
   "20201070": {
@@ -270,13 +270,13 @@
     "groupName": "Kommersiella och professionella tjänster",
     "industryName": "Kommersiella tjänster och förnödenheter",
     "subIndustryName": "Säkerhets- och larmtjänster",
-    "subIndustryDescription": "Företag som tillhandahåller säkerhets- och skyddstjänster till företag och myndigheter. Omfattar företag som tillhandahåller tjänster såsom kriminalvårdsanstalter, säkerhets- och larmtjänster, värdetransporter och bevakning.  Exkluderar företag som tillhandahåller säkerhetsprogramvara som klassificeras under underbranschen Systems Software och hemsäkerhetstjänster som klassificeras under underbranschen Specialiserade konsumenttjänster. Omfattar inte heller företag som tillverkar utrustning för säkerhetssystem klassificerade under underbranschen Electronic Equipment & Instruments."
+    "subIndustryDescription": "Företag som tillhandahåller säkerhets- och skyddstjänster till företag och myndigheter. Omfattar företag som tillhandahåller tjänster såsom kriminalvårdsanstalter, säkerhets- och larmtjänster, värdetransporter och bevakning.  Exkluderar företag som tillhandahåller säkerhetsprogramvara som klassificeras under underbranschen Programvara för system och hemsäkerhetstjänster som klassificeras under underbranschen Specialiserade konsumenttjänster. Omfattar inte heller företag som tillverkar utrustning för säkerhetssystem klassificerade under underbranschen Electronic Equipment och Instruments."
   },
   "20202010": {
     "sectorName": "Industriprodukter",
     "groupName": "Kommersiella och professionella tjänster",
     "industryName": "Professionella tjänster",
-    "subIndustryName": "Human Resource & Arbetsförmedling",
+    "subIndustryName": "Human Resource och Arbetsförmedling",
     "subIndustryDescription": "Företag som tillhandahåller affärsstödjande tjänster relaterade till hantering av humankapital. Denna underbransch omfattar arbetsförmedlingar, utbildning av anställda, lönebearbetning, stödtjänster för förmåner och pensioner, rekryteringstjänster för företag och arbetssökande samt jobbportaler på nätet som genererar intäkter från avgifter eller provisioner för att erbjuda rekryteringstjänster till företag eller arbetssökande."
   },
   "20202020": {
@@ -284,20 +284,20 @@
     "groupName": "Kommersiella och professionella tjänster",
     "industryName": "Professionella tjänster",
     "subIndustryName": "Forskning och konsulttjänster",
-    "subIndustryDescription": "Företag som huvudsakligen tillhandahåller forsknings- och konsulttjänster till företag och myndigheter som inte klassificeras någon annanstans.  Omfattar företag som arbetar med managementkonsulttjänster, arkitektonisk design, affärsinformation eller vetenskaplig forskning, marknadsföring samt test- och certifieringstjänster. Exkluderar företag som tillhandahåller konsulttjänster inom informationsteknologi som klassificeras i undergruppen IT-konsulttjänster och andra tjänster."
+    "subIndustryDescription": "Företag som huvudsakligen tillhandahåller forsknings- och konsulttjänster till företag och myndigheter som inte klassificeras någon annanstans.  Omfattar företag som arbetar med managementkonsulttjänster, arkitektonisk design, affärsinformation eller vetenskaplig forskning, marknadsföring samt test- och certifieringstjänster. Exkluderar företag som tillhandahåller konsulttjänster inom informationsteknologi som klassificeras i underbranschen IT-konsulttjänster och andra tjänster."
   },
   "20202030": {
     "sectorName": "Industriprodukter",
     "groupName": "Kommersiella och professionella tjänster",
     "industryName": "Professionella tjänster",
-    "subIndustryName": "Databehandling & outsourcade tjänster",
+    "subIndustryName": "Databehandling och outsourcade tjänster",
     "subIndustryDescription": "Leverantörer av tjänster för kommersiell databehandling och/eller outsourcing av affärsprocesser. Denna underbransch omfattar företag som tillhandahåller tjänster för hantering av kundupplevelser, automatisering av backoffice, hantering av callcenter och investerarkommunikation."
   },
   "20301010": {
     "sectorName": "Industriprodukter",
     "groupName": "Transport",
-    "industryName": "Flygfrakt & logistik",
-    "subIndustryName": "Flygfrakt & logistik",
+    "industryName": "Flygfrakt och logistik",
+    "subIndustryName": "Flygfrakt och logistik",
     "subIndustryDescription": "Företag som tillhandahåller flygfrakt, kurir- och logistiktjänster, inklusive paket- och postleveranser samt tullombud. Utesluter de företag som klassificeras i underbranscherna Airlines, Marine eller Trucking."
   },
   "20302010": {
@@ -312,7 +312,7 @@
     "groupName": "Transport",
     "industryName": "Sjötransporter",
     "subIndustryName": "Sjötransporter",
-    "subIndustryDescription": "Företag som tillhandahåller sjötransport av gods eller passagerare. Utesluter kryssningsfartyg som klassificeras i underbranschen Hotels, Resorts & Cruise Lines."
+    "subIndustryDescription": "Företag som tillhandahåller sjötransport av gods eller passagerare. Utesluter kryssningsfartyg som klassificeras i underbranschen Hotell, resorter och kryssningsrederier."
   },
   "20304010": {
     "sectorName": "Industriprodukter",
@@ -357,757 +357,757 @@
     "subIndustryDescription": "Ägare och operatörer av marina hamnar och relaterade tjänster."
   },
   "25101010": {
-    "sectorName": "Diskretionära konsumentvaror",
-    "groupName": "Bilar & komponenter",
+    "sectorName": "Sällanköpsvaror",
+    "groupName": "Bilar och komponenter",
     "industryName": "Fordonskomponenter",
     "subIndustryName": "Reservdelar och utrustning till fordon",
-    "subIndustryDescription": "Tillverkare av delar och tillbehör till bilar och motorcyklar. Exkluderar företag som klassificeras i underindustrin Däck & Gummi."
+    "subIndustryDescription": "Tillverkare av delar och tillbehör till bilar och motorcyklar. Exkluderar företag som klassificeras i underbranschen Däck och Gummi."
   },
   "25101020": {
-    "sectorName": "Diskretionära konsumentvaror",
-    "groupName": "Bilar & komponenter",
+    "sectorName": "Sällanköpsvaror",
+    "groupName": "Bilar och komponenter",
     "industryName": "Fordonskomponenter",
-    "subIndustryName": "Däck & gummi",
+    "subIndustryName": "Däck och gummi",
     "subIndustryDescription": "Tillverkare av däck och gummi."
   },
   "25102010": {
-    "sectorName": "Diskretionära konsumentvaror",
-    "groupName": "Bilar & komponenter",
+    "sectorName": "Sällanköpsvaror",
+    "groupName": "Bilar och komponenter",
     "industryName": "Bilar",
     "subIndustryName": "Biltillverkare",
-    "subIndustryDescription": "Företag som huvudsakligen tillverkar personbilar och lätta lastbilar. Utesluter företag som huvudsakligen tillverkar motorcyklar och trehjulingar klassificerade i underindustrin Motorcykeltillverkare och tunga lastbilar klassificerade i underindustrin Entreprenadmaskiner och tunga lastbilar."
+    "subIndustryDescription": "Företag som huvudsakligen tillverkar personbilar och lätta lastbilar. Utesluter företag som huvudsakligen tillverkar motorcyklar och trehjulingar klassificerade i underbranschen Motorcykeltillverkare och tunga lastbilar klassificerade i underbranschen Entreprenadmaskiner och tunga lastbilar."
   },
   "25102020": {
-    "sectorName": "Diskretionära konsumentvaror",
-    "groupName": "Bilar & komponenter",
+    "sectorName": "Sällanköpsvaror",
+    "groupName": "Bilar och komponenter",
     "industryName": "Bilar",
     "subIndustryName": "Tillverkare av motorcyklar",
-    "subIndustryDescription": "Företag som tillverkar motorcyklar, skotrar eller trehjulingar. Exkluderar cyklar som klassificeras i underindustrin för fritidsprodukter."
+    "subIndustryDescription": "Företag som tillverkar motorcyklar, skotrar eller trehjulingar. Exkluderar cyklar som klassificeras i underbranschen för fritidsprodukter."
   },
   "25201010": {
-    "sectorName": "Diskretionära konsumentvaror",
-    "groupName": "Sällanköpsvaror & kläder",
+    "sectorName": "Sällanköpsvaror",
+    "groupName": "Konsumentvaror och kläder",
     "industryName": "Sällanköpsvaror för hushåll",
     "subIndustryName": "Konsumentelektronik",
-    "subIndustryDescription": "Tillverkare av konsumentelektronikprodukter, inklusive TV-apparater, ljudutrustning för hemmet, spelkonsoler, digitalkameror och relaterade produkter. Exkluderar tillverkare av hemdatorer som klassificeras i undergruppen Technology Hardware, Storage & Peripherals, och elektriska hushållsapparater som klassificeras i undergruppen Household Appliances."
+    "subIndustryDescription": "Tillverkare av konsumentelektronikprodukter, inklusive TV-apparater, ljudutrustning för hemmet, spelkonsoler, digitalkameror och relaterade produkter. Exkluderar tillverkare av hemdatorer som klassificeras i underbranschen Teknik Hårdvara, lagring och kringutrustning, och elektriska hushållsapparater som klassificeras i underbranschen Hushållsapparater."
   },
   "25201020": {
-    "sectorName": "Diskretionära konsumentvaror",
-    "groupName": "Sällanköpsvaror & kläder",
+    "sectorName": "Sällanköpsvaror",
+    "groupName": "Konsumentvaror och kläder",
     "industryName": "Sällanköpsvaror för hushåll",
     "subIndustryName": "Heminredning",
     "subIndustryDescription": "Tillverkare av mjuka heminredningsartiklar eller möbler, inklusive stoppning, mattor och väggbeklädnad."
   },
   "25201030": {
-    "sectorName": "Diskretionära konsumentvaror",
-    "groupName": "Sällanköpsvaror & kläder",
+    "sectorName": "Sällanköpsvaror",
+    "groupName": "Konsumentvaror och kläder",
     "industryName": "Sällanköpsvaror för hushåll",
     "subIndustryName": "Husbyggnad",
     "subIndustryDescription": "Bostadsbyggnadsföretag. Inkluderar tillverkare av prefabricerade hus och halvfasta tillverkade hem."
   },
   "25201040": {
-    "sectorName": "Diskretionära konsumentvaror",
-    "groupName": "Sällanköpsvaror & kläder",
+    "sectorName": "Sällanköpsvaror",
+    "groupName": "Konsumentvaror och kläder",
     "industryName": "Sällanköpsvaror för hushåll",
     "subIndustryName": "Hushållsapparater",
-    "subIndustryDescription": "Tillverkare av elektriska hushållsapparater och relaterade produkter.  Inkluderar tillverkare av el- och handverktyg, inklusive verktyg för trädgårdsskötsel.  Exkluderar TV-apparater och andra ljud- och videoprodukter som klassificeras i undergruppen Consumer Electronics och persondatorer som klassificeras i undergruppen Technology Hardware, Storage & Peripherals."
+    "subIndustryDescription": "Tillverkare av elektriska hushållsapparater och relaterade produkter.  Inkluderar tillverkare av el- och handverktyg, inklusive verktyg för trädgårdsskötsel.  Exkluderar TV-apparater och andra ljud- och videoprodukter som klassificeras i underbranschen Konsumentelektronik och persondatorer som klassificeras i underbranschen Teknik Hårdvara, lagring och kringutrustning."
   },
   "25201050": {
-    "sectorName": "Diskretionära konsumentvaror",
-    "groupName": "Sällanköpsvaror & kläder",
+    "sectorName": "Sällanköpsvaror",
+    "groupName": "Konsumentvaror och kläder",
     "industryName": "Sällanköpsvaror för hushåll",
-    "subIndustryName": "Hushållsartiklar & specialiteter",
+    "subIndustryName": "Hushållsartiklar och specialiteter",
     "subIndustryDescription": "Tillverkare av varaktiga hushållsprodukter, inklusive bestick, köksredskap, glas, kristall, silver, köksredskap och specialprodukter för konsumenter som inte klassificeras annorstädes."
   },
   "25202010": {
-    "sectorName": "Diskretionära konsumentvaror",
-    "groupName": "Sällanköpsvaror & kläder",
+    "sectorName": "Sällanköpsvaror",
+    "groupName": "Konsumentvaror och kläder",
     "industryName": "Fritidsprodukter",
     "subIndustryName": "Fritidsprodukter",
     "subIndustryDescription": "Tillverkare av fritidsprodukter och utrustning, inklusive sportutrustning, cyklar och leksaker."
   },
   "25203010": {
-    "sectorName": "Diskretionära konsumentvaror",
-    "groupName": "Sällanköpsvaror & kläder",
+    "sectorName": "Sällanköpsvaror",
+    "groupName": "Konsumentvaror och kläder",
     "industryName": "Textilier, kläder och lyxvaror",
     "subIndustryName": "Kläder, accessoarer och lyxvaror",
-    "subIndustryDescription": "Tillverkare av kläder, accessoarer och lyxvaror. Inkluderar företag som främst tillverkar designerhandväskor, plånböcker, bagage, smycken och klockor. Exkluderar skor som klassificeras i underindustrin för skor."
+    "subIndustryDescription": "Tillverkare av kläder, accessoarer och lyxvaror. Inkluderar företag som främst tillverkar designerhandväskor, plånböcker, bagage, smycken och klockor. Exkluderar skor som klassificeras i underbranschen för skor."
   },
   "25203020": {
-    "sectorName": "Diskretionära konsumentvaror",
-    "groupName": "Sällanköpsvaror & kläder",
+    "sectorName": "Sällanköpsvaror",
+    "groupName": "Konsumentvaror och kläder",
     "industryName": "Textilier, kläder och lyxvaror",
     "subIndustryName": "Skor",
     "subIndustryDescription": "Tillverkare av skor. Inkluderar sport- och läderskor."
   },
   "25203030": {
-    "sectorName": "Diskretionära konsumentvaror",
-    "groupName": "Sällanköpsvaror & kläder",
+    "sectorName": "Sällanköpsvaror",
+    "groupName": "Konsumentvaror och kläder",
     "industryName": "Textilier, kläder och lyxvaror",
     "subIndustryName": "Textilier",
-    "subIndustryDescription": "Tillverkare av textil och relaterade produkter som inte klassificeras i underindustrierna kläder, accessoarer och lyxvaror, skor eller heminredning."
+    "subIndustryDescription": "Tillverkare av textil och relaterade produkter som inte klassificeras i underbranscherna kläder, accessoarer och lyxvaror, skor eller heminredning."
   },
   "25301010": {
-    "sectorName": "Diskretionära konsumentvaror",
+    "sectorName": "Sällanköpsvaror",
     "groupName": "Konsumenttjänster",
     "industryName": "Hotell, restauranger och fritid",
     "subIndustryName": "Kasinon och spel",
     "subIndustryDescription": "Ägare och operatörer av kasinon och spelanläggningar. Inkluderar företag som tillhandahåller lotteri- och vadslagningstjänster."
   },
   "25301020": {
-    "sectorName": "Diskretionära konsumentvaror",
+    "sectorName": "Sällanköpsvaror",
     "groupName": "Konsumenttjänster",
     "industryName": "Hotell, restauranger och fritid",
     "subIndustryName": "Hotell, resorter och kryssningsrederier",
     "subIndustryDescription": "Ägare och operatörer av hotell, resorts och kryssningsfartyg. Omfattar resebyråer, researrangörer och relaterade tjänster som inte klassificeras någon annanstans. Omfattar inte kasinohotell som klassificeras i underbranschen Kasinon och spel."
   },
   "25301030": {
-    "sectorName": "Diskretionära konsumentvaror",
+    "sectorName": "Sällanköpsvaror",
     "groupName": "Konsumenttjänster",
     "industryName": "Hotell, restauranger och fritid",
     "subIndustryName": "Fritidsanläggningar",
-    "subIndustryDescription": "Ägare och operatörer av fritidsanläggningar, inklusive sport- och fitnesscenter, arenor, golfbanor och nöjesparker som inte klassificeras i underbranschen Film & underhållning."
+    "subIndustryDescription": "Ägare och operatörer av fritidsanläggningar, inklusive sport- och fitnesscenter, arenor, golfbanor och nöjesparker som inte klassificeras i underbranschen Film och underhållning."
   },
   "25301040": {
-    "sectorName": "Diskretionära konsumentvaror",
+    "sectorName": "Sällanköpsvaror",
     "groupName": "Konsumenttjänster",
     "industryName": "Hotell, restauranger och fritid",
     "subIndustryName": "Restauranger",
     "subIndustryDescription": "Ägare och operatörer av restauranger, barer, pubar, snabbmatsrestauranger eller avhämtningsställen. Omfattar även företag som tillhandahåller cateringtjänster för livsmedel."
   },
   "25302010": {
-    "sectorName": "Diskretionära konsumentvaror",
+    "sectorName": "Sällanköpsvaror",
     "groupName": "Konsumenttjänster",
     "industryName": "Diversifierade konsumenttjänster",
     "subIndustryName": "Utbildningstjänster",
-    "subIndustryDescription": "Företag som tillhandahåller utbildningstjänster, antingen online eller genom konventionella undervisningsmetoder. Inkluderar privata universitet, korrespondensundervisning, leverantörer av utbildningsseminarier, utbildningsmaterial och teknisk utbildning. Exkluderar företag som tillhandahåller utbildningsprogram för anställda som klassificeras i underbranschen Human Resources & Employment Services"
+    "subIndustryDescription": "Företag som tillhandahåller utbildningstjänster, antingen online eller genom konventionella undervisningsmetoder. Inkluderar privata universitet, korrespondensundervisning, leverantörer av utbildningsseminarier, utbildningsmaterial och teknisk utbildning. Exkluderar företag som tillhandahåller utbildningsprogram för anställda som klassificeras i underbranschen Human Resources och Employment Services"
   },
   "25302020": {
-    "sectorName": "Diskretionära konsumentvaror",
+    "sectorName": "Sällanköpsvaror",
     "groupName": "Konsumenttjänster",
     "industryName": "Diversifierade konsumenttjänster",
     "subIndustryName": "Specialiserade konsumenttjänster",
     "subIndustryDescription": "Företag som tillhandahåller konsumenttjänster som inte klassificeras någon annanstans.  Omfattar bostadstjänster, hemsäkerhet, juridiska tjänster, personliga tjänster, renoverings- och inredningstjänster, konsumentauktioner samt bröllops- och begravningstjänster."
   },
   "25501010": {
-    "sectorName": "Diskretionära konsumentvaror",
-    "groupName": "Diskretionära konsumentvaror Distribution & Detaljhandel",
+    "sectorName": "Sällanköpsvaror",
+    "groupName": "Distribution och detaljhandel för sällanköpsvaror",
     "industryName": "Distributörer",
     "subIndustryName": "Distributörer",
     "subIndustryDescription": "Distributörer och grossister av allmänna handelsvaror som inte klassificeras annorstädes. Inkluderar fordonsdistributörer."
   },
   "25503030": {
-    "sectorName": "Diskretionära konsumentvaror",
-    "groupName": "Diskretionära konsumentvaror Distribution & Detaljhandel",
+    "sectorName": "Sällanköpsvaror",
+    "groupName": "Distribution och detaljhandel för sällanköpsvaror",
     "industryName": "Broadline Detaljhandel",
     "subIndustryName": "Broadline Detaljhandel",
     "subIndustryDescription": "Återförsäljare som erbjuder ett brett sortiment av sällanköpsvaror. Denna delbransch omfattar detaljister som säljer allmänna varor och lågprisvaror, varuhus och online-återförsäljare och marknadsplatser som främst säljer sällanköpsvaror."
   },
   "25504010": {
-    "sectorName": "Diskretionära konsumentvaror",
-    "groupName": "Diskretionära konsumentvaror Distribution & Detaljhandel",
+    "sectorName": "Sällanköpsvaror",
+    "groupName": "Distribution och detaljhandel för sällanköpsvaror",
     "industryName": "Specialiserad butikshandel",
     "subIndustryName": "Detaljhandel med kläder",
     "subIndustryDescription": "Detaljhandeln är huvudsakligen specialiserad på kläder och accessoarer."
   },
   "25504020": {
-    "sectorName": "Diskretionära konsumentvaror",
-    "groupName": "Diskretionära konsumentvaror Distribution & Detaljhandel",
+    "sectorName": "Sällanköpsvaror",
+    "groupName": "Distribution och detaljhandel för sällanköpsvaror",
     "industryName": "Specialiserad butikshandel",
-    "subIndustryName": "Detaljhandel med datorer & elektronik",
+    "subIndustryName": "Detaljhandel med datorer och elektronik",
     "subIndustryDescription": "Ägare och operatörer av detaljhandelsbutiker för konsumentelektronik, datorer, video och relaterade produkter."
   },
   "25504030": {
-    "sectorName": "Diskretionära konsumentvaror",
-    "groupName": "Diskretionära konsumentvaror Distribution & Detaljhandel",
+    "sectorName": "Sällanköpsvaror",
+    "groupName": "Distribution och detaljhandel för sällanköpsvaror",
     "industryName": "Specialiserad butikshandel",
     "subIndustryName": "Detaljhandel för hemförbättring",
     "subIndustryDescription": "Ägare och operatörer av detaljhandelsbutiker för hem- och trädgårdsförbättringar. Inkluderar butiker som erbjuder byggmaterial och förnödenheter."
   },
   "25504040": {
-    "sectorName": "Diskretionära konsumentvaror",
-    "groupName": "Diskretionära konsumentvaror Distribution & Detaljhandel",
+    "sectorName": "Sällanköpsvaror",
+    "groupName": "Distribution och detaljhandel för sällanköpsvaror",
     "industryName": "Specialiserad butikshandel",
     "subIndustryName": "Övrig specialiserad butikshandel",
     "subIndustryDescription": "Ägare och operatörer av specialiserade detaljhandelsbutiker som inte klassificeras någon annanstans. Omfattar smyckesaffärer, leksaksaffärer, kontorsmaterialaffärer, hälso- och synvårdsaffärer samt bok- och nöjesaffärer."
   },
   "25504050": {
-    "sectorName": "Diskretionära konsumentvaror",
-    "groupName": "Diskretionära konsumentvaror Distribution & Detaljhandel",
+    "sectorName": "Sällanköpsvaror",
+    "groupName": "Distribution och detaljhandel för sällanköpsvaror",
     "industryName": "Specialiserad butikshandel",
     "subIndustryName": "Detaljhandel med fordon",
     "subIndustryDescription": "Ägare och operatörer av butiker som specialiserar sig på detaljhandel med fordon.  Omfattar bilhandlare, bensinstationer och återförsäljare av biltillbehör, motorcyklar och reservdelar, bilglas samt bilutrustning och reservdelar."
   },
   "25504060": {
-    "sectorName": "Diskretionära konsumentvaror",
-    "groupName": "Diskretionära konsumentvaror Distribution & Detaljhandel",
+    "sectorName": "Sällanköpsvaror",
+    "groupName": "Distribution och detaljhandel för sällanköpsvaror",
     "industryName": "Specialiserad butikshandel",
     "subIndustryName": "Detaljhandel med heminredning",
     "subIndustryDescription": "Ägare och operatörer av möbel- och heminredningsbutiker.  Omfattar möbler för bostäder, heminredning, hushållsartiklar och inredningsdesign.  Exklusive butiker för hem- och trädgårdsförbättringar, klassificerade i underbranschen för detaljhandel med hemförbättringar."
   },
   "30101010": {
     "sectorName": "Dagligvaror",
-    "groupName": "Dagligvaror Distribution & Detaljhandel",
-    "industryName": "Dagligvaror Distribution & Detaljhandel",
+    "groupName": "Distribution och detaljhandel för dagligvaror",
+    "industryName": "Distribution och detaljhandel för dagligvaror",
     "subIndustryName": "Detaljhandel med läkemedel",
     "subIndustryDescription": "Ägare och operatörer av främst drug retail-butiker och apotek."
   },
   "30101020": {
     "sectorName": "Dagligvaror",
-    "groupName": "Dagligvaror Distribution & Detaljhandel",
-    "industryName": "Dagligvaror Distribution & Detaljhandel",
+    "groupName": "Distribution och detaljhandel för dagligvaror",
+    "industryName": "Distribution och detaljhandel för dagligvaror",
     "subIndustryName": "Livsmedelsdistributörer",
     "subIndustryDescription": "Distributörer av livsmedelsprodukter till andra företag och inte direkt till konsumenten."
   },
   "30101030": {
     "sectorName": "Dagligvaror",
-    "groupName": "Dagligvaror Distribution & Detaljhandel",
-    "industryName": "Dagligvaror Distribution & Detaljhandel",
+    "groupName": "Distribution och detaljhandel för dagligvaror",
+    "industryName": "Distribution och detaljhandel för dagligvaror",
     "subIndustryName": "Dagligvaruhandel",
     "subIndustryDescription": "Ägare och operatörer av främst dagligvarubutiker."
   },
   "30101040": {
     "sectorName": "Dagligvaror",
-    "groupName": "Dagligvaror Distribution & Detaljhandel",
-    "industryName": "Dagligvaror Distribution & Detaljhandel",
+    "groupName": "Distribution och detaljhandel för dagligvaror",
+    "industryName": "Distribution och detaljhandel för dagligvaror",
     "subIndustryName": "Konsumentvaror Dagligvaror Detaljhandel",
     "subIndustryDescription": "Återförsäljare som erbjuder ett brett sortiment av dagligvaror såsom livsmedel, hushållsprodukter och produkter för personlig vård. Denna delbransch omfattar hypermarkets, supercenters och andra detaljister som säljer dagligvaror, t.ex. lågprisbutiker och marknadsplatser på nätet som främst säljer dagligvaror."
   },
   "30201010": {
     "sectorName": "Dagligvaror",
-    "groupName": "Livsmedel, dryck och tobak",
+    "groupName": "Livsmedel, drycker och tobak",
     "industryName": "Drycker",
     "subIndustryName": "Bryggerier",
     "subIndustryDescription": "Producenter av öl och maltsprit. Inkluderar bryggerier som inte klassificeras i underbranschen Restauranger."
   },
   "30201020": {
     "sectorName": "Dagligvaror",
-    "groupName": "Livsmedel, dryck och tobak",
+    "groupName": "Livsmedel, drycker och tobak",
     "industryName": "Drycker",
     "subIndustryName": "Destillerier och vinodlare",
-    "subIndustryDescription": "Destillatörer, vinodlare och producenter av alkoholhaltiga drycker som inte klassificeras i undergruppen bryggerier."
+    "subIndustryDescription": "Destillatörer, vinodlare och producenter av alkoholhaltiga drycker som inte klassificeras i underbranschen bryggerier."
   },
   "30201030": {
     "sectorName": "Dagligvaror",
-    "groupName": "Livsmedel, dryck och tobak",
+    "groupName": "Livsmedel, drycker och tobak",
     "industryName": "Drycker",
-    "subIndustryName": "Läskedrycker & alkoholfria drycker",
-    "subIndustryDescription": "Producenter av alkoholfria drycker inklusive mineralvatten. Utesluter mjölkproducenter som klassificeras i underindustrin för förpackade livsmedel."
+    "subIndustryName": "Läskedrycker och alkoholfria drycker",
+    "subIndustryDescription": "Producenter av alkoholfria drycker inklusive mineralvatten. Utesluter mjölkproducenter som klassificeras i underbranschen för förpackade livsmedel."
   },
   "30202010": {
     "sectorName": "Dagligvaror",
-    "groupName": "Livsmedel, dryck och tobak",
+    "groupName": "Livsmedel, drycker och tobak",
     "industryName": "Livsmedelsprodukter",
     "subIndustryName": "Jordbruksprodukter och tjänster",
-    "subIndustryDescription": "Producenter av jordbruksprodukter. Omfattar växtodlare, ägare av plantager och företag som producerar och bearbetar livsmedel men inte förpackar och marknadsför dem. Utesluter företag som klassificeras i underindustrin för skogsprodukter och de som förpackar och marknadsför livsmedelsprodukter som klassificeras i underindustrin för förpackade livsmedel."
+    "subIndustryDescription": "Producenter av jordbruksprodukter. Omfattar växtodlare, ägare av plantager och företag som producerar och bearbetar livsmedel men inte förpackar och marknadsför dem. Utesluter företag som klassificeras i underbranschen för skogsprodukter och de som förpackar och marknadsför livsmedelsprodukter som klassificeras i underbranschen för förpackade livsmedel."
   },
   "30202030": {
     "sectorName": "Dagligvaror",
-    "groupName": "Livsmedel, dryck och tobak",
+    "groupName": "Livsmedel, drycker och tobak",
     "industryName": "Livsmedelsprodukter",
-    "subIndustryName": "Förpackade livsmedel & kött",
+    "subIndustryName": "Förpackade livsmedel och kött",
     "subIndustryDescription": "Producenter av förpackade livsmedel, inklusive mejeriprodukter, fruktjuicer, kött, fågel, fisk och djurfoder."
   },
   "30203010": {
     "sectorName": "Dagligvaror",
-    "groupName": "Livsmedel, dryck och tobak",
+    "groupName": "Livsmedel, drycker och tobak",
     "industryName": "Tobak",
     "subIndustryName": "Tobak",
     "subIndustryDescription": "Tillverkare av cigaretter och andra tobaksprodukter."
   },
   "30301010": {
     "sectorName": "Dagligvaror",
-    "groupName": "Produkter för personlig vård",
+    "groupName": "Personvårdsprodukter",
     "industryName": "Hushållsprodukter",
     "subIndustryName": "Hushållsprodukter",
-    "subIndustryDescription": "Tillverkare av icke varaktiga hushållsprodukter, inklusive tvättmedel, tvål, blöjor och andra mjukpapper och hushållspapper som inte klassificeras i underindustrin för pappersprodukter."
+    "subIndustryDescription": "Tillverkare av icke varaktiga hushållsprodukter, inklusive tvättmedel, tvål, blöjor och andra mjukpapper och hushållspapper som inte klassificeras i underbranschen för pappersprodukter."
   },
   "30302010": {
     "sectorName": "Dagligvaror",
-    "groupName": "Produkter för personlig vård",
-    "industryName": "Produkter för personlig vård",
-    "subIndustryName": "Produkter för personlig vård",
+    "groupName": "Personvårdsprodukter",
+    "industryName": "Personvårdsprodukter",
+    "subIndustryName": "Personvårdsprodukter",
     "subIndustryDescription": "Tillverkare av produkter för personlig vård och skönhetsvård, inklusive kosmetika och parfymer."
   },
   "35101010": {
-    "sectorName": "Hälso- och sjukvård",
-    "groupName": "Utrustning och tjänster för hälso- och sjukvård",
+    "sectorName": "Hälsovård",
+    "groupName": "Medicinteknisk utrustning och vårdtjänster",
     "industryName": "Utrustning och förnödenheter för hälso- och sjukvård",
     "subIndustryName": "Utrustning för hälso- och sjukvård",
     "subIndustryDescription": "Tillverkare av utrustning och apparater för hälso- och sjukvården. Inkluderar medicinska instrument, system för läkemedelstillförsel, kardiovaskulär och ortopedisk utrustning samt diagnostisk utrustning."
   },
   "35101020": {
-    "sectorName": "Hälso- och sjukvård",
-    "groupName": "Utrustning och tjänster för hälso- och sjukvård",
+    "sectorName": "Hälsovård",
+    "groupName": "Medicinteknisk utrustning och vårdtjänster",
     "industryName": "Utrustning och förnödenheter för hälso- och sjukvård",
     "subIndustryName": "Förbrukningsmaterial för hälso- och sjukvård",
     "subIndustryDescription": "Tillverkare av sjukvårdsmaterial och medicinska produkter som inte klassificeras annorstädes. Inkluderar ögonvårdsprodukter, sjukhusartiklar och säkerhetsanordningar för nålar och sprutor."
   },
   "35102010": {
-    "sectorName": "Hälso- och sjukvård",
-    "groupName": "Utrustning och tjänster för hälso- och sjukvård",
-    "industryName": "Vårdgivare & tjänster inom hälso- och sjukvård",
+    "sectorName": "Hälsovård",
+    "groupName": "Medicinteknisk utrustning och vårdtjänster",
+    "industryName": "Vårdgivare och tjänster inom hälso- och sjukvård",
     "subIndustryName": "Distributörer inom hälso- och sjukvård",
     "subIndustryDescription": "Distributörer och grossister av hälsovårdsprodukter som inte klassificeras annorstädes."
   },
   "35102015": {
-    "sectorName": "Hälso- och sjukvård",
-    "groupName": "Utrustning och tjänster för hälso- och sjukvård",
-    "industryName": "Vårdgivare & tjänster inom hälso- och sjukvård",
+    "sectorName": "Hälsovård",
+    "groupName": "Medicinteknisk utrustning och vårdtjänster",
+    "industryName": "Vårdgivare och tjänster inom hälso- och sjukvård",
     "subIndustryName": "Hälsovårdstjänster",
     "subIndustryDescription": "Leverantörer av patienthälsovårdstjänster som inte klassificeras någon annanstans. Omfattar dialyscentraler, laboratorietjänster och apotekshanteringstjänster. Omfattar även företag som tillhandahåller affärsstödjande tjänster till vårdgivare, t.ex. kontorstjänster, inkassotjänster, bemanningstjänster och outsourcade försäljnings- och marknadsföringstjänster."
   },
   "35102020": {
-    "sectorName": "Hälso- och sjukvård",
-    "groupName": "Utrustning och tjänster för hälso- och sjukvård",
-    "industryName": "Vårdgivare & tjänster inom hälso- och sjukvård",
+    "sectorName": "Hälsovård",
+    "groupName": "Medicinteknisk utrustning och vårdtjänster",
+    "industryName": "Vårdgivare och tjänster inom hälso- och sjukvård",
     "subIndustryName": "Hälso- och sjukvårdsinrättningar",
     "subIndustryDescription": "Ägare och operatörer av vårdinrättningar, t.ex. sjukhus, vårdhem, rehabiliteringscenter och djursjukhus."
   },
   "35102030": {
-    "sectorName": "Hälso- och sjukvård",
-    "groupName": "Utrustning och tjänster för hälso- och sjukvård",
-    "industryName": "Vårdgivare & tjänster inom hälso- och sjukvård",
+    "sectorName": "Hälsovård",
+    "groupName": "Medicinteknisk utrustning och vårdtjänster",
+    "industryName": "Vårdgivare och tjänster inom hälso- och sjukvård",
     "subIndustryName": "Managed Health Care",
     "subIndustryDescription": "Ägare och operatörer av Health Maintenance Organizations (HMOs) och andra managed plans."
   },
   "35103010": {
-    "sectorName": "Hälso- och sjukvård",
-    "groupName": "Utrustning och tjänster för hälso- och sjukvård",
+    "sectorName": "Hälsovård",
+    "groupName": "Medicinteknisk utrustning och vårdtjänster",
     "industryName": "Hälsovårdsteknik",
     "subIndustryName": "Hälsovårdsteknik",
     "subIndustryDescription": "Företag som tillhandahåller informationsteknologitjänster främst till vårdgivare.  Inkluderar företag som tillhandahåller programvaror för applikationer, system och/eller databehandling, internetbaserade verktyg och IT-konsulttjänster till läkare, sjukhus eller företag som huvudsakligen är verksamma inom hälso- och sjukvårdssektorn"
   },
   "35201010": {
-    "sectorName": "Hälso- och sjukvård",
-    "groupName": "Läkemedel, bioteknik och biovetenskap",
+    "sectorName": "Hälsovård",
+    "groupName": "Läkemedel, bioteknik och life sciences",
     "industryName": "Bioteknik",
     "subIndustryName": "Bioteknik",
     "subIndustryDescription": "Företag som främst ägnar sig åt forskning, utveckling, tillverkning och/eller marknadsföring av produkter baserade på genetisk analys och genteknik.  Inkluderar företag som specialiserar sig på proteinbaserade läkemedel för behandling av sjukdomar hos människor. Utesluter företag som tillverkar produkter med hjälp av bioteknik men utan tillämpning inom hälso- och sjukvården."
   },
   "35202010": {
-    "sectorName": "Hälso- och sjukvård",
-    "groupName": "Läkemedel, bioteknik och biovetenskap",
+    "sectorName": "Hälsovård",
+    "groupName": "Läkemedel, bioteknik och life sciences",
     "industryName": "Läkemedel",
     "subIndustryName": "Läkemedel",
     "subIndustryDescription": "Företag som sysslar med forskning, utveckling eller produktion av läkemedel. Inkluderar veterinärmedicinska läkemedel."
   },
   "35203010": {
-    "sectorName": "Hälso- och sjukvård",
-    "groupName": "Läkemedel, bioteknik och biovetenskap",
+    "sectorName": "Hälsovård",
+    "groupName": "Läkemedel, bioteknik och life sciences",
     "industryName": "Verktyg och tjänster för biovetenskap",
     "subIndustryName": "Verktyg och tjänster för biovetenskap",
     "subIndustryDescription": "Företag som möjliggör läkemedelsupptäckt, utveckling och produktion genom att tillhandahålla analytiska verktyg, instrument, förbrukningsvaror och tillbehör, tjänster för kliniska prövningar och kontraktsforskningstjänster.  Inkluderar företag som främst betjänar läkemedels- och bioteknikindustrin."
   },
   "40101010": {
-    "sectorName": "Finansiell information",
+    "sectorName": "Finans",
     "groupName": "Banker",
     "industryName": "Banker",
     "subIndustryName": "Diversifierade banker",
-    "subIndustryDescription": "Stora, geografiskt diversifierade banker med nationell täckning vars intäkter främst härrör från konventionell bankverksamhet, som har betydande affärsverksamhet inom retail banking och utlåning till små och medelstora företag och som tillhandahåller ett brett utbud av finansiella tjänster.  Exkluderar banker klassificerade i underbranscherna Regional Banks och Thrifts & Mortgage Finance. Exkluderar även investmentbanker klassificerade i undergruppen Investment Banking & Brokerage."
+    "subIndustryDescription": "Stora, geografiskt diversifierade banker med nationell täckning vars intäkter främst härrör från konventionell bankverksamhet, som har betydande affärsverksamhet inom retail banking och utlåning till små och medelstora företag och som tillhandahåller ett brett utbud av finansiella tjänster.  Exkluderar banker klassificerade i underbranscherna Regionala banker och Finansiering av kommersiella och privata bostadslån. Exkluderar även investmentbanker klassificerade i underbranschen Investmentbanking och mäkleri."
   },
   "40101015": {
-    "sectorName": "Finansiell information",
+    "sectorName": "Finans",
     "groupName": "Banker",
     "industryName": "Banker",
     "subIndustryName": "Regionala banker",
-    "subIndustryDescription": "Affärsbanker, sparbanker och thrifts vars verksamhet huvudsakligen består av konventionell bankverksamhet såsom bankverksamhet för privatpersoner och mindre företag, utlåning till företag och olika typer av hypotekslån till bostäder och kommersiella fastigheter som huvudsakligen finansieras genom inlåning. Regionbanker tenderar att bedriva verksamhet i begränsade geografiska regioner. Exkluderar företag som klassificeras i underbranscherna Diversified Banks och Commercial & Residential Mortgage Finance. Utesluter även investmentbanker som klassificeras i undergruppen Investment Banking & Brokerage."
+    "subIndustryDescription": "Affärsbanker, sparbanker och thrifts vars verksamhet huvudsakligen består av konventionell bankverksamhet såsom bankverksamhet för privatpersoner och mindre företag, utlåning till företag och olika typer av hypotekslån till bostäder och kommersiella fastigheter som huvudsakligen finansieras genom inlåning. Regionbanker tenderar att bedriva verksamhet i begränsade geografiska regioner. Exkluderar företag som klassificeras i underbranscherna Diversifierade banker och Finansiering av kommersiella och privata bostadslån. Utesluter även investmentbanker som klassificeras i underbranschen Investmentbanking och mäkleri."
   },
   "40201020": {
-    "sectorName": "Finansiell information",
+    "sectorName": "Finans",
     "groupName": "Finansiella tjänster",
     "industryName": "Finansiella tjänster",
     "subIndustryName": "Diversifierade finansiella tjänster",
     "subIndustryDescription": "Leverantörer av ett brett utbud av finansiella tjänster och/eller med visst intresse för ett brett utbud av finansiella tjänster, inklusive bank, försäkring och kapitalmarknader, men utan dominerande affärsområde. Utesluter företag som klassificeras i underbranscherna Regionalbanker och Diversifierade banker."
   },
   "40201030": {
-    "sectorName": "Finansiell information",
+    "sectorName": "Finans",
     "groupName": "Finansiella tjänster",
     "industryName": "Finansiella tjänster",
     "subIndustryName": "Multisektoriella innehav",
-    "subIndustryDescription": "Ett företag med betydande diversifierade innehav i tre eller flera sektorer, där ingen av dessa bidrar med en majoritet av vinsten och/eller försäljningen. Innehavet är till övervägande del av icke-kontrollerande karaktär.  Inkluderar diversifierade finansbolag där ägarandelarna är av kontrollerande karaktär. Utesluter andra diversifierade företag som klassificeras i undergruppen Industrials Conglomerates."
+    "subIndustryDescription": "Ett företag med betydande diversifierade innehav i tre eller flera sektorer, där ingen av dessa bidrar med en majoritet av vinsten och/eller försäljningen. Innehavet är till övervägande del av icke-kontrollerande karaktär.  Inkluderar diversifierade finansbolag där ägarandelarna är av kontrollerande karaktär. Utesluter andra diversifierade företag som klassificeras i underbranschen Industriella konglomerat."
   },
   "40201040": {
-    "sectorName": "Finansiell information",
+    "sectorName": "Finans",
     "groupName": "Finansiella tjänster",
     "industryName": "Finansiella tjänster",
     "subIndustryName": "Specialiserad finansiering",
-    "subIndustryDescription": "Leverantörer av specialiserade finansiella tjänster som inte klassificeras annorstädes. Företag inom denna underbransch får en majoritet av sina intäkter från en specialiserad verksamhet.\nInkluderar, men är inte begränsat till, kommersiella finansieringsbolag, centralbanker, leasinginstitut, factoringtjänster och specialiserade butiker. Utesluter företag som klassificeras i undergruppen Financial Exchanges & Data."
+    "subIndustryDescription": "Leverantörer av specialiserade finansiella tjänster som inte klassificeras annorstädes. Företag inom denna underbransch får en majoritet av sina intäkter från en specialiserad verksamhet.\nInkluderar, men är inte begränsat till, kommersiella finansieringsbolag, centralbanker, leasinginstitut, factoringtjänster och specialiserade butiker. Utesluter företag som klassificeras i underbranschen Finansiella utbyten och data."
   },
   "40201050": {
-    "sectorName": "Finansiell information",
+    "sectorName": "Finans",
     "groupName": "Finansiella tjänster",
     "industryName": "Finansiella tjänster",
     "subIndustryName": "Finansiering av kommersiella och privata bostadslån",
     "subIndustryDescription": "Finansiella företag som tillhandahåller finansiering av kommersiella lån och bostadslån samt relaterade bolånetjänster. Denna delbransch omfattar hypotekslåneinstitut som inte är inlåningsfinansierade, byggnadsföreningar, företag som tillhandahåller fastighetsfinansieringsprodukter, låneförvaltning, hypoteksmäklartjänster och hypoteksförsäkring."
   },
   "40201060": {
-    "sectorName": "Finansiell information",
+    "sectorName": "Finans",
     "groupName": "Finansiella tjänster",
     "industryName": "Finansiella tjänster",
     "subIndustryName": "Tjänster för transaktions- och betalningshantering",
     "subIndustryDescription": "Leverantörer av transaktions- och betalningstjänster och relaterade betaltjänster, inklusive digitala/mobila betalningsprocessorer, betaltjänstleverantörer och gateways samt leverantörer av digitala plånböcker."
   },
   "40202010": {
-    "sectorName": "Finansiell information",
+    "sectorName": "Finans",
     "groupName": "Finansiella tjänster",
     "industryName": "Konsumentfinansiering",
     "subIndustryName": "Konsumentfinansiering",
-    "subIndustryDescription": "Leverantörer av konsumentfinansieringstjänster, inklusive personliga krediter, kreditkort, leasingfinansiering, reserelaterade penningtjänster och pantbanker.  Omfattar inte hypotekslångivare som klassificeras i undergruppen Thrifts & Mortgage Finance Sub-Industry."
+    "subIndustryDescription": "Leverantörer av konsumentfinansieringstjänster, inklusive personliga krediter, kreditkort, leasingfinansiering, reserelaterade penningtjänster och pantbanker.  Omfattar inte hypotekslångivare som klassificeras i underbranschen Finansiering av kommersiella och privata bostadslån."
   },
   "40203010": {
-    "sectorName": "Finansiell information",
+    "sectorName": "Finans",
     "groupName": "Finansiella tjänster",
     "industryName": "Kapitalmarknader",
-    "subIndustryName": "Kapitalförvaltning & depåbanker",
+    "subIndustryName": "Kapitalförvaltning och depåbanker",
     "subIndustryDescription": "Finansiella institutioner som främst ägnar sig åt investeringsförvaltning och/eller relaterade depåförvarings- och värdepapperstjänster. Inkluderar företag som driver värdepappersfonder, slutna fonder och investeringsfonder.  Exkluderar banker och andra finansiella institutioner som främst ägnar sig åt kommersiell utlåning, investment banking, mäkleri och annan specialiserad finansiell verksamhet."
   },
   "40203020": {
-    "sectorName": "Finansiell information",
+    "sectorName": "Finans",
     "groupName": "Finansiella tjänster",
     "industryName": "Kapitalmarknader",
-    "subIndustryName": "Investmentbanking & mäkleri",
+    "subIndustryName": "Investmentbanking och mäkleri",
     "subIndustryDescription": "Finansiella institutioner som främst ägnar sig åt investment banking och mäklartjänster, inklusive aktie- och skuldgarantier, fusioner och förvärv, värdepapperslån och rådgivning. Exkluderar banker och andra finansinstitut som främst ägnar sig åt kommersiell utlåning, kapitalförvaltning och specialiserad finansiell verksamhet."
   },
   "40203030": {
-    "sectorName": "Finansiell information",
+    "sectorName": "Finans",
     "groupName": "Finansiella tjänster",
     "industryName": "Kapitalmarknader",
     "subIndustryName": "Diversifierade kapitalmarknader",
-    "subIndustryDescription": "Finansiella institutioner som främst ägnar sig åt diversifierad kapitalmarknadsverksamhet, inklusive en betydande närvaro inom minst två av följande områden: utlåning till stora företag, investment banking, mäkleri och kapitalförvaltning. Utesluter mindre diversifierade företag som klassificeras i underbranscherna Asset Management & Custody Banks eller Investment Banking & Brokerage.  Utesluter även företag som klassificeras i branschgrupperna Banks or Insurance eller Consumer Finance Sub-Industry."
+    "subIndustryDescription": "Finansiella institutioner som främst ägnar sig åt diversifierad kapitalmarknadsverksamhet, inklusive en betydande närvaro inom minst två av följande områden: utlåning till stora företag, investment banking, mäkleri och kapitalförvaltning. Utesluter mindre diversifierade företag som klassificeras i underbranscherna Asset Management och Custody Banks eller Investmentbanking och mäkleri.  Utesluter även företag som klassificeras i branschgrupperna Banker eller Försäkringar eller underbranschen Konsumentfinansiering."
   },
   "40203040": {
-    "sectorName": "Finansiell information",
+    "sectorName": "Finans",
     "groupName": "Finansiella tjänster",
     "industryName": "Kapitalmarknader",
     "subIndustryName": "Finansiella utbyten och data",
     "subIndustryDescription": "Finansiella börser för värdepapper, råvaror, derivat och andra finansiella instrument samt leverantörer av finansiella beslutsverktyg och produkter, inklusive kreditvärderingsinstitut"
   },
   "40204010": {
-    "sectorName": "Finansiell information",
+    "sectorName": "Finans",
     "groupName": "Finansiella tjänster",
     "industryName": "Hypotekslån Fastighetsinvesteringar\nTrusts (REITs)",
     "subIndustryName": "REITs för hypotekslån",
     "subIndustryDescription": "Företag eller stiftelser som tillhandahåller, genererar, köper och/eller värdepapperiserar bostadslån och/eller kommersiella hypotekslån.  Inkluderar truster som investerar i värdepapper med säkerhet i hypotekslån och andra tillgångar relaterade till hypotekslån."
   },
   "40301010": {
-    "sectorName": "Finansiell information",
-    "groupName": "Försäkring",
-    "industryName": "Försäkring",
+    "sectorName": "Finans",
+    "groupName": "Försäkringar",
+    "industryName": "Försäkringar",
     "subIndustryName": "Försäkringsmäklare",
     "subIndustryDescription": "Försäkrings- och återförsäkringsmäklarfirmor."
   },
   "40301020": {
-    "sectorName": "Finansiell information",
-    "groupName": "Försäkring",
-    "industryName": "Försäkring",
+    "sectorName": "Finans",
+    "groupName": "Försäkringar",
+    "industryName": "Försäkringar",
     "subIndustryName": "Liv- och sjukförsäkring",
     "subIndustryDescription": "Företag som främst tillhandahåller liv-, invaliditets-, skade- eller kompletterande sjukförsäkring. Exkluderar managed care-bolag som klassificeras i underbranschen Managed Health Care."
   },
   "40301030": {
-    "sectorName": "Finansiell information",
-    "groupName": "Försäkring",
-    "industryName": "Försäkring",
+    "sectorName": "Finans",
+    "groupName": "Försäkringar",
+    "industryName": "Försäkringar",
     "subIndustryName": "Multi-line försäkring",
     "subIndustryDescription": "Försäkringsbolag med diversifierade intressen inom liv-, sjuk-, sak- och olycksfallsförsäkring."
   },
   "40301040": {
-    "sectorName": "Finansiell information",
-    "groupName": "Försäkring",
-    "industryName": "Försäkring",
+    "sectorName": "Finans",
+    "groupName": "Försäkringar",
+    "industryName": "Försäkringar",
     "subIndustryName": "Sak- och skadeförsäkring",
     "subIndustryDescription": "Bolag som huvudsakligen tillhandahåller egendoms- och skadeförsäkring."
   },
   "40301050": {
-    "sectorName": "Finansiell information",
-    "groupName": "Försäkring",
-    "industryName": "Försäkring",
+    "sectorName": "Finans",
+    "groupName": "Försäkringar",
+    "industryName": "Försäkringar",
     "subIndustryName": "Återförsäkring",
     "subIndustryDescription": "Bolag som huvudsakligen tillhandahåller återförsäkring."
   },
   "45102010": {
-    "sectorName": "Informationsteknik",
-    "groupName": "Programvara & tjänster",
+    "sectorName": "IT",
+    "groupName": "Programvara och tjänster",
     "industryName": "IT-tjänster",
     "subIndustryName": "IT-konsulttjänster och andra tjänster",
     "subIndustryDescription": "Leverantörer av tjänster inom informationsteknik och systemintegration som inte klassificeras i underbranschen Databehandling och outsourcade tjänster.  Omfattar konsulttjänster inom informationsteknik och informationshantering."
   },
   "45102030": {
-    "sectorName": "Informationsteknik",
-    "groupName": "Programvara & tjänster",
+    "sectorName": "IT",
+    "groupName": "Programvara och tjänster",
     "industryName": "IT-tjänster",
-    "subIndustryName": "Internettjänster & infrastruktur",
+    "subIndustryName": "Internettjänster och infrastruktur",
     "subIndustryDescription": "Företag som tillhandahåller tjänster och infrastruktur för internetindustrin, inklusive datacenter och molnbaserade nätverks- och lagringsinfrastrukturer. Inkluderar även företag som tillhandahåller webbhotellstjänster. Exkluderar företag som klassificeras i Software Industry."
   },
   "45103010": {
-    "sectorName": "Informationsteknik",
-    "groupName": "Programvara & tjänster",
+    "sectorName": "IT",
+    "groupName": "Programvara och tjänster",
     "industryName": "Programvara",
     "subIndustryName": "Programvara för applikationer",
-    "subIndustryDescription": "Företag som utvecklar och producerar programvara avsedd för specialiserade applikationer för affärs- eller konsumentmarknaden. Inkluderar företags- och teknisk programvara samt molnbaserad programvara. Exkluderar företag som klassificeras i underbranschen Interactive Home Entertainment. Exkluderar även företag som producerar programvara för system- eller databashantering som klassificeras i underbranschen Systems Software Sub-Industry."
+    "subIndustryDescription": "Företag som utvecklar och producerar programvara avsedd för specialiserade applikationer för affärs- eller konsumentmarknaden. Inkluderar företags- och teknisk programvara samt molnbaserad programvara. Exkluderar företag som klassificeras i underbranschen Interaktiv hemunderhållning. Exkluderar även företag som producerar programvara för system- eller databashantering som klassificeras i underbranschen Programvara för system."
   },
   "45103020": {
-    "sectorName": "Informationsteknik",
-    "groupName": "Programvara & tjänster",
+    "sectorName": "IT",
+    "groupName": "Programvara och tjänster",
     "industryName": "Programvara",
     "subIndustryName": "Programvara för system",
     "subIndustryDescription": "Företag som utvecklar och producerar programvara för system- och databashantering."
   },
   "45201020": {
-    "sectorName": "Informationsteknik",
-    "groupName": "Teknik Hårdvara & utrustning",
+    "sectorName": "IT",
+    "groupName": "Teknisk hårdvara och utrustning",
     "industryName": "Kommunikationsutrustning",
     "subIndustryName": "Kommunikationsutrustning",
     "subIndustryDescription": "Tillverkare av kommunikationsutrustning och -produkter, inklusive LAN, WAN, routrar, telefoner, växlar och centraler. Omfattar inte tillverkare av mobiltelefoner som klassificeras i underbranschen för teknisk hårdvara, lagring och kringutrustning."
   },
   "45202030": {
-    "sectorName": "Informationsteknik",
-    "groupName": "Teknik Hårdvara & utrustning",
+    "sectorName": "IT",
+    "groupName": "Teknisk hårdvara och utrustning",
     "industryName": "Teknik Hårdvara, lagring och kringutrustning",
     "subIndustryName": "Teknik Hårdvara, lagring och kringutrustning",
-    "subIndustryDescription": "Tillverkare av mobiltelefoner, persondatorer, servrar, elektroniska datorkomponenter och kringutrustning. Inkluderar datalagringskomponenter, moderkort, ljud- och bildkort, bildskärmar, tangentbord, skrivare och annan kringutrustning. Omfattar inte halvledare som klassificeras i underindustrin Semiconductors Sub-Industry."
+    "subIndustryDescription": "Tillverkare av mobiltelefoner, persondatorer, servrar, elektroniska datorkomponenter och kringutrustning. Inkluderar datalagringskomponenter, moderkort, ljud- och bildkort, bildskärmar, tangentbord, skrivare och annan kringutrustning. Omfattar inte halvledare som klassificeras i underbranschen Halvledare."
   },
   "45203010": {
-    "sectorName": "Informationsteknik",
-    "groupName": "Teknik Hårdvara & utrustning",
+    "sectorName": "IT",
+    "groupName": "Teknisk hårdvara och utrustning",
     "industryName": "Elektronisk utrustning, instrument och komponenter",
-    "subIndustryName": "Elektronisk utrustning & instrument",
+    "subIndustryName": "Elektronisk utrustning och instrument",
     "subIndustryDescription": "Tillverkare av elektronisk utrustning och instrument, inklusive analytiska, elektroniska test- och mätinstrument, skanner-/streckkodsprodukter, lasrar, bildskärmar, kassamaskiner och utrustning för säkerhetssystem."
   },
   "45203015": {
-    "sectorName": "Informationsteknik",
-    "groupName": "Teknik Hårdvara & utrustning",
+    "sectorName": "IT",
+    "groupName": "Teknisk hårdvara och utrustning",
     "industryName": "Elektronisk utrustning, instrument och komponenter",
     "subIndustryName": "Elektroniska komponenter",
     "subIndustryDescription": "Tillverkare av elektroniska komponenter. Omfattar elektroniska komponenter, anslutningsdon, elektronrör, elektroniska kondensatorer och resistorer, elektroniska spolar, kretskort, transformatorer och andra induktorer, signalbehandlingsteknik/komponenter."
   },
   "45203020": {
-    "sectorName": "Informationsteknik",
-    "groupName": "Teknik Hårdvara & utrustning",
+    "sectorName": "IT",
+    "groupName": "Teknisk hårdvara och utrustning",
     "industryName": "Elektronisk utrustning, instrument och komponenter",
     "subIndustryName": "Tjänster för elektronisk tillverkning",
     "subIndustryDescription": "Tillverkare av elektronisk utrustning, främst för OEM-marknaden (Original Equipment Manufacturers)."
   },
   "45203030": {
-    "sectorName": "Informationsteknik",
-    "groupName": "Teknik Hårdvara & utrustning",
+    "sectorName": "IT",
+    "groupName": "Teknisk hårdvara och utrustning",
     "industryName": "Elektronisk utrustning, instrument och komponenter",
     "subIndustryName": "Teknikdistributörer",
     "subIndustryDescription": "Distributörer av teknisk hårdvara och utrustning. Omfattar distributörer av kommunikationsutrustning, datorer och kringutrustning, halvledare samt elektronisk utrustning och komponenter."
   },
   "45301010": {
-    "sectorName": "Informationsteknik",
-    "groupName": "Halvledare & Halvledarutrustning",
-    "industryName": "Halvledare & Halvledarutrustning",
+    "sectorName": "IT",
+    "groupName": "Halvledare och halvledarutrustning",
+    "industryName": "Halvledare och halvledarutrustning",
     "subIndustryName": "Material och utrustning för halvledare",
     "subIndustryDescription": "Tillverkare av halvledarutrustning, inklusive tillverkare av råmaterial och utrustning som används inom solenergiindustrin."
   },
   "45301020": {
-    "sectorName": "Informationsteknik",
-    "groupName": "Halvledare & Halvledarutrustning",
-    "industryName": "Halvledare & Halvledarutrustning",
+    "sectorName": "IT",
+    "groupName": "Halvledare och halvledarutrustning",
+    "industryName": "Halvledare och halvledarutrustning",
     "subIndustryName": "Halvledare",
     "subIndustryDescription": "Tillverkare av halvledare och relaterade produkter, inklusive tillverkare av solcellsmoduler och solceller."
   },
   "50101010": {
-    "sectorName": "Kommunikationstjänster",
+    "sectorName": "Kommunikation",
     "groupName": "Telekommunikationstjänster",
     "industryName": "Diversifierade telekommunikationstjänster",
     "subIndustryName": "Alternativa transportörer",
     "subIndustryDescription": "Leverantör av kommunikations- och dataöverföringstjänster med hög densitet, främst genom ett fiberoptiskt kabelnätverk med hög bandbredd."
   },
   "50101020": {
-    "sectorName": "Kommunikationstjänster",
+    "sectorName": "Kommunikation",
     "groupName": "Telekommunikationstjänster",
     "industryName": "Diversifierade telekommunikationstjänster",
     "subIndustryName": "Integrerade telekommunikationstjänster",
     "subIndustryDescription": "Operatörer av främst fasta telekommunikationsnät och företag som tillhandahåller både trådlösa och fasta telekommunikationstjänster som inte klassificeras någon annanstans. Inkluderar även internetleverantörer som erbjuder internetaccess till slutanvändare."
   },
   "50102010": {
-    "sectorName": "Kommunikationstjänster",
+    "sectorName": "Kommunikation",
     "groupName": "Telekommunikationstjänster",
     "industryName": "Trådlösa telekommunikationstjänster",
     "subIndustryName": "Trådlösa telekommunikationstjänster",
     "subIndustryDescription": "Leverantörer av främst cellulära eller trådlösa telekommunikationstjänster."
   },
   "50201010": {
-    "sectorName": "Kommunikationstjänster",
-    "groupName": "Media & underhållning",
+    "sectorName": "Kommunikation",
+    "groupName": "Media och underhållning",
     "industryName": "Media",
     "subIndustryName": "Annonsering",
     "subIndustryDescription": "Företag som tillhandahåller reklam-, marknadsförings- eller PR-tjänster."
   },
   "50201020": {
-    "sectorName": "Kommunikationstjänster",
-    "groupName": "Media & underhållning",
+    "sectorName": "Kommunikation",
+    "groupName": "Media och underhållning",
     "industryName": "Media",
     "subIndustryName": "Sändning",
     "subIndustryDescription": "Ägare och operatörer av system för tv- eller radiosändningar, inklusive programmering. Omfattar radio- och tv-sändningar, radionätverk och radiostationer."
   },
   "50201030": {
-    "sectorName": "Kommunikationstjänster",
-    "groupName": "Media & underhållning",
+    "sectorName": "Kommunikation",
+    "groupName": "Media och underhållning",
     "industryName": "Media",
-    "subIndustryName": "Kabel &Satellit",
+    "subIndustryName": "Kabel och satellit",
     "subIndustryDescription": "Leverantörer av kabel- eller satellit-TV-tjänster. Inkluderar kabelnät och programdistribution."
   },
   "50201040": {
-    "sectorName": "Kommunikationstjänster",
-    "groupName": "Media & underhållning",
+    "sectorName": "Kommunikation",
+    "groupName": "Media och underhållning",
     "industryName": "Media",
     "subIndustryName": "Utgivning",
     "subIndustryDescription": "Utgivare av tidningar, tidskrifter och böcker i tryckt eller elektronisk form."
   },
   "50202010": {
-    "sectorName": "Kommunikationstjänster",
-    "groupName": "Media & underhållning",
+    "sectorName": "Kommunikation",
+    "groupName": "Media och underhållning",
     "industryName": "Underhållning",
-    "subIndustryName": "Filmer & underhållning",
+    "subIndustryName": "Filmer och underhållning",
     "subIndustryDescription": "Företag som producerar och säljer underhållningsprodukter och -tjänster, inklusive företag som producerar, distribuerar och visar filmer och TV-program, producenter och distributörer av musik, underhållningsteatrar och idrottslag. Inkluderar även företag som erbjuder och/eller producerar underhållningsinnehåll som streamas online."
   },
   "50202020": {
-    "sectorName": "Kommunikationstjänster",
-    "groupName": "Media & underhållning",
+    "sectorName": "Kommunikation",
+    "groupName": "Media och underhållning",
     "industryName": "Underhållning",
     "subIndustryName": "Interaktiv hemunderhållning",
-    "subIndustryDescription": "Producenter av interaktiva spelprodukter, inklusive mobila spelapplikationer. Inkluderar även pedagogisk programvara som främst används i hemmet. Utesluter onlinespelföretag som klassificeras i underbranschen Casinos & Gaming."
+    "subIndustryDescription": "Producenter av interaktiva spelprodukter, inklusive mobila spelapplikationer. Inkluderar även pedagogisk programvara som främst används i hemmet. Utesluter onlinespelföretag som klassificeras i underbranschen Kasinon och spel."
   },
   "50203010": {
-    "sectorName": "Kommunikationstjänster",
-    "groupName": "Media & underhållning",
+    "sectorName": "Kommunikation",
+    "groupName": "Media och underhållning",
     "industryName": "Interaktiva medier och tjänster",
     "subIndustryName": "Interaktiva medier och tjänster",
-    "subIndustryDescription": "Företag som skapar eller distribuerar innehåll och information via egna plattformar, där intäkterna främst kommer från pay-per-click-annonser. Inkluderar sökmotorer, sociala medier och nätverksplattformar, radannonser på nätet och företag som erbjuder recensioner på nätet. Exkluderar företag som driver marknadsplatser online klassificerade i Internet & Direct Marketing Retail."
+    "subIndustryDescription": "Företag som skapar eller distribuerar innehåll och information via egna plattformar, där intäkterna främst kommer från pay-per-click-annonser. Inkluderar sökmotorer, sociala medier och nätverksplattformar, radannonser på nätet och företag som erbjuder recensioner på nätet. Exkluderar företag som driver marknadsplatser online klassificerade i Internet och Direct Marketing Retail."
   },
   "55101010": {
-    "sectorName": "Verktyg",
-    "groupName": "Verktyg",
+    "sectorName": "Kraftförsörjning",
+    "groupName": "Kraftförsörjning",
     "industryName": "Elektriska försörjningstjänster",
     "subIndustryName": "Elektriska försörjningstjänster",
     "subIndustryDescription": "Företag som producerar eller distribuerar el. Inkluderar både kärntekniska och icke-nukleära anläggningar."
   },
   "55102010": {
-    "sectorName": "Verktyg",
-    "groupName": "Verktyg",
+    "sectorName": "Kraftförsörjning",
+    "groupName": "Kraftförsörjning",
     "industryName": "Gasförsörjning",
     "subIndustryName": "Gasförsörjning",
-    "subIndustryDescription": "Företag vars huvuduppgift är att distribuera och överföra naturgas och tillverkad gas. Exkluderar företag som huvudsakligen är involverade i prospektering eller produktion av gas, klassificerade i underindustrin Oil & Gas Exploration & Production. Omfattar inte heller företag som sysslar med lagring och/eller transport av olja, gas och/eller raffinerade produkter, klassificerade i undergruppen Oil & Gas Storage & Transportation Sub-Industry."
+    "subIndustryDescription": "Företag vars huvuduppgift är att distribuera och överföra naturgas och tillverkad gas. Exkluderar företag som huvudsakligen är involverade i prospektering eller produktion av gas, klassificerade i underbranschen Oil och Gas Exploration och Production. Omfattar inte heller företag som sysslar med lagring och/eller transport av olja, gas och/eller raffinerade produkter, klassificerade i underbranschen Oil och Gas Storage och Transportation Sub-Industry."
   },
   "55103010": {
-    "sectorName": "Verktyg",
-    "groupName": "Verktyg",
+    "sectorName": "Kraftförsörjning",
+    "groupName": "Kraftförsörjning",
     "industryName": "Flera användningsområden",
     "subIndustryName": "Flera användningsområden",
     "subIndustryDescription": "Allmännyttiga företag med betydande diversifierad verksamhet utöver kärnverksamheten inom el, gas och/eller vatten."
   },
   "55104010": {
-    "sectorName": "Verktyg",
-    "groupName": "Verktyg",
+    "sectorName": "Kraftförsörjning",
+    "groupName": "Kraftförsörjning",
     "industryName": "Vattenförsörjning",
     "subIndustryName": "Vattenförsörjning",
     "subIndustryDescription": "Företag som köper och distribuerar vatten vidare till slutkonsumenten. Inkluderar storskaliga vattenreningssystem."
   },
   "55105010": {
-    "sectorName": "Verktyg",
-    "groupName": "Verktyg",
+    "sectorName": "Kraftförsörjning",
+    "groupName": "Kraftförsörjning",
     "industryName": "Oberoende kraftproducenter och producenter av förnybar el",
     "subIndustryName": "Oberoende kraftproducenter och energihandlare",
-    "subIndustryDescription": "Företag som är verksamma som oberoende kraftproducenter (IPP), specialister på marknadsföring och handel med gas och kraft och/eller integrerade energihandlare. Exkluderar producenter av elektricitet från förnybara källor, såsom solkraft, vattenkraft och vindkraft. Exkluderar även elöverföringsbolag och eldistributionsbolag som klassificeras i underbranschen Electric Utilities Sub-Industry."
+    "subIndustryDescription": "Företag som är verksamma som oberoende kraftproducenter (IPP), specialister på marknadsföring och handel med gas och kraft och/eller integrerade energihandlare. Exkluderar producenter av elektricitet från förnybara källor, såsom solkraft, vattenkraft och vindkraft. Exkluderar även elöverföringsbolag och eldistributionsbolag som klassificeras i underbranschen Elektriska försörjningstjänster."
   },
   "55105020": {
-    "sectorName": "Verktyg",
-    "groupName": "Verktyg",
+    "sectorName": "Kraftförsörjning",
+    "groupName": "Kraftförsörjning",
     "industryName": "Oberoende kraftproducenter och producenter av förnybar el",
     "subIndustryName": "Förnybar elektricitet",
     "subIndustryDescription": "Företag som ägnar sig åt produktion och distribution av el med hjälp av förnybara energikällor, inklusive men inte begränsat till företag som producerar el med hjälp av biomassa, geotermisk energi, solenergi, vattenkraft och vindkraft. Omfattar inte företag som tillverkar kapitalutrustning som används för att generera el med hjälp av förnybara energikällor, t.ex. tillverkare av solenergisystem, installatörer av solceller och företag som tillhandahåller teknik, komponenter och tjänster främst till denna marknad."
   },
   "60101010": {
     "sectorName": "Fastigheter",
-    "groupName": "Aktier Real Estate Investment Trusts (REITs)",
+    "groupName": "Equity Real Estate Investment Trusts (REITs)",
     "industryName": "Diversifierade REITs",
     "subIndustryName": "Diversifierade REITs",
     "subIndustryDescription": "Ett företag eller en stiftelse med betydande diversifierad verksamhet inom två eller flera fastighetstyper."
   },
   "60102510": {
     "sectorName": "Fastigheter",
-    "groupName": "Aktier Real Estate Investment Trusts (REITs)",
+    "groupName": "Equity Real Estate Investment Trusts (REITs)",
     "industryName": "Industriella REITs",
     "subIndustryName": "Industriella REITs",
     "subIndustryDescription": "Företag eller stiftelser som ägnar sig åt förvärv, utveckling, ägande, uthyrning, förvaltning och drift av industrifastigheter. Inkluderar företag som driver industriella lager och distributionsfastigheter."
   },
   "60103010": {
     "sectorName": "Fastigheter",
-    "groupName": "Aktier Real Estate Investment Trusts (REITs)",
+    "groupName": "Equity Real Estate Investment Trusts (REITs)",
     "industryName": "REITs för hotell och semesteranläggningar",
     "subIndustryName": "REITs för hotell och semesteranläggningar",
     "subIndustryDescription": "Företag eller stiftelser som ägnar sig åt förvärv, utveckling, ägande, uthyrning, förvaltning och drift av hotell- och resortfastigheter."
   },
   "60104010": {
     "sectorName": "Fastigheter",
-    "groupName": "Aktier Real Estate Investment Trusts (REITs)",
+    "groupName": "Equity Real Estate Investment Trusts (REITs)",
     "industryName": "REITs för kontor",
     "subIndustryName": "REITs för kontor",
     "subIndustryDescription": "Företag eller stiftelser som ägnar sig åt förvärv, utveckling, ägande, uthyrning, förvaltning och drift av kontorsfastigheter."
   },
   "60105010": {
     "sectorName": "Fastigheter",
-    "groupName": "Aktier Real Estate Investment Trusts (REITs)",
+    "groupName": "Equity Real Estate Investment Trusts (REITs)",
     "industryName": "REITs för hälso- och sjukvård",
     "subIndustryName": "REITs för hälso- och sjukvård",
     "subIndustryDescription": "Företag eller stiftelser som ägnar sig åt förvärv, utveckling, ägande, uthyrning, förvaltning och drift av fastigheter som betjänar hälsovårdsindustrin, inklusive sjukhus, vårdhem och fastigheter för stödboende."
   },
   "60106010": {
     "sectorName": "Fastigheter",
-    "groupName": "Aktier Real Estate Investment Trusts (REITs)",
+    "groupName": "Equity Real Estate Investment Trusts (REITs)",
     "industryName": "REITs för bostadsfastigheter",
     "subIndustryName": "REITs för flerfamiljshus och bostäder",
     "subIndustryDescription": "Företag eller stiftelser som ägnar sig åt förvärv, utveckling, ägande, uthyrning, förvaltning och drift av lägenheter och andra flerfamiljshus inklusive studentbostäder."
   },
   "60106020": {
     "sectorName": "Fastigheter",
-    "groupName": "Aktier Real Estate Investment Trusts (REITs)",
+    "groupName": "Equity Real Estate Investment Trusts (REITs)",
     "industryName": "REITs för bostadsfastigheter",
     "subIndustryName": "REITs för enfamiljsbostäder",
     "subIndustryDescription": "Företag eller stiftelser som ägnar sig åt förvärv, utveckling, ägande, uthyrning, förvaltning och drift av enfamiljsbostäder inklusive tillverkade hus."
   },
   "60107010": {
     "sectorName": "Fastigheter",
-    "groupName": "Aktier Real Estate Investment Trusts (REITs)",
+    "groupName": "Equity Real Estate Investment Trusts (REITs)",
     "industryName": "REITs för detaljhandeln",
     "subIndustryName": "REITs för detaljhandeln",
     "subIndustryDescription": "Företag eller stiftelser som ägnar sig åt förvärv, utveckling, ägande, uthyrning, förvaltning och drift av köpcentrum, outletgallerior, kvartersköpcentrum och lokala köpcentrum."
   },
   "60108010": {
     "sectorName": "Fastigheter",
-    "groupName": "Aktier Real Estate Investment Trusts (REITs)",
+    "groupName": "Equity Real Estate Investment Trusts (REITs)",
     "industryName": "Specialiserade REITs",
     "subIndustryName": "Andra specialiserade REITs",
     "subIndustryDescription": "Företag eller stiftelser som ägnar sig åt förvärv, utveckling, ägande, uthyrning, förvaltning och drift av fastigheter som inte klassificeras någon annanstans. Denna underbransch omfattar REITs som förvaltar och äger fastigheter såsom pipelines för naturgas och råolja, bensinstationer, fiberoptiska kablar, fängelser, bilparkeringar och bilhandlare."
   },
   "60108020": {
     "sectorName": "Fastigheter",
-    "groupName": "Aktier Real Estate Investment Trusts (REITs)",
+    "groupName": "Equity Real Estate Investment Trusts (REITs)",
     "industryName": "Specialiserade REITs",
     "subIndustryName": "REITs för självförvarare",
     "subIndustryDescription": "Företag eller stiftelser som ägnar sig åt förvärv, utveckling, ägande, uthyrning, förvaltning och drift av lagerfastigheter."
   },
   "60108030": {
     "sectorName": "Fastigheter",
-    "groupName": "Aktier Real Estate Investment Trusts (REITs)",
+    "groupName": "Equity Real Estate Investment Trusts (REITs)",
     "industryName": "Specialiserade REITs",
     "subIndustryName": "REITs för telekomtorn",
     "subIndustryDescription": "Företag eller stiftelser som ägnar sig åt förvärv, utveckling, ägande, uthyrning, förvaltning och drift av telekomtorn och tillhörande strukturer som stöder trådlös telekommunikation."
   },
   "60108040": {
     "sectorName": "Fastigheter",
-    "groupName": "Aktier Real Estate Investment Trusts (REITs)",
+    "groupName": "Equity Real Estate Investment Trusts (REITs)",
     "industryName": "Specialiserade REITs",
     "subIndustryName": "REITs för skog",
     "subIndustryDescription": "Företag eller stiftelser som ägnar sig åt förvärv, utveckling, ägande, uthyrning, förvaltning och drift av skogsmark och skogsrelaterade fastigheter."
   },
   "60108050": {
     "sectorName": "Fastigheter",
-    "groupName": "Aktier Real Estate Investment Trusts (REITs)",
+    "groupName": "Equity Real Estate Investment Trusts (REITs)",
     "industryName": "Specialiserade REITs",
     "subIndustryName": "REITs för datacenter",
     "subIndustryDescription": "Företag eller stiftelser som ägnar sig åt förvärv, utveckling, ägande, uthyrning, förvaltning och drift av datacenterfastigheter."
@@ -1131,7 +1131,7 @@
     "groupName": "Fastighetsförvaltning och fastighetsutveckling",
     "industryName": "Fastighetsförvaltning och fastighetsutveckling",
     "subIndustryName": "Fastighetsutveckling",
-    "subIndustryDescription": "Företag som utvecklar fastigheter och säljer fastigheterna efter utveckling. Exkluderar företag som klassificeras i underbranschen Homebuilding Sub-Industry."
+    "subIndustryDescription": "Företag som utvecklar fastigheter och säljer fastigheterna efter utveckling. Exkluderar företag som klassificeras i underbranschen Husbyggnad."
   },
   "60201040": {
     "sectorName": "Fastigheter",


### PR DESCRIPTION
### ✨ What’s Changed?

The Swedish translation of the sectors and industry groups have been updated to match the ones found in the front-end to keep things consistent. The industry and sub-industry names and the sub-industry descriptions have also been updated to improve consistency and accuracy (e.g. categories referenced in the Swedish sub-industry description have been updated to always use the Swedish name).

### 🔍 How to Review / Test

The text version of the GICS categories are included in the response from the detailed company end-point (e.g. [https://stage.klimatkollen.se/api/companies/Q157675](https://stage.klimatkollen.se/api/companies/Q157675)).

### 📋 Checklist

- [x] PR title starts with `[#issue-number]`; if no issue is applicable use: `[fix]`, `[feat]`, `[ops]`, or `[prod]`
- [x] I’ve added/updated tests (or noted why they’re not needed)
- [x] I’ve verified the change runs locally (and in Docker/k8s if relevant)
- [x] If this changes the API contract, I’ve called that out clearly (and considered backward compatibility)
- [x] If this includes a DB change, I’ve included a migration + rollout/rollback notes
- [x] I’ve considered observability (logs/metrics/traces) and added what’s needed
- [ ] I’ve set labels, linked issue, and milestone (if applicable)

### 🛠 Related Issue

Closes #1405 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static JSON label updates with stable keys; no logic, auth, or schema changes—main risk is inconsistent UI if frontend and API strings diverge elsewhere.
> 
> **Overview**
> Updates **GICS industry copy** in `output/en/industry-gics.json` and `output/sv/industry-gics.json`, which feed `getGics()` and the company detail API.
> 
> **English:** Removes trailing spaces from a handful of `subIndustryName` values (no semantic change).
> 
> **Swedish:** Broad terminology pass so sectors, groups, industries, and sub-industries match frontend wording—e.g. `&` → `och`, **Sällanköpsvaror** / **Finans** / **IT** / **Kraftförsörjning**, and clearer retail/healthcare/REIT labels. **Sub-industry descriptions** now cross-reference other categories using Swedish names instead of leftover English GICS labels, plus assorted wording fixes (managed care, mortgage REITs, utilities multi-sector naming, etc.).
> 
> GICS codes are unchanged; only display strings change for API consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e10b34cf753c1be953d2843027c6ab17309b544. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->